### PR TITLE
Separate orgs from personal publishers in homepage stats

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Package, Building2, Shield, Zap, ArrowRight, Download, Star, Bot, Terminal } from "lucide-react";
+import { Package, Building2, Users, Zap, ArrowRight, Download, Star, Bot, Terminal } from "lucide-react";
 import { getRegistryStats, listSkillsFiltered } from "../api/client";
 import { useApi } from "../hooks/useApi";
 import { useCountUp } from "../hooks/useCountUp";
@@ -19,10 +19,12 @@ export default function HomePage() {
   const topSkills = latestSkills?.items ?? [];
   const totalSkills = stats?.total_skills ?? 0;
   const totalOrgs = stats?.total_orgs ?? 0;
+  const totalPublishers = stats?.total_publishers ?? 0;
   const totalDownloads = stats?.total_downloads ?? 0;
 
   const [animatedSkills, skillsRef] = useCountUp(totalSkills);
   const [animatedOrgs, orgsRef] = useCountUp(totalOrgs);
+  const [animatedPublishers, publishersRef] = useCountUp(totalPublishers);
   const [animatedDownloads, downloadsRef] = useCountUp(totalDownloads);
 
   return (
@@ -77,10 +79,10 @@ export default function HomePage() {
           </div>
         </NeonCard>
         <NeonCard glow="green">
-          <div className={styles.statItem}>
-            <Shield size={24} className={styles.statIcon} />
-            <span className={styles.statNumber}>A-F</span>
-            <span className={styles.statLabel}>Safety Grading</span>
+          <div className={styles.statItem} ref={publishersRef as React.RefObject<HTMLDivElement>}>
+            <Users size={24} className={styles.statIcon} />
+            <span className={styles.statNumber}>{animatedPublishers.toLocaleString()}</span>
+            <span className={styles.statLabel}>Publishers</span>
           </div>
         </NeonCard>
       </section>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -94,6 +94,7 @@ export interface TaxonomyResponse {
 export interface RegistryStats {
   total_skills: number;
   total_orgs: number;
+  total_publishers: number;
   total_downloads: number;
   active_categories: string[];
 }

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1722,7 +1722,20 @@ def fetch_registry_stats(conn: Connection) -> dict:
     stmt = (
         sa.select(
             sa.func.count(sa.distinct(skills_table.c.id)).label("total_skills"),
-            sa.func.count(sa.distinct(organizations_table.c.slug)).label("total_orgs"),
+            sa.func.count(
+                sa.distinct(
+                    sa.case(
+                        (organizations_table.c.is_personal == sa.false(), organizations_table.c.slug),
+                    )
+                )
+            ).label("total_orgs"),
+            sa.func.count(
+                sa.distinct(
+                    sa.case(
+                        (organizations_table.c.is_personal == sa.true(), organizations_table.c.slug),
+                    )
+                )
+            ).label("total_publishers"),
             sa.func.coalesce(sa.func.sum(skills_table.c.download_count), 0).label("total_downloads"),
         )
         .select_from(
@@ -1759,6 +1772,7 @@ def fetch_registry_stats(conn: Connection) -> dict:
     return {
         "total_skills": row.total_skills,
         "total_orgs": row.total_orgs,
+        "total_publishers": row.total_publishers,
         "total_downloads": row.total_downloads,
         "active_categories": active_categories,
     }


### PR DESCRIPTION
## Summary
- Split `total_orgs` in `fetch_registry_stats()` into real organizations (`is_personal=false`) and individual publishers (`is_personal=true`) using conditional `COUNT(DISTINCT CASE WHEN ...)` 
- Added `total_publishers` to the API response and `RegistryStats` TypeScript type
- Replaced the static "A-F Safety Grading" card on the homepage with a dynamic animated "Publishers" count using the `Users` icon

## Test plan
- [x] `make test-server` — 498 passed
- [x] `make lint` — all checks passed
- [x] `make typecheck` — no issues
- [x] `npx tsc -b` — frontend types pass
- [ ] Deploy to dev and verify homepage shows separate org/publisher counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)