### PR TITLE
Optimize fetch_all_skills_for_index with LATERAL join

### DIFF
--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1307,33 +1307,31 @@ def fetch_all_skills_for_index(
     """Fetch all skills with their latest version info for the search index.
 
     Returns a list of dicts, each with keys: org_slug, skill_name,
-    latest_version, eval_status, visibility. Uses a subquery to find
-    the latest version per skill (ordered by semver parts numerically).
+    latest_version, eval_status, visibility. Uses a LATERAL subquery to find
+    the latest version per skill via one index lookup each (ordered by semver
+    parts numerically), leveraging idx_versions_skill_semver_parts.
 
     When user_org_ids is provided, applies visibility filtering so
     private skills are only returned for org members or granted orgs.
     When None (unauthenticated), only public skills are returned.
     """
-    # Subquery: for each skill, find the highest semver using integer columns
+    # LATERAL subquery: for each skill, one index scan to find the highest semver
     latest_version = (
         sa.select(
-            versions_table.c.skill_id,
             versions_table.c.semver,
             versions_table.c.eval_status,
             versions_table.c.created_at,
             versions_table.c.published_by,
-            sa.func.row_number()
-            .over(
-                partition_by=versions_table.c.skill_id,
-                order_by=[
-                    versions_table.c.semver_major.desc(),
-                    versions_table.c.semver_minor.desc(),
-                    versions_table.c.semver_patch.desc(),
-                ],
-            )
-            .label("rn"),
         )
-    ).subquery("ranked")
+        .where(versions_table.c.skill_id == skills_table.c.id)
+        .order_by(
+            versions_table.c.semver_major.desc(),
+            versions_table.c.semver_minor.desc(),
+            versions_table.c.semver_patch.desc(),
+        )
+        .limit(1)
+        .lateral("latest_version")
+    )
 
     base = sa.select(
         organizations_table.c.slug.label("org_slug"),
@@ -1353,10 +1351,7 @@ def fetch_all_skills_for_index(
             skills_table.c.org_id == organizations_table.c.id,
         ).join(
             latest_version,
-            sa.and_(
-                skills_table.c.id == latest_version.c.skill_id,
-                latest_version.c.rn == 1,
-            ),
+            sa.literal(True),
         )
     )
 


### PR DESCRIPTION
## Summary

- Replace `ROW_NUMBER()` window function with a `LATERAL` subquery in `fetch_all_skills_for_index` for finding the latest version per skill
- The lateral join performs one index lookup per skill using `idx_versions_skill_semver_parts` and stops after 1 row via `LIMIT 1`, reducing cost from O(versions) to O(skills)
- No schema changes, no migration needed — query-only optimization

Closes #39
Spec: `specs/pr-31-lateral-join-optimization.md`

## Test plan

- [x] `ruff check` passes
- [x] `mypy` passes — no type issues
- [x] `make test-server` — all 460 tests pass
- [ ] Verify on dev that `/api/skills` returns the same results

🤖 Generated with [Claude Code](https://claude.com/claude-code)