### PR TITLE
Add --org flag to override namespace during publish

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -123,6 +123,7 @@ def _publish_skill_directory(
 def publish_command(
     source: str = typer.Argument(..., help="Path to a directory containing skills, or a git repo URL"),
     version: str = typer.Option(None, "--version", help="Explicit semver version (overrides auto-bump)"),
+    org: str = typer.Option(None, "--org", "-o", help="Override the default namespace (org slug)"),
     patch: bool = typer.Option(False, "--patch", help="Bump patch version"),
     minor: bool = typer.Option(False, "--minor", help="Bump minor version"),
     major: bool = typer.Option(False, "--major", help="Bump major version"),
@@ -142,6 +143,9 @@ def publish_command(
     Version is auto-bumped by default (patch). Use --major or --minor to
     control the bump level, or --version to set an explicit version.
 
+    Use --org to override the default namespace. You can also specify the
+    org inline: dhub publish org/skill-name .
+
     When publishing from a GitHub URL, a tracker is automatically created
     so future commits are republished. Use --no-track to skip, or --track
     to re-enable a previously disabled tracker.
@@ -157,7 +161,9 @@ def publish_command(
 
     # Detect git URL in the first positional arg
     if looks_like_git_url(source):
-        _publish_from_git_repo(source, ref, version, bump_level, private=private, no_track=no_track, track=track)
+        _publish_from_git_repo(
+            source, ref, version, bump_level, private=private, no_track=no_track, track=track, org_override=org
+        )
         return
 
     if ref is not None:
@@ -167,7 +173,7 @@ def publish_command(
         console.print("[red]Error: --track can only be used with a git repository URL.[/]")
         raise typer.Exit(1)
 
-    _publish_from_directory(Path(source), version, bump_level, private=private)
+    _publish_from_directory(Path(source), version, bump_level, private=private, org_override=org)
 
 
 def _publish_discovered_skills(
@@ -232,6 +238,7 @@ def _publish_from_directory(
     bump_level: str,
     *,
     private: bool = False,
+    org_override: str | None = None,
 ) -> None:
     """Discover and publish all skills under a local directory."""
     from dhub.cli.config import get_api_url, get_token
@@ -249,7 +256,12 @@ def _publish_from_directory(
 
     api_url = get_api_url()
     token = get_token()
-    org = _auto_detect_org(api_url, token)
+
+    if org_override:
+        console.print(f"Using namespace: [cyan]{org_override}[/]")
+        org = org_override
+    else:
+        org = _auto_detect_org(api_url, token)
 
     _publish_discovered_skills(skill_dirs, path, org, version, bump_level, api_url, token, private=private)
 
@@ -263,6 +275,7 @@ def _publish_from_git_repo(
     private: bool = False,
     no_track: bool = False,
     track: bool = False,
+    org_override: str | None = None,
 ) -> None:
     """Clone a git repo, discover skills, and publish each one."""
     from dhub.cli.config import build_headers, get_api_url, get_token
@@ -270,7 +283,12 @@ def _publish_from_git_repo(
 
     api_url = get_api_url()
     token = get_token()
-    org = _auto_detect_org(api_url, token)
+
+    if org_override:
+        console.print(f"Using namespace: [cyan]{org_override}[/]")
+        org = org_override
+    else:
+        org = _auto_detect_org(api_url, token)
 
     with console.status(f"Cloning {repo_url}..."):
         try:
@@ -416,7 +434,7 @@ def _auto_detect_org(api_url: str, token: str) -> str:
             f"[red]Error: You have multiple namespaces ({slugs}). "
             f"Run 'dhub config default-org' to set a default, "
             f"or set DHUB_DEFAULT_ORG, "
-            f"or specify: dhub publish <org>/<skill>[/]"
+            f"or use --org to specify the namespace.[/]"
         )
         raise typer.Exit(1)
 
@@ -439,7 +457,7 @@ def _auto_detect_org(api_url: str, token: str) -> str:
             f"[red]Error: You have multiple namespaces ({slugs}). "
             f"Run 'dhub config default-org' to set a default, "
             f"or set DHUB_DEFAULT_ORG, "
-            f"or specify: dhub publish <org>/<skill>[/]"
+            f"or use --org to specify the namespace.[/]"
         )
         raise typer.Exit(1)
 

--- a/client/tests/test_cli/test_publish_repo_cli.py
+++ b/client/tests/test_cli/test_publish_repo_cli.py
@@ -297,3 +297,33 @@ class TestPublishFromGitRepo:
 
         assert result.exit_code == 0
         mock_clone.assert_called_once_with("git@github.com:example/repo.git", ref=None)
+
+    @respx.mock
+    @patch("dhub.core.git_repo.clone_repo")
+    @patch("dhub.cli.config.get_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_publish_git_with_org_flag(
+        self,
+        _mock_url,
+        _mock_token,
+        mock_clone,
+        tmp_path: Path,
+    ) -> None:
+        """--org overrides auto-detection when publishing from a git repo."""
+        repo_root = tmp_path / "repo"
+        _write_skill_md(repo_root / "my-skill", name="my-skill")
+        mock_clone.return_value = repo_root
+
+        respx.get("http://test:8000/v1/skills/custom-org/my-skill/latest-version").mock(
+            return_value=httpx.Response(404)
+        )
+        respx.post("http://test:8000/v1/publish").mock(return_value=httpx.Response(200, json={"eval_status": "A"}))
+
+        result = runner.invoke(
+            app,
+            ["publish", "https://github.com/example/repo", "--org", "custom-org"],
+        )
+
+        assert result.exit_code == 0
+        assert "Using namespace: custom-org" in result.output
+        assert "1 published" in result.output

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -330,6 +330,60 @@ class TestPublishCommand:
         else:
             raise AssertionError("metadata field not found in request")
 
+    @respx.mock
+    @patch("dhub.cli.config.get_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_publish_with_org_flag_skips_auto_detect(
+        self,
+        _mock_url,
+        _mock_token,
+        tmp_path: Path,
+    ) -> None:
+        """--org overrides auto-detection and uses the specified org."""
+        _write_skill_md(tmp_path)
+        publish_route = respx.post("http://test:8000/v1/publish").mock(return_value=httpx.Response(200, json={}))
+
+        result = runner.invoke(
+            app,
+            ["publish", str(tmp_path), "--version", "1.0.0", "--org", "custom-org"],
+        )
+
+        assert result.exit_code == 0
+        assert "Using namespace: custom-org" in result.output
+        assert "Published: custom-org/test-skill@1.0.0" in result.output
+        # Verify the org in metadata
+        request = publish_route.calls[0].request
+        body = request.content.decode("utf-8", errors="replace")
+        for part in body.split("Content-Disposition"):
+            if 'name="metadata"' in part:
+                json_str = part.split("\r\n\r\n", 1)[1].split("\r\n--", 1)[0]
+                meta = json.loads(json_str)
+                assert meta["org_slug"] == "custom-org"
+                break
+        else:
+            raise AssertionError("metadata field not found in request")
+
+    @respx.mock
+    @patch("dhub.cli.config.get_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_publish_with_org_short_flag(
+        self,
+        _mock_url,
+        _mock_token,
+        tmp_path: Path,
+    ) -> None:
+        """Short -o flag works as an alias for --org."""
+        _write_skill_md(tmp_path)
+        respx.post("http://test:8000/v1/publish").mock(return_value=httpx.Response(200, json={}))
+
+        result = runner.invoke(
+            app,
+            ["publish", str(tmp_path), "--version", "1.0.0", "-o", "short-org"],
+        )
+
+        assert result.exit_code == 0
+        assert "Published: short-org/test-skill@1.0.0" in result.output
+
 
 # ---------------------------------------------------------------------------
 # install_command


### PR DESCRIPTION
## What changed
Added a new `--org` / `-o` command-line flag to the `publish` command that allows users to explicitly specify the organization namespace, overriding the auto-detection logic.

## Why
Users previously had to rely on auto-detection of their organization namespace or set a default via configuration. This flag provides a convenient way to publish to a specific organization without changing global settings, improving flexibility for users with multiple namespaces.

## How to test
Run the existing test suite:
```bash
make test
```

The following new tests verify the functionality:
- `test_publish_with_org_flag_skips_auto_detect`: Verifies `--org` overrides auto-detection for directory-based publishing
- `test_publish_with_org_short_flag`: Verifies the `-o` short flag alias works
- `test_publish_git_with_org_flag`: Verifies `--org` works when publishing from a git repository

## Checklist
- [x] Tests pass (3 new tests added covering the feature)
- [x] No breaking API changes (flag is optional, backward compatible)
- [x] Database migration not needed (CLI-only change)

https://claude.ai/code/session_01Vm7iC9UetDCad4EXPM1Etn