### PR TITLE
Show GitHub repo link on skill page + fix install copy

### DIFF
--- a/frontend/src/pages/SkillDetailPage.module.css
+++ b/frontend/src/pages/SkillDetailPage.module.css
@@ -68,6 +68,11 @@
   font-size: 0.85rem;
   color: var(--text-muted);
   font-family: 'Share Tech Mono', monospace;
+  text-decoration: none;
+}
+
+a.metaItem:hover {
+  color: var(--neon-cyan);
 }
 
 .headerRight {

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   Clock,
   Copy,
   Check,
+  Github,
 } from "lucide-react";
 import JSZip from "jszip";
 import { saveAs } from "file-saver";
@@ -126,7 +127,7 @@ export default function SkillDetailPage() {
   };
 
   const handleCopyInstall = () => {
-    navigator.clipboard.writeText(`dhub install ${orgSlug}/${skillName}`);
+    navigator.clipboard.writeText(`dhub install ${orgSlug}/${skillName} --agent all`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -188,6 +189,16 @@ export default function SkillDetailPage() {
               <span className={styles.metaItem}>
                 <Clock size={14} /> {skill.updated_at}
               </span>
+            )}
+            {skill.source_repo_url && (
+              <a
+                href={skill.source_repo_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.metaItem}
+              >
+                <Github size={14} /> Source
+              </a>
             )}
           </div>
         </div>

--- a/frontend/src/pages/SkillsPage.test.tsx
+++ b/frontend/src/pages/SkillsPage.test.tsx
@@ -19,6 +19,7 @@ function makeSkill(overrides: Partial<SkillSummary> = {}): SkillSummary {
     download_count: 10,
     is_personal_org: false,
     category: "",
+    source_repo_url: null,
     ...overrides,
   };
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -11,6 +11,7 @@ export interface SkillSummary {
   download_count: number;
   is_personal_org: boolean;
   category: string;
+  source_repo_url: string | null;
 }
 
 export interface PaginatedSkillsResponse {

--- a/server/migrations/20260212_120000_add_skill_source_repo_url.sql
+++ b/server/migrations/20260212_120000_add_skill_source_repo_url.sql
@@ -1,0 +1,2 @@
+-- Add source_repo_url to skills for linking to the original GitHub repository.
+ALTER TABLE skills ADD COLUMN IF NOT EXISTS source_repo_url TEXT;

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -199,6 +199,7 @@ class SkillSummary(BaseModel):
     is_personal_org: bool = False
     category: str = ""
     visibility: str = "public"
+    source_repo_url: str | None = None
 
 
 class PaginatedSkillsResponse(BaseModel):
@@ -576,6 +577,7 @@ def list_skills(
             is_personal_org=row.get("is_personal_org", False),
             category=row.get("category", ""),
             visibility=row.get("visibility", "public"),
+            source_repo_url=row.get("source_repo_url"),
         )
         for row in rows
     ]
@@ -620,6 +622,7 @@ def get_skill_summary(
         is_personal_org=org.is_personal if org else False,
         category=skill.category,
         visibility=skill.visibility,
+        source_repo_url=skill.source_repo_url,
     )
 
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -159,6 +159,7 @@ skills_table = Table(
     Column("download_count", sa.Integer, nullable=False, server_default="0"),
     Column("category", String, nullable=False, server_default=""),
     Column("visibility", String(10), nullable=False, server_default="public"),
+    Column("source_repo_url", Text, nullable=True),
     Column(
         "created_at",
         DateTime(timezone=True),
@@ -556,6 +557,7 @@ def _row_to_skill(row: sa.Row) -> Skill:
         download_count=row.download_count,
         category=row.category,
         visibility=row.visibility,
+        source_repo_url=row.source_repo_url,
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
@@ -787,6 +789,7 @@ def insert_skill(
     category: str = "",
     *,
     visibility: str = "public",
+    source_repo_url: str | None = None,
 ) -> Skill:
     """Register a new skill under an organization.
 
@@ -797,15 +800,15 @@ def insert_skill(
         description: Short description from SKILL.md frontmatter.
         category: Skill category from LLM classification.
         visibility: Skill visibility ('public' or 'org').
+        source_repo_url: URL of the source GitHub repository.
 
     Returns:
         The newly created Skill.
     """
-    stmt = (
-        sa.insert(skills_table)
-        .values(org_id=org_id, name=name, description=description, category=category, visibility=visibility)
-        .returning(*skills_table.c)
-    )
+    values: dict = dict(org_id=org_id, name=name, description=description, category=category, visibility=visibility)
+    if source_repo_url is not None:
+        values["source_repo_url"] = source_repo_url
+    stmt = sa.insert(skills_table).values(**values).returning(*skills_table.c)
     row = conn.execute(stmt).one()
     skill = _row_to_skill(row)
     logger.debug("Inserted skill name={} org={} visibility={} id={}", name, org_id, visibility, skill.id)
@@ -911,6 +914,12 @@ def _row_to_skill_access_grant(row: sa.Row) -> SkillAccessGrant:
 def update_skill_visibility(conn: Connection, skill_id: UUID, visibility: str) -> None:
     """Update the visibility of an existing skill."""
     stmt = sa.update(skills_table).where(skills_table.c.id == skill_id).values(visibility=visibility)
+    conn.execute(stmt)
+
+
+def update_skill_source_repo_url(conn: Connection, skill_id: UUID, source_repo_url: str) -> None:
+    """Set or update the source GitHub repository URL for a skill."""
+    stmt = sa.update(skills_table).where(skills_table.c.id == skill_id).values(source_repo_url=source_repo_url)
     conn.execute(stmt)
 
 
@@ -1419,6 +1428,7 @@ def fetch_all_skills_for_index(
         skills_table.c.download_count,
         skills_table.c.category,
         skills_table.c.visibility,
+        skills_table.c.source_repo_url,
         latest_version.c.semver.label("latest_version"),
         latest_version.c.eval_status,
         latest_version.c.created_at,

--- a/server/src/decision_hub/models.py
+++ b/server/src/decision_hub/models.py
@@ -65,6 +65,7 @@ class Skill:
     download_count: int = 0
     category: str = ""
     visibility: str = "public"
+    source_repo_url: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/server/src/decision_hub/scripts/crawler/processing.py
+++ b/server/src/decision_hub/scripts/crawler/processing.py
@@ -188,6 +188,7 @@ def process_repo_on_modal(
                 result["status"] = "no_skills"
                 return result
 
+            source_repo_url = f"https://github.com/{repo_dict['full_name']}"
             with engine.connect() as conn:
                 for skill_dir in skill_dirs:
                     try:
@@ -198,6 +199,7 @@ def process_repo_on_modal(
                             org,
                             skill_dir,
                             result,
+                            source_repo_url=source_repo_url,
                         )
                         conn.commit()
                     except Exception:
@@ -219,7 +221,9 @@ def process_repo_on_modal(
     return result
 
 
-def _publish_one_skill(conn, s3_client, settings, org, skill_dir: Path, result: dict) -> None:
+def _publish_one_skill(
+    conn, s3_client, settings, org, skill_dir: Path, result: dict, *, source_repo_url: str | None = None
+) -> None:
     """Parse, gauntlet-check, and publish a single skill. Mutates result counts."""
     from decision_hub.api.registry_service import run_gauntlet_pipeline
     from decision_hub.infra.database import (
@@ -230,6 +234,7 @@ def _publish_one_skill(conn, s3_client, settings, org, skill_dir: Path, result: 
         insert_version,
         resolve_latest_version,
         update_skill_description,
+        update_skill_source_repo_url,
     )
     from decision_hub.infra.storage import compute_checksum, upload_skill_zip
     from dhub_core.manifest import parse_skill_md
@@ -246,9 +251,11 @@ def _publish_one_skill(conn, s3_client, settings, org, skill_dir: Path, result: 
     # Upsert skill record
     skill = find_skill(conn, org.id, name)
     if skill is None:
-        skill = insert_skill(conn, org.id, name, description)
+        skill = insert_skill(conn, org.id, name, description, source_repo_url=source_repo_url)
     else:
         update_skill_description(conn, skill.id, description)
+        if source_repo_url and skill.source_repo_url != source_repo_url:
+            update_skill_source_repo_url(conn, skill.id, source_repo_url)
 
     # Determine version (auto-bump patch or start at 0.1.0)
     latest = resolve_latest_version(conn, org.slug, name)


### PR DESCRIPTION
## Summary
- Add `source_repo_url` column to the skills table so skills discovered by the crawler link back to their GitHub repo
- Show a GitHub "Source" link in the skill detail page header when `source_repo_url` is set
- Fix the "dhub install" copy button to include `--agent all`

## Test plan
- [ ] Run `make migrate-dev` to apply the new migration
- [ ] Re-crawl a few skills and verify `source_repo_url` is populated
- [ ] Check skill detail page shows the GitHub link
- [ ] Verify the copy button copies `dhub install org/skill --agent all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)