### PR TITLE
Add pagination to /v1/skills endpoint

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -405,8 +405,11 @@ def _create_zip(path: Path) -> bytes:
     return buf.getvalue()
 
 
-def list_command() -> None:
-    """List all published skills on the registry."""
+def list_command(
+    page: int = typer.Option(1, "--page", "-p", min=1, help="Page number"),
+    page_size: int = typer.Option(20, "--page-size", "-n", min=1, max=100, help="Items per page"),
+) -> None:
+    """List published skills on the registry."""
     from dhub.cli.banner import check_and_show_update, print_banner
     from dhub.cli.config import build_headers, get_api_url, get_token
 
@@ -417,10 +420,16 @@ def list_command() -> None:
     with httpx.Client(timeout=60) as client:
         resp = client.get(
             f"{api_url}/v1/skills",
+            params={"page": page, "page_size": page_size},
             headers=build_headers(get_token()),
         )
         resp.raise_for_status()
-        skills = resp.json()
+        data = resp.json()
+
+    skills = data.get("items", [])
+    total = data.get("total", 0)
+    total_pages = data.get("total_pages", 1)
+    current_page = data.get("page", page)
 
     console.print(f"Registry: [dim]{api_url}[/]")
 
@@ -455,6 +464,9 @@ def list_command() -> None:
         )
 
     console.print(table)
+    console.print(
+        f"Page {current_page} of {total_pages} ({total} total skills)"
+    )
 
     check_and_show_update(console)
 

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -483,18 +483,24 @@ class TestListCommand:
     ) -> None:
         """List displays a table when skills exist."""
         respx.get("http://test:8000/v1/skills").mock(
-            return_value=httpx.Response(200, json=[
-                {
-                    "org_slug": "acme",
-                    "skill_name": "doc-writer",
-                    "description": "Writes docs",
-                    "latest_version": "1.0.0",
-                    "updated_at": "2025-06-01",
-                    "safety_rating": "A",
-                    "author": "alice",
-                    "download_count": 5,
-                },
-            ])
+            return_value=httpx.Response(200, json={
+                "items": [
+                    {
+                        "org_slug": "acme",
+                        "skill_name": "doc-writer",
+                        "description": "Writes docs",
+                        "latest_version": "1.0.0",
+                        "updated_at": "2025-06-01",
+                        "safety_rating": "A",
+                        "author": "alice",
+                        "download_count": 5,
+                    },
+                ],
+                "total": 1,
+                "page": 1,
+                "page_size": 20,
+                "total_pages": 1,
+            })
         )
         respx.get("http://test:8000/cli/latest-version").mock(
             return_value=httpx.Response(200, json={"latest_version": ""})
@@ -512,6 +518,7 @@ class TestListCommand:
         assert "1.0.0" in result.output
         assert "alice" in result.output
         assert "5" in result.output
+        assert "Page 1 of 1" in result.output
 
     @respx.mock
     @patch("dhub.cli.config.get_token", return_value="test-token")
@@ -523,7 +530,13 @@ class TestListCommand:
     ) -> None:
         """List prints a message when no skills are published."""
         respx.get("http://test:8000/v1/skills").mock(
-            return_value=httpx.Response(200, json=[])
+            return_value=httpx.Response(200, json={
+                "items": [],
+                "total": 0,
+                "page": 1,
+                "page_size": 20,
+                "total_pages": 1,
+            })
         )
         respx.get("http://test:8000/cli/latest-version").mock(
             return_value=httpx.Response(200, json={"latest_version": ""})
@@ -534,6 +547,35 @@ class TestListCommand:
         assert result.exit_code == 0
         assert "Registry:" in result.output
         assert "No skills published yet" in result.output
+
+    @respx.mock
+    @patch("dhub.cli.config.get_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_list_command_with_page_option(
+        self,
+        _mock_url,
+        _mock_token,
+    ) -> None:
+        """--page and --page-size flags are sent as query params."""
+        route = respx.get("http://test:8000/v1/skills").mock(
+            return_value=httpx.Response(200, json={
+                "items": [],
+                "total": 50,
+                "page": 3,
+                "page_size": 5,
+                "total_pages": 10,
+            })
+        )
+        respx.get("http://test:8000/cli/latest-version").mock(
+            return_value=httpx.Response(200, json={"latest_version": ""})
+        )
+
+        result = runner.invoke(app, ["list", "--page", "3", "--page-size", "5"])
+
+        assert result.exit_code == 0
+        request = route.calls.last.request
+        assert "page=3" in str(request.url)
+        assert "page_size=5" in str(request.url)
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import type {
-  SkillSummary,
+  PaginatedSkillsResponse,
   ResolveResponse,
   EvalReport,
   AuditLogEntry,
@@ -24,8 +24,13 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export async function listSkills(): Promise<SkillSummary[]> {
-  return fetchJSON<SkillSummary[]>("/v1/skills");
+export async function listSkills(
+  page = 1,
+  pageSize = 20
+): Promise<PaginatedSkillsResponse> {
+  return fetchJSON<PaginatedSkillsResponse>(
+    `/v1/skills?page=${page}&page_size=${pageSize}`
+  );
 }
 
 export async function resolveSkill(

--- a/frontend/src/pages/SkillsPage.module.css
+++ b/frontend/src/pages/SkillsPage.module.css
@@ -170,6 +170,49 @@
   color: var(--text-muted);
 }
 
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 32px;
+  padding: 16px 0;
+}
+
+.pageButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--neon-cyan);
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.pageButton:hover:not(:disabled) {
+  border-color: var(--neon-cyan);
+  box-shadow: 0 0 10px rgba(0, 240, 255, 0.15);
+}
+
+.pageButton:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.pageInfo {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  letter-spacing: 1px;
+}
+
 /* Empty */
 .empty {
   display: flex;

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Link } from "react-router-dom";
-import { Search, Package, Download, Filter, User } from "lucide-react";
+import { Search, Package, Download, Filter, User, ChevronLeft, ChevronRight } from "lucide-react";
 import { listSkills } from "../api/client";
 import { useApi } from "../hooks/useApi";
 import NeonCard from "../components/NeonCard";
@@ -8,20 +8,29 @@ import GradeBadge from "../components/GradeBadge";
 import LoadingSpinner from "../components/LoadingSpinner";
 import styles from "./SkillsPage.module.css";
 
+const PAGE_SIZE = 12;
+
 export default function SkillsPage() {
-  const { data: skills, loading, error } = useApi(() => listSkills(), []);
+  const [page, setPage] = useState(1);
+  const { data, loading, error } = useApi(
+    () => listSkills(page, PAGE_SIZE),
+    [page]
+  );
+
+  const skills = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.total_pages ?? 1;
+
   const [search, setSearch] = useState("");
   const [orgFilter, setOrgFilter] = useState<string>("all");
   const [gradeFilter, setGradeFilter] = useState<string>("all");
   const [sortBy, setSortBy] = useState<"name" | "downloads" | "updated">("updated");
 
   const orgs = useMemo(() => {
-    if (!skills) return [];
     return [...new Set(skills.map((s) => s.org_slug))].sort();
   }, [skills]);
 
   const filtered = useMemo(() => {
-    if (!skills) return [];
     let result = [...skills];
 
     if (search) {
@@ -55,6 +64,10 @@ export default function SkillsPage() {
     return result;
   }, [skills, search, orgFilter, gradeFilter, sortBy]);
 
+  const goToPage = useCallback((p: number) => {
+    setPage(Math.max(1, Math.min(p, totalPages)));
+  }, [totalPages]);
+
   if (loading) return <LoadingSpinner text="Loading skills..." />;
   if (error) {
     return (
@@ -74,7 +87,7 @@ export default function SkillsPage() {
           Skill Registry
         </h1>
         <p className={styles.subtitle}>
-          {skills?.length ?? 0} skills published across {orgs.length} organizations
+          {total} skills published across {orgs.length} organizations
         </p>
       </div>
 
@@ -170,6 +183,31 @@ export default function SkillsPage() {
               </NeonCard>
             </Link>
           ))}
+        </div>
+      )}
+
+      {/* Pagination controls */}
+      {totalPages > 1 && (
+        <div className={styles.pagination}>
+          <button
+            className={styles.pageButton}
+            onClick={() => goToPage(page - 1)}
+            disabled={page <= 1}
+          >
+            <ChevronLeft size={16} />
+            Prev
+          </button>
+          <span className={styles.pageInfo}>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            className={styles.pageButton}
+            onClick={() => goToPage(page + 1)}
+            disabled={page >= totalPages}
+          >
+            Next
+            <ChevronRight size={16} />
+          </button>
         </div>
       )}
     </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -12,6 +12,14 @@ export interface SkillSummary {
   is_personal_org: boolean;
 }
 
+export interface PaginatedSkillsResponse {
+  items: SkillSummary[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
 export interface OrgSummary {
   id: string;
   slug: string;

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -31,6 +31,7 @@ from decision_hub.infra.database import (
     delete_all_versions,
     delete_skill as delete_skill_record,
     delete_version,
+    count_all_skills,
     fetch_all_skills_for_index,
     find_active_eval_runs_for_user,
     find_audit_logs,
@@ -120,6 +121,15 @@ class SkillSummary(BaseModel):
     author: str
     download_count: int = 0
     is_personal_org: bool = False
+
+
+class PaginatedSkillsResponse(BaseModel):
+    """Paginated list of skills."""
+    items: list[SkillSummary]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
 
 
 class AuditLogResponse(BaseModel):
@@ -342,13 +352,19 @@ def publish_skill(
     )
 
 
-@public_router.get("/skills", response_model=list[SkillSummary])
+@public_router.get("/skills", response_model=PaginatedSkillsResponse)
 def list_skills(
+    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
     conn: Connection = Depends(get_connection),
-) -> list[SkillSummary]:
-    """List all published skills with their latest version info."""
-    rows = fetch_all_skills_for_index(conn)
-    return [
+) -> PaginatedSkillsResponse:
+    """List published skills with offset-based pagination."""
+    total = count_all_skills(conn)
+    total_pages = max(1, (total + page_size - 1) // page_size)
+    offset = (page - 1) * page_size
+
+    rows = fetch_all_skills_for_index(conn, limit=page_size, offset=offset)
+    items = [
         SkillSummary(
             org_slug=row["org_slug"],
             skill_name=row["skill_name"],
@@ -362,6 +378,13 @@ def list_skills(
         )
         for row in rows
     ]
+    return PaginatedSkillsResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+    )
 
 
 @public_router.get(

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -949,14 +949,12 @@ def delete_api_key(conn: Connection, user_id: UUID, key_name: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def fetch_all_skills_for_index(conn: Connection) -> list[dict]:
-    """Fetch all skills with their latest version info for the search index.
+def _skills_index_base_query() -> tuple:
+    """Build the base query components for the skills index.
 
-    Returns a list of dicts, each with keys: org_slug, skill_name,
-    latest_version, eval_status. Uses a subquery to find the latest
-    version per skill (ordered by semver parts numerically).
+    Returns (join, latest_version_subquery) so callers can build
+    SELECT or COUNT statements without duplicating the join logic.
     """
-    # Subquery: for each skill, find the highest semver
     major = sa.cast(
         sa.func.split_part(versions_table.c.semver, ".", 1), sa.Integer
     )
@@ -983,6 +981,34 @@ def fetch_all_skills_for_index(conn: Connection) -> list[dict]:
         )
     ).subquery("ranked")
 
+    join = skills_table.join(
+        organizations_table,
+        skills_table.c.org_id == organizations_table.c.id,
+    ).join(
+        latest_version,
+        sa.and_(
+            skills_table.c.id == latest_version.c.skill_id,
+            latest_version.c.rn == 1,
+        ),
+    )
+
+    return join, latest_version
+
+
+def fetch_all_skills_for_index(
+    conn: Connection,
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> list[dict]:
+    """Fetch skills with their latest version info for the search index.
+
+    When *limit* and *offset* are ``None`` (the default), returns every skill
+    – keeping backward compatibility with the search endpoint.  Pass both to
+    enable offset-based pagination.
+    """
+    join, latest_version = _skills_index_base_query()
+
     stmt = (
         sa.select(
             organizations_table.c.slug.label("org_slug"),
@@ -995,19 +1021,14 @@ def fetch_all_skills_for_index(conn: Connection) -> list[dict]:
             latest_version.c.created_at,
             latest_version.c.published_by,
         )
-        .select_from(
-            skills_table.join(
-                organizations_table,
-                skills_table.c.org_id == organizations_table.c.id,
-            ).join(
-                latest_version,
-                sa.and_(
-                    skills_table.c.id == latest_version.c.skill_id,
-                    latest_version.c.rn == 1,
-                ),
-            )
-        )
+        .select_from(join)
+        .order_by(latest_version.c.created_at.desc().nulls_last())
     )
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    if offset is not None:
+        stmt = stmt.offset(offset)
 
     rows = conn.execute(stmt).all()
     return [
@@ -1024,6 +1045,13 @@ def fetch_all_skills_for_index(conn: Connection) -> list[dict]:
         }
         for row in rows
     ]
+
+
+def count_all_skills(conn: Connection) -> int:
+    """Return the total number of published skills (those with at least one version)."""
+    join, _latest_version = _skills_index_base_query()
+    stmt = sa.select(sa.func.count()).select_from(join)
+    return conn.execute(stmt).scalar() or 0
 
 
 def get_api_keys_for_eval(

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -827,29 +827,37 @@ class TestDeleteSkillVersion:
 # ---------------------------------------------------------------------------
 
 class TestListSkills:
-    """GET /v1/skills -- list all published skills."""
+    """GET /v1/skills -- paginated list of published skills."""
 
+    @patch("decision_hub.api.registry_routes.count_all_skills", return_value=0)
     @patch("decision_hub.api.registry_routes.fetch_all_skills_for_index")
     def test_list_skills_empty(
         self,
         mock_fetch: MagicMock,
+        mock_count: MagicMock,
         client: TestClient,
     ) -> None:
-        """Empty registry returns an empty list."""
+        """Empty registry returns a paginated response with no items."""
         mock_fetch.return_value = []
 
         resp = client.get("/v1/skills")
 
         assert resp.status_code == 200
-        assert resp.json() == []
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["page"] == 1
+        assert data["total_pages"] == 1
 
+    @patch("decision_hub.api.registry_routes.count_all_skills", return_value=1)
     @patch("decision_hub.api.registry_routes.fetch_all_skills_for_index")
     def test_list_skills_returns_data(
         self,
         mock_fetch: MagicMock,
+        mock_count: MagicMock,
         client: TestClient,
     ) -> None:
-        """Skills are returned with all expected fields."""
+        """Skills are returned with all expected fields inside paginated wrapper."""
         from datetime import datetime, timezone
 
         mock_fetch.return_value = [
@@ -869,8 +877,10 @@ class TestListSkills:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        skill = data[0]
+        assert data["total"] == 1
+        assert data["page"] == 1
+        assert len(data["items"]) == 1
+        skill = data["items"][0]
         assert skill["org_slug"] == "acme"
         assert skill["skill_name"] == "doc-writer"
         assert skill["description"] == "Writes documentation"
@@ -880,10 +890,12 @@ class TestListSkills:
         assert skill["author"] == "alice"
         assert skill["download_count"] == 42
 
+    @patch("decision_hub.api.registry_routes.count_all_skills", return_value=4)
     @patch("decision_hub.api.registry_routes.fetch_all_skills_for_index")
     def test_list_skills_safety_rating(
         self,
         mock_fetch: MagicMock,
+        mock_count: MagicMock,
         client: TestClient,
     ) -> None:
         """Safety rating maps eval_status correctly for both new and legacy values."""
@@ -933,16 +945,18 @@ class TestListSkills:
         resp = client.get("/v1/skills")
 
         assert resp.status_code == 200
-        data = resp.json()
+        data = resp.json()["items"]
         assert data[0]["safety_rating"] == "A"
         assert data[1]["safety_rating"] == "B"
         assert data[2]["safety_rating"] == "C"
         assert data[3]["safety_rating"] == "A"  # legacy "passed" -> A
 
+    @patch("decision_hub.api.registry_routes.count_all_skills", return_value=0)
     @patch("decision_hub.api.registry_routes.fetch_all_skills_for_index")
     def test_list_skills_does_not_require_auth(
         self,
         mock_fetch: MagicMock,
+        mock_count: MagicMock,
         client: TestClient,
     ) -> None:
         """List endpoint is public — no auth required."""
@@ -951,6 +965,30 @@ class TestListSkills:
         resp = client.get("/v1/skills")
 
         assert resp.status_code == 200
+
+    @patch("decision_hub.api.registry_routes.count_all_skills", return_value=50)
+    @patch("decision_hub.api.registry_routes.fetch_all_skills_for_index")
+    def test_list_skills_pagination_params(
+        self,
+        mock_fetch: MagicMock,
+        mock_count: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Page and page_size query params are forwarded to the DB layer."""
+        mock_fetch.return_value = []
+
+        resp = client.get("/v1/skills?page=3&page_size=10")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["page"] == 3
+        assert data["page_size"] == 10
+        assert data["total"] == 50
+        assert data["total_pages"] == 5
+        mock_fetch.assert_called_once()
+        _, kwargs = mock_fetch.call_args
+        assert kwargs["limit"] == 10
+        assert kwargs["offset"] == 20
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds pagination support to `/v1/skills` across backend, CLI, and frontend
- Enables efficient browsing of large skill catalogs

## Test plan
- [ ] Verify paginated API responses with `page` and `per_page` params
- [ ] Test CLI `dhub list` with pagination
- [ ] Confirm frontend renders paginated skill list

🤖 Generated with [Claude Code](https://claude.com/claude-code)