### PR TITLE
Add count-up animation to homepage statistics

### DIFF
--- a/frontend/src/hooks/useCountUp.ts
+++ b/frontend/src/hooks/useCountUp.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useRef } from "react";
+
+/**
+ * Animates a number from 0 to `target` over `duration` ms once the
+ * referenced element scrolls into view. Uses requestAnimationFrame
+ * with an ease-out curve for a smooth counting effect.
+ */
+export function useCountUp(target: number, duration = 1500): [number, React.RefObject<HTMLElement | null>] {
+  const [value, setValue] = useState(0);
+  const ref = useRef<HTMLElement | null>(null);
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || hasAnimated.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting || hasAnimated.current) return;
+        hasAnimated.current = true;
+        observer.disconnect();
+
+        if (target === 0) {
+          setValue(0);
+          return;
+        }
+
+        const start = performance.now();
+        const step = (now: number) => {
+          const elapsed = now - start;
+          const progress = Math.min(elapsed / duration, 1);
+          // ease-out cubic
+          const eased = 1 - Math.pow(1 - progress, 3);
+          setValue(Math.round(eased * target));
+
+          if (progress < 1) {
+            requestAnimationFrame(step);
+          }
+        };
+        requestAnimationFrame(step);
+      },
+      { threshold: 0.2 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [target, duration]);
+
+  return [value, ref];
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Package, Building2, Shield, Zap, ArrowRight, Download, Star, Bot, Terminal } from "lucide-react";
 import { getRegistryStats, listSkillsFiltered } from "../api/client";
 import { useApi } from "../hooks/useApi";
+import { useCountUp } from "../hooks/useCountUp";
 import NeonCard from "../components/NeonCard";
 import GradeBadge from "../components/GradeBadge";
 import AnimatedTerminal from "../components/AnimatedTerminal";
@@ -19,6 +20,10 @@ export default function HomePage() {
   const totalSkills = stats?.total_skills ?? 0;
   const totalOrgs = stats?.total_orgs ?? 0;
   const totalDownloads = stats?.total_downloads ?? 0;
+
+  const [animatedSkills, skillsRef] = useCountUp(totalSkills);
+  const [animatedOrgs, orgsRef] = useCountUp(totalOrgs);
+  const [animatedDownloads, downloadsRef] = useCountUp(totalDownloads);
 
   return (
     <div className="container">
@@ -50,23 +55,23 @@ export default function HomePage() {
       {/* Stats */}
       <section className={styles.stats}>
         <NeonCard glow="cyan">
-          <div className={styles.statItem}>
+          <div className={styles.statItem} ref={skillsRef as React.RefObject<HTMLDivElement>}>
             <Package size={24} className={styles.statIcon} />
-            <span className={styles.statNumber}>{totalSkills}</span>
+            <span className={styles.statNumber}>{animatedSkills.toLocaleString()}</span>
             <span className={styles.statLabel}>Skills Published</span>
           </div>
         </NeonCard>
         <NeonCard glow="pink">
-          <div className={styles.statItem}>
+          <div className={styles.statItem} ref={orgsRef as React.RefObject<HTMLDivElement>}>
             <Building2 size={24} className={styles.statIcon} />
-            <span className={styles.statNumber}>{totalOrgs}</span>
+            <span className={styles.statNumber}>{animatedOrgs.toLocaleString()}</span>
             <span className={styles.statLabel}>Organizations</span>
           </div>
         </NeonCard>
         <NeonCard glow="purple">
-          <div className={styles.statItem}>
+          <div className={styles.statItem} ref={downloadsRef as React.RefObject<HTMLDivElement>}>
             <Download size={24} className={styles.statIcon} />
-            <span className={styles.statNumber}>{totalDownloads.toLocaleString()}</span>
+            <span className={styles.statNumber}>{animatedDownloads.toLocaleString()}</span>
             <span className={styles.statLabel}>Downloads</span>
           </div>
         </NeonCard>


### PR DESCRIPTION
## What changed
Added a new `useCountUp` hook that animates numbers from 0 to a target value when scrolling into view, and integrated it into the HomePage stats section to animate the skills, organizations, and downloads counters.

## Why
This improves the visual appeal and user engagement of the homepage by adding smooth, animated transitions to the key statistics rather than displaying static numbers. The animation triggers when the stats section becomes visible, creating a more polished and interactive experience.

## How to test
1. Navigate to the homepage
2. Scroll down to the stats section (Skills Published, Organizations, Downloads)
3. Verify that the numbers animate smoothly from 0 to their final values when the section comes into view
4. Confirm the animation uses an ease-out curve for a natural feel
5. Verify the animation only plays once per page load

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01QzBfR4uv1tmdBBJbd7JhjM