### PR TITLE
Remove AWS unset workaround from backfill target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ publish-cli: ## Publish CLI to PyPI (BUMP=patch|minor|major, BREAKING=1 to sync 
 # ---------------------------------------------------------------------------
 
 backfill: ## Run all backfills: categories, embeddings, org metadata (needs DHUB_ENV)
-	cd server && unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE && \
-		DHUB_ENV=$(or $(DHUB_ENV),dev) uv run --package decision-hub-server \
+	cd server && DHUB_ENV=$(or $(DHUB_ENV),dev) uv run --package decision-hub-server \
 		python scripts/backfill_categories.py
 	cd server && DHUB_ENV=$(or $(DHUB_ENV),dev) uv run --package decision-hub-server \
 		python -m decision_hub.scripts.backfill_embeddings


### PR DESCRIPTION
## Summary
- Removes the `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE` workaround from the `make backfill` target
- Root cause was a stray `export AWS_SECRET_ACCESS_KEY` in `.zshrc` (without a matching `AWS_ACCESS_KEY_ID`) that caused pydantic-settings to mix credentials from env vars and `.env.prod` — resulting in `SignatureDoesNotMatch`
- The shell profile has been fixed, so the workaround is no longer needed

## Test plan
- [ ] Run `make backfill` against dev and verify it completes without S3 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)