### PR TITLE
Sync GitHub org metadata on login

### DIFF
--- a/server/migrations/009_add_org_github_metadata.sql
+++ b/server/migrations/009_add_org_github_metadata.sql
@@ -1,0 +1,7 @@
+-- Add GitHub metadata columns to organizations for display on org profile pages.
+-- Synced periodically from the GitHub API.
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS email TEXT;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS blog TEXT;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS github_synced_at TIMESTAMPTZ;

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -8,7 +8,7 @@ from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_settings
 from decision_hub.domain.auth import create_jwt
-from decision_hub.domain.orgs import sync_user_orgs
+from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
 from decision_hub.infra.github import (
     AuthorizationPending,
@@ -131,6 +131,15 @@ async def exchange_token(
 
     org_slugs = sync_user_orgs(conn, user.id, github_org_logins, username)
     logger.debug("Synced orgs for {}: {}", username, org_slugs)
+
+    # Sync GitHub metadata (avatar, email, description) for each org.
+    # Best-effort: failures are logged but don't block login.
+    try:
+        await sync_org_github_metadata(conn, gh_token, org_slugs, username)
+    except Exception:
+        logger.opt(exception=True).warning(
+            "Failed to sync GitHub metadata for {}; continuing", username,
+        )
 
     jwt_token = create_jwt(
         str(user.id),

--- a/server/src/decision_hub/api/org_routes.py
+++ b/server/src/decision_hub/api/org_routes.py
@@ -1,4 +1,6 @@
-"""Organisation management routes -- create and list."""
+"""Organisation management routes -- create, list, and detail."""
+
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -9,11 +11,12 @@ from sqlalchemy.exc import IntegrityError
 from decision_hub.api.deps import get_connection, get_current_user
 from decision_hub.domain.orgs import validate_org_slug
 from decision_hub.infra.database import (
+    find_org_by_slug,
     insert_org_member,
     insert_organization,
     list_user_orgs,
 )
-from decision_hub.models import User
+from decision_hub.models import Organization, User
 
 org_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
 
@@ -37,6 +40,42 @@ class OrgSummary(BaseModel):
     """Summary of an organisation for listing."""
     id: str
     slug: str
+    avatar_url: str | None = None
+    is_personal: bool = False
+
+
+class OrgDetail(BaseModel):
+    """Full organisation profile for a dedicated org page."""
+    id: str
+    slug: str
+    is_personal: bool
+    avatar_url: str | None = None
+    email: str | None = None
+    description: str | None = None
+    blog: str | None = None
+    github_synced_at: datetime | None = None
+
+
+def _org_to_summary(org: Organization) -> OrgSummary:
+    return OrgSummary(
+        id=str(org.id),
+        slug=org.slug,
+        avatar_url=org.avatar_url,
+        is_personal=org.is_personal,
+    )
+
+
+def _org_to_detail(org: Organization) -> OrgDetail:
+    return OrgDetail(
+        id=str(org.id),
+        slug=org.slug,
+        is_personal=org.is_personal,
+        avatar_url=org.avatar_url,
+        email=org.email,
+        description=org.description,
+        blog=org.blog,
+        github_synced_at=org.github_synced_at,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -75,4 +114,17 @@ def list_orgs(
 ) -> list[OrgSummary]:
     """List organisations the authenticated user belongs to."""
     orgs = list_user_orgs(conn, current_user.id)
-    return [OrgSummary(id=str(o.id), slug=o.slug) for o in orgs]
+    return [_org_to_summary(o) for o in orgs]
+
+
+@org_router.get("/{slug}", response_model=OrgDetail)
+def get_org(
+    slug: str,
+    conn: Connection = Depends(get_connection),
+    current_user: User = Depends(get_current_user),
+) -> OrgDetail:
+    """Get full profile for a single organisation."""
+    org = find_org_by_slug(conn, slug)
+    if org is None:
+        raise HTTPException(status_code=404, detail=f"Organisation '{slug}' not found")
+    return _org_to_detail(org)

--- a/server/src/decision_hub/domain/orgs.py
+++ b/server/src/decision_hub/domain/orgs.py
@@ -1,6 +1,7 @@
 """Organization validation and sync logic."""
 
 import re
+from datetime import datetime, timezone
 from uuid import UUID
 
 from loguru import logger
@@ -139,3 +140,57 @@ def _ensure_org_membership(
         insert_member_fn(conn, org.id, user_id, default_role)
 
 
+# Metadata refresh threshold: skip orgs synced within this window
+_METADATA_REFRESH_HOURS = 24
+
+
+async def sync_org_github_metadata(
+    conn: Connection,
+    access_token: str,
+    org_slugs: list[str],
+    username: str,
+) -> None:
+    """Fetch GitHub metadata for each org and persist it.
+
+    For personal namespaces (slug == username.lower()), uses the GitHub
+    /users/{username} endpoint. For team orgs, uses /orgs/{org}.
+    Skips orgs that were synced within the last _METADATA_REFRESH_HOURS.
+    Errors on individual orgs are logged and skipped (best-effort).
+    """
+    from decision_hub.infra.database import find_org_by_slug, update_org_github_metadata
+    from decision_hub.infra.github import fetch_org_metadata, fetch_user_metadata
+
+    now = datetime.now(timezone.utc)
+    personal_slug = username.lower()
+
+    for slug in org_slugs:
+        org = find_org_by_slug(conn, slug)
+        if org is None:
+            continue
+
+        # Skip if recently synced
+        if org.github_synced_at is not None:
+            age_hours = (now - org.github_synced_at).total_seconds() / 3600
+            if age_hours < _METADATA_REFRESH_HOURS:
+                continue
+
+        try:
+            if slug == personal_slug:
+                meta = await fetch_user_metadata(access_token, username)
+            else:
+                meta = await fetch_org_metadata(access_token, slug)
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Failed to fetch GitHub metadata for org={}", slug
+            )
+            continue
+
+        update_org_github_metadata(
+            conn,
+            org.id,
+            avatar_url=meta.get("avatar_url"),
+            email=meta.get("email"),
+            description=meta.get("description"),
+            blog=meta.get("blog"),
+        )
+        logger.debug("Synced GitHub metadata for org={}", slug)

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -74,6 +74,11 @@ organizations_table = Table(
         nullable=False,
     ),
     Column("is_personal", Boolean, nullable=False, server_default="false"),
+    Column("avatar_url", Text, nullable=True),
+    Column("email", Text, nullable=True),
+    Column("description", Text, nullable=True),
+    Column("blog", Text, nullable=True),
+    Column("github_synced_at", DateTime(timezone=True), nullable=True),
 )
 
 org_members_table = Table(
@@ -323,7 +328,17 @@ def _row_to_user(row: sa.Row) -> User:
 
 def _row_to_organization(row: sa.Row) -> Organization:
     """Map a database row to an Organization model."""
-    return Organization(id=row.id, slug=row.slug, owner_id=row.owner_id, is_personal=row.is_personal)
+    return Organization(
+        id=row.id,
+        slug=row.slug,
+        owner_id=row.owner_id,
+        is_personal=row.is_personal,
+        avatar_url=row.avatar_url,
+        email=row.email,
+        description=row.description,
+        blog=row.blog,
+        github_synced_at=row.github_synced_at,
+    )
 
 
 def _row_to_org_member(row: sa.Row) -> OrgMember:
@@ -462,6 +477,34 @@ def find_org_by_slug(conn: Connection, slug: str) -> Organization | None:
     if row is None:
         return None
     return _row_to_organization(row)
+
+
+def update_org_github_metadata(
+    conn: Connection,
+    org_id: UUID,
+    *,
+    avatar_url: str | None = None,
+    email: str | None = None,
+    description: str | None = None,
+    blog: str | None = None,
+) -> None:
+    """Update GitHub-sourced metadata on an organization.
+
+    Sets github_synced_at to the current time.
+    """
+    stmt = (
+        sa.update(organizations_table)
+        .where(organizations_table.c.id == org_id)
+        .values(
+            avatar_url=avatar_url,
+            email=email,
+            description=description,
+            blog=blog,
+            github_synced_at=sa.func.now(),
+        )
+    )
+    conn.execute(stmt)
+    logger.debug("Updated GitHub metadata for org={}", org_id)
 
 
 def list_user_orgs(conn: Connection, user_id: UUID) -> list[Organization]:

--- a/server/src/decision_hub/infra/github.py
+++ b/server/src/decision_hub/infra/github.py
@@ -191,6 +191,53 @@ async def list_user_orgs(access_token: str) -> list[dict]:
     return orgs
 
 
+async def fetch_org_metadata(access_token: str, org_login: str) -> dict:
+    """Fetch public profile metadata for a GitHub organization.
+
+    Returns a dict with keys: avatar_url, email, description, blog.
+    Missing or empty values are returned as None.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://api.github.com/orgs/{org_login}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": _ACCEPT_JSON,
+            },
+        )
+    response.raise_for_status()
+    data = response.json()
+    return {
+        "avatar_url": data.get("avatar_url") or None,
+        "email": data.get("email") or None,
+        "description": data.get("description") or None,
+        "blog": data.get("blog") or None,
+    }
+
+
+async def fetch_user_metadata(access_token: str, username: str) -> dict:
+    """Fetch public profile metadata for a GitHub user (personal namespace).
+
+    Returns a dict with keys: avatar_url, email, description, blog.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://api.github.com/users/{username}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": _ACCEPT_JSON,
+            },
+        )
+    response.raise_for_status()
+    data = response.json()
+    return {
+        "avatar_url": data.get("avatar_url") or None,
+        "email": data.get("email") or None,
+        "description": data.get("bio") or None,
+        "blog": data.get("blog") or None,
+    }
+
+
 async def check_org_membership(access_token: str, org: str, username: str) -> bool:
     """Check whether a GitHub user is a member of an organization.
 

--- a/server/src/decision_hub/models.py
+++ b/server/src/decision_hub/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
+
 # Re-export shared models from dhub_core (single source of truth)
 from dhub_core.models import (  # noqa: F401
     AgentTestTarget,
@@ -36,6 +37,11 @@ class Organization:
     slug: str
     owner_id: UUID
     is_personal: bool = False
+    avatar_url: str | None = None
+    email: str | None = None
+    description: str | None = None
+    blog: str | None = None
+    github_synced_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/server/tests/test_api/test_org_routes.py
+++ b/server/tests/test_api/test_org_routes.py
@@ -1,5 +1,6 @@
 """Tests for decision_hub.api.org_routes -- organisation management endpoints."""
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -117,3 +118,86 @@ class TestListOrgs:
         assert len(data) == 2
         assert data[0]["slug"] == "org-one"
         assert data[1]["slug"] == "org-two"
+
+    @patch("decision_hub.api.org_routes.list_user_orgs")
+    def test_list_orgs_includes_avatar_url(
+        self,
+        mock_list: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        sample_user_id: UUID,
+    ) -> None:
+        """OrgSummary should include avatar_url and is_personal."""
+        mock_list.return_value = [
+            Organization(
+                id=UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+                slug="org-one",
+                owner_id=sample_user_id,
+                avatar_url="https://avatars.githubusercontent.com/u/1",
+                is_personal=False,
+            ),
+        ]
+
+        resp = client.get("/v1/orgs", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["avatar_url"] == "https://avatars.githubusercontent.com/u/1"
+        assert data[0]["is_personal"] is False
+
+
+class TestGetOrg:
+    """GET /v1/orgs/{slug} -- get full org profile."""
+
+    @patch("decision_hub.api.org_routes.find_org_by_slug")
+    def test_get_org_success(
+        self,
+        mock_find: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        sample_user_id: UUID,
+    ) -> None:
+        """Should return full org profile with GitHub metadata."""
+        synced_at = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_find.return_value = Organization(
+            id=UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+            slug="pymc-labs",
+            owner_id=sample_user_id,
+            is_personal=False,
+            avatar_url="https://avatars.githubusercontent.com/u/123",
+            email="info@pymc-labs.com",
+            description="Bayesian modeling",
+            blog="https://pymc-labs.com",
+            github_synced_at=synced_at,
+        )
+
+        resp = client.get("/v1/orgs/pymc-labs", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slug"] == "pymc-labs"
+        assert data["avatar_url"] == "https://avatars.githubusercontent.com/u/123"
+        assert data["email"] == "info@pymc-labs.com"
+        assert data["description"] == "Bayesian modeling"
+        assert data["blog"] == "https://pymc-labs.com"
+        assert data["github_synced_at"] is not None
+
+    @patch("decision_hub.api.org_routes.find_org_by_slug")
+    def test_get_org_not_found(
+        self,
+        mock_find: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Should return 404 for unknown org slug."""
+        mock_find.return_value = None
+
+        resp = client.get("/v1/orgs/nonexistent", headers=auth_headers)
+
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"]
+
+    def test_get_org_unauthenticated(self, client: TestClient) -> None:
+        """Missing auth header should return 401."""
+        resp = client.get("/v1/orgs/pymc-labs")
+        assert resp.status_code == 401

--- a/server/tests/test_domain/test_orgs.py
+++ b/server/tests/test_domain/test_orgs.py
@@ -1,12 +1,14 @@
 """Tests for decision_hub.domain.orgs -- organisation validation and sync logic."""
 
 from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 
-from decision_hub.domain.orgs import sync_user_orgs, validate_org_slug, validate_role
+from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs, validate_org_slug, validate_role
+from decision_hub.models import Organization
 
 
 # ---------------------------------------------------------------------------
@@ -290,3 +292,106 @@ class TestSyncUserOrgs:
         result = sync_user_orgs(conn, user_id, ["z-org", "a-org"], "m-user")
 
         assert result == ["a-org", "m-user", "z-org"]
+
+
+# ---------------------------------------------------------------------------
+# sync_org_github_metadata
+# ---------------------------------------------------------------------------
+
+class TestSyncOrgGithubMetadata:
+    """sync_org_github_metadata should fetch and persist GitHub metadata."""
+
+    @patch("decision_hub.infra.database.update_org_github_metadata")
+    @patch("decision_hub.infra.github.fetch_user_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.github.fetch_org_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.database.find_org_by_slug")
+    @pytest.mark.asyncio
+    async def test_syncs_personal_namespace_via_user_api(
+        self, mock_find_org, mock_fetch_org, mock_fetch_user, mock_update
+    ) -> None:
+        """Personal namespace (slug == username.lower()) should use /users/{username}."""
+        conn = MagicMock()
+        org = Organization(id=uuid4(), slug="alice", owner_id=uuid4(), is_personal=True)
+        mock_find_org.return_value = org
+        mock_fetch_user.return_value = {
+            "avatar_url": "https://avatars.githubusercontent.com/u/1",
+            "email": "alice@example.com",
+            "description": "Dev",
+            "blog": "https://alice.dev",
+        }
+
+        await sync_org_github_metadata(conn, "token", ["alice"], "Alice")
+
+        mock_fetch_user.assert_called_once_with("token", "Alice")
+        mock_fetch_org.assert_not_called()
+        mock_update.assert_called_once_with(
+            conn, org.id,
+            avatar_url="https://avatars.githubusercontent.com/u/1",
+            email="alice@example.com",
+            description="Dev",
+            blog="https://alice.dev",
+        )
+
+    @patch("decision_hub.infra.database.update_org_github_metadata")
+    @patch("decision_hub.infra.github.fetch_user_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.github.fetch_org_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.database.find_org_by_slug")
+    @pytest.mark.asyncio
+    async def test_syncs_team_org_via_org_api(
+        self, mock_find_org, mock_fetch_org, mock_fetch_user, mock_update
+    ) -> None:
+        """Team orgs should use /orgs/{org}."""
+        conn = MagicMock()
+        org = Organization(id=uuid4(), slug="pymc-labs", owner_id=uuid4())
+        mock_find_org.return_value = org
+        mock_fetch_org.return_value = {
+            "avatar_url": "https://avatars.githubusercontent.com/u/2",
+            "email": None,
+            "description": "Bayesian",
+            "blog": None,
+        }
+
+        await sync_org_github_metadata(conn, "token", ["pymc-labs"], "alice")
+
+        mock_fetch_org.assert_called_once_with("token", "pymc-labs")
+        mock_fetch_user.assert_not_called()
+
+    @patch("decision_hub.infra.database.update_org_github_metadata")
+    @patch("decision_hub.infra.github.fetch_user_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.github.fetch_org_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.database.find_org_by_slug")
+    @pytest.mark.asyncio
+    async def test_skips_recently_synced_orgs(
+        self, mock_find_org, mock_fetch_org, mock_fetch_user, mock_update
+    ) -> None:
+        """Orgs synced within the refresh window should be skipped."""
+        conn = MagicMock()
+        org = Organization(
+            id=uuid4(), slug="pymc-labs", owner_id=uuid4(),
+            github_synced_at=datetime.now(timezone.utc),
+        )
+        mock_find_org.return_value = org
+
+        await sync_org_github_metadata(conn, "token", ["pymc-labs"], "alice")
+
+        mock_fetch_org.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch("decision_hub.infra.database.update_org_github_metadata")
+    @patch("decision_hub.infra.github.fetch_user_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.github.fetch_org_metadata", new_callable=AsyncMock)
+    @patch("decision_hub.infra.database.find_org_by_slug")
+    @pytest.mark.asyncio
+    async def test_continues_on_fetch_error(
+        self, mock_find_org, mock_fetch_org, mock_fetch_user, mock_update
+    ) -> None:
+        """GitHub API errors should be logged and skipped, not raised."""
+        conn = MagicMock()
+        org = Organization(id=uuid4(), slug="bad-org", owner_id=uuid4())
+        mock_find_org.return_value = org
+        mock_fetch_org.side_effect = Exception("API error")
+
+        # Should not raise
+        await sync_org_github_metadata(conn, "token", ["bad-org"], "alice")
+
+        mock_update.assert_not_called()

--- a/server/tests/test_infra/test_github.py
+++ b/server/tests/test_infra/test_github.py
@@ -4,7 +4,12 @@ import httpx
 import pytest
 import respx
 
-from decision_hub.infra.github import _parse_next_link, list_user_orgs
+from decision_hub.infra.github import (
+    _parse_next_link,
+    fetch_org_metadata,
+    fetch_user_metadata,
+    list_user_orgs,
+)
 
 
 class TestParseNextLink:
@@ -82,3 +87,71 @@ class TestListUserOrgs:
         result = await list_user_orgs("gh-token-abc")
 
         assert result == []
+
+
+class TestFetchOrgMetadata:
+    """fetch_org_metadata extracts profile fields from the GitHub org API."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_metadata(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs").mock(
+            return_value=httpx.Response(200, json={
+                "login": "pymc-labs",
+                "avatar_url": "https://avatars.githubusercontent.com/u/123",
+                "email": "info@pymc-labs.com",
+                "description": "Bayesian modeling",
+                "blog": "https://pymc-labs.com",
+            })
+        )
+
+        meta = await fetch_org_metadata("token", "pymc-labs")
+
+        assert meta["avatar_url"] == "https://avatars.githubusercontent.com/u/123"
+        assert meta["email"] == "info@pymc-labs.com"
+        assert meta["description"] == "Bayesian modeling"
+        assert meta["blog"] == "https://pymc-labs.com"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_values_become_none(self) -> None:
+        respx.get("https://api.github.com/orgs/empty-org").mock(
+            return_value=httpx.Response(200, json={
+                "login": "empty-org",
+                "avatar_url": "",
+                "email": "",
+                "description": "",
+                "blog": "",
+            })
+        )
+
+        meta = await fetch_org_metadata("token", "empty-org")
+
+        assert meta["avatar_url"] is None
+        assert meta["email"] is None
+        assert meta["description"] is None
+        assert meta["blog"] is None
+
+
+class TestFetchUserMetadata:
+    """fetch_user_metadata extracts profile fields from the GitHub user API."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_metadata_with_bio_as_description(self) -> None:
+        respx.get("https://api.github.com/users/alice").mock(
+            return_value=httpx.Response(200, json={
+                "login": "alice",
+                "avatar_url": "https://avatars.githubusercontent.com/u/456",
+                "email": "alice@example.com",
+                "bio": "Data scientist",
+                "blog": "https://alice.dev",
+            })
+        )
+
+        meta = await fetch_user_metadata("token", "alice")
+
+        assert meta["avatar_url"] == "https://avatars.githubusercontent.com/u/456"
+        assert meta["email"] == "alice@example.com"
+        assert meta["description"] == "Data scientist"
+        assert meta["blog"] == "https://alice.dev"


### PR DESCRIPTION
## Summary
- Syncs GitHub org metadata (avatar, email, description, blog URL) during user login
- Keeps org profiles up-to-date with their GitHub source

## Test plan
- [ ] Verify org metadata is fetched and stored on login
- [ ] Confirm existing orgs get updated metadata on next login
- [ ] Test with orgs that have missing optional fields (email, blog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)