### PR TITLE
Refactor hero title layout and update section heading

### DIFF
--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -20,19 +20,29 @@
   line-height: 1;
   margin-bottom: 20px;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
 }
 
 .heroAccent {
-  display: block;
-  font-size: 1.2rem;
-  letter-spacing: 12px;
+  letter-spacing: 6px;
   color: var(--neon-pink);
   text-shadow: var(--glow-pink);
-  margin-bottom: 8px;
+}
+
+.heroDivider {
+  font-size: 2.5rem;
+  color: var(--neon-purple);
+  opacity: 0.5;
+  text-shadow: var(--glow-purple);
+  font-weight: 400;
+  letter-spacing: -2px;
 }
 
 .heroMain {
-  display: block;
+  letter-spacing: 6px;
   background: linear-gradient(135deg, var(--neon-cyan), var(--neon-purple));
   -webkit-background-clip: text;
   background-clip: text;
@@ -329,7 +339,12 @@
 
 @media (max-width: 768px) {
   .heroTitle {
-    font-size: 2.5rem;
+    font-size: 2.2rem;
+    gap: 10px;
+  }
+
+  .heroDivider {
+    font-size: 1.6rem;
   }
 
   .stats {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -27,6 +27,7 @@ export default function HomePage() {
         <div className={styles.heroGrid} />
         <h1 className={styles.heroTitle}>
           <span className={styles.heroAccent}>DECISION</span>
+          <span className={styles.heroDivider}>//</span>
           <span className={styles.heroMain}>HUB</span>
         </h1>
         <p className={styles.heroSub}>
@@ -83,7 +84,7 @@ export default function HomePage() {
       <section className={styles.cliSection}>
         <h2 className={styles.sectionTitle}>
           <Bot size={20} />
-          Agent First
+          Agentic First
         </h2>
         <AnimatedTerminal />
       </section>


### PR DESCRIPTION
## What changed
Updated the hero title layout to use flexbox with a centered divider element between "DECISION" and "HUB", and changed "Agent First" to "Agentic First" in the CLI section heading.

## Why
Improves visual hierarchy and design of the hero section by introducing a stylized divider (`//`) between the two parts of the title. Also corrects the terminology in the section heading to be more accurate.

## How to test
1. Run `make test` to ensure all tests pass
2. Verify the hero title displays "DECISION // HUB" with proper spacing and styling on desktop and mobile views
3. Check that the CLI section heading now reads "Agentic First"
4. Confirm responsive behavior at 768px breakpoint shows appropriate font sizes and gaps

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01KdZPdutMiNxvrNVVkrP4Bh