### PR TITLE
Add created_at/updated_at timestamps to all DB tables

### DIFF
--- a/client/tests/test_core/test_docx_integration.py
+++ b/client/tests/test_core/test_docx_integration.py
@@ -240,9 +240,9 @@ class TestNameAndVersionValidation:
         for name in test_names:
             manifest_ok = _NAME_PATTERN.match(name) is not None
             validation_ok = _SKILL_NAME_PATTERN.match(name) is not None
-            assert (
-                manifest_ok == validation_ok
-            ), f"Inconsistency for '{name}': manifest={manifest_ok}, validation={validation_ok}"
+            assert manifest_ok == validation_ok, (
+                f"Inconsistency for '{name}': manifest={manifest_ok}, validation={validation_ok}"
+            )
 
 
 class TestInstallPathResolution:

--- a/server/migrations/009_add_timestamps.sql
+++ b/server/migrations/009_add_timestamps.sql
@@ -1,0 +1,103 @@
+-- Add created_at / updated_at timestamps to all tables
+-- Tables already with created_at: versions, user_api_keys, eval_audit_logs, eval_reports, eval_runs
+-- eval_audit_logs is append-only so it does NOT get updated_at.
+
+-- ---------------------------------------------------------------------------
+-- 1. Reusable trigger function for auto-updating updated_at
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Add created_at where missing
+-- ---------------------------------------------------------------------------
+ALTER TABLE users
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE organizations
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE org_members
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE skills
+    ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Add updated_at to all mutable tables
+-- ---------------------------------------------------------------------------
+ALTER TABLE users
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE organizations
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE org_members
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE skills
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE versions
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE user_api_keys
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE eval_reports
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE eval_runs
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+
+-- ---------------------------------------------------------------------------
+-- 4. Auto-update triggers
+-- ---------------------------------------------------------------------------
+CREATE TRIGGER trg_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_organizations_updated_at
+    BEFORE UPDATE ON organizations
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_org_members_updated_at
+    BEFORE UPDATE ON org_members
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_skills_updated_at
+    BEFORE UPDATE ON skills
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_versions_updated_at
+    BEFORE UPDATE ON versions
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_user_api_keys_updated_at
+    BEFORE UPDATE ON user_api_keys
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_eval_reports_updated_at
+    BEFORE UPDATE ON eval_reports
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER trg_eval_runs_updated_at
+    BEFORE UPDATE ON eval_runs
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+
+-- ---------------------------------------------------------------------------
+-- 5. Indexes for time-based queries
+-- ---------------------------------------------------------------------------
+CREATE INDEX idx_skills_created_at ON skills (created_at);
+CREATE INDEX idx_versions_updated_at ON versions (updated_at);
+CREATE INDEX idx_eval_reports_updated_at ON eval_reports (updated_at);
+CREATE INDEX idx_eval_runs_updated_at ON eval_runs (updated_at);

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -57,6 +57,8 @@ users_table = Table(
     ),
     Column("github_id", String, nullable=False, unique=True),
     Column("username", String, nullable=False, unique=True),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
 )
 
 organizations_table = Table(
@@ -76,6 +78,8 @@ organizations_table = Table(
         nullable=False,
     ),
     Column("is_personal", Boolean, nullable=False, server_default="false"),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
 )
 
 org_members_table = Table(
@@ -94,6 +98,8 @@ org_members_table = Table(
         primary_key=True,
     ),
     Column("role", String, nullable=False),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
 )
 
 skills_table = Table(
@@ -114,7 +120,10 @@ skills_table = Table(
     Column("name", String, nullable=False),
     Column("description", Text, nullable=False, server_default=""),
     Column("download_count", sa.Integer, nullable=False, server_default="0"),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
     sa.UniqueConstraint("org_id", "name"),
+    sa.Index("idx_skills_created_at", "created_at"),
 )
 
 versions_table = Table(
@@ -147,6 +156,7 @@ versions_table = Table(
         server_default=sa.func.now(),
     ),
     Column("published_by", String, nullable=False, server_default=""),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
     sa.UniqueConstraint("skill_id", "semver"),
     sa.Index(
         "idx_versions_skill_semver_parts",
@@ -155,6 +165,7 @@ versions_table = Table(
         sa.text("semver_minor DESC"),
         sa.text("semver_patch DESC"),
     ),
+    sa.Index("idx_versions_updated_at", "updated_at"),
 )
 
 user_api_keys_table = Table(
@@ -180,6 +191,7 @@ user_api_keys_table = Table(
         nullable=False,
         server_default=sa.func.now(),
     ),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
     sa.UniqueConstraint("user_id", "key_name"),
 )
 
@@ -244,6 +256,8 @@ eval_reports_table = Table(
         nullable=False,
         server_default=sa.func.now(),
     ),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    sa.Index("idx_eval_reports_updated_at", "updated_at"),
 )
 
 eval_runs_table = Table(
@@ -285,6 +299,8 @@ eval_runs_table = Table(
         server_default=sa.func.now(),
     ),
     Column("completed_at", DateTime(timezone=True), nullable=True),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    sa.Index("idx_eval_runs_updated_at", "updated_at"),
 )
 
 
@@ -320,23 +336,40 @@ def create_engine(database_url: str) -> Engine:
 
 def _row_to_user(row: sa.Row) -> User:
     """Map a database row to a User model."""
-    return User(id=row.id, github_id=row.github_id, username=row.username)
+    return User(
+        id=row.id, github_id=row.github_id, username=row.username, created_at=row.created_at, updated_at=row.updated_at
+    )
 
 
 def _row_to_organization(row: sa.Row) -> Organization:
     """Map a database row to an Organization model."""
-    return Organization(id=row.id, slug=row.slug, owner_id=row.owner_id, is_personal=row.is_personal)
+    return Organization(
+        id=row.id,
+        slug=row.slug,
+        owner_id=row.owner_id,
+        is_personal=row.is_personal,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
 
 
 def _row_to_org_member(row: sa.Row) -> OrgMember:
     """Map a database row to an OrgMember model."""
-    return OrgMember(org_id=row.org_id, user_id=row.user_id, role=row.role)
+    return OrgMember(
+        org_id=row.org_id, user_id=row.user_id, role=row.role, created_at=row.created_at, updated_at=row.updated_at
+    )
 
 
 def _row_to_skill(row: sa.Row) -> Skill:
     """Map a database row to a Skill model."""
     return Skill(
-        id=row.id, org_id=row.org_id, name=row.name, description=row.description, download_count=row.download_count
+        id=row.id,
+        org_id=row.org_id,
+        name=row.name,
+        description=row.description,
+        download_count=row.download_count,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 
@@ -352,6 +385,7 @@ def _row_to_version(row: sa.Row) -> Version:
         eval_status=row.eval_status,
         created_at=row.created_at,
         published_by=row.published_by,
+        updated_at=row.updated_at,
     )
 
 
@@ -363,6 +397,7 @@ def _row_to_user_api_key(row: sa.Row) -> UserApiKey:
         key_name=row.key_name,
         encrypted_value=row.encrypted_value,
         created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 
@@ -1144,6 +1179,7 @@ def _row_to_eval_report(row: sa.Row) -> EvalReport:
         status=row.status,
         error_message=row.error_message,
         created_at=row.created_at,
+        updated_at=row.updated_at,
     )
 
 
@@ -1302,6 +1338,7 @@ def _row_to_eval_run(row: sa.Row) -> EvalRun:
         error_message=row.error_message,
         created_at=row.created_at,
         completed_at=row.completed_at,
+        updated_at=row.updated_at,
     )
 
 

--- a/server/src/decision_hub/models.py
+++ b/server/src/decision_hub/models.py
@@ -28,6 +28,8 @@ class User:
     github_id: str
     username: str
     github_orgs: tuple[str, ...] = ()
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -36,6 +38,8 @@ class Organization:
     slug: str
     owner_id: UUID
     is_personal: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -43,6 +47,8 @@ class OrgMember:
     org_id: UUID
     user_id: UUID
     role: str
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -52,6 +58,8 @@ class Skill:
     name: str
     description: str
     download_count: int = 0
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -65,6 +73,7 @@ class Version:
     eval_status: str
     created_at: datetime | None = None
     published_by: str = ""
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -88,6 +97,7 @@ class UserApiKey:
     key_name: str
     encrypted_value: bytes
     created_at: datetime
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -141,6 +151,7 @@ class EvalReport:
     status: EvalReportStatus
     error_message: str | None = None
     created_at: datetime | None = None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -163,6 +174,7 @@ class EvalRun:
     error_message: str | None
     created_at: datetime | None
     completed_at: datetime | None
+    updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Adds `created_at` and `updated_at` timestamp columns to all database tables via migration

## Test plan
- [ ] Verify migration applies cleanly on dev
- [ ] Confirm existing rows get default timestamps
- [ ] Check `updated_at` auto-updates on row modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)