### PR TITLE
Catch BaseException instead of Exception in crawler error handling

### DIFF
--- a/server/src/decision_hub/scripts/crawler/__main__.py
+++ b/server/src/decision_hub/scripts/crawler/__main__.py
@@ -299,7 +299,7 @@ def run_processing_phase(
                 return_exceptions=True,
                 wrap_returned_exceptions=False,
             ):
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
                     stats.errors.append(str(result)[:500])
                     repo_name = "unknown"
                     commit_sha = None


### PR DESCRIPTION
## What changed
Changed the exception type check in the crawler's processing phase from `Exception` to `BaseException` to catch a broader range of exceptions including `KeyboardInterrupt`, `SystemExit`, and other non-`Exception` subclasses.

## Why
The current code only catches `Exception` subclasses, which means critical exceptions like `KeyboardInterrupt` and `SystemExit` would not be properly handled and logged in the error statistics. Using `BaseException` ensures all exception types are caught and recorded.

Closes #

## How to test
Existing error handling tests will continue to pass. The change is backward compatible and will now additionally catch system-level exceptions that were previously unhandled.

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01AXheG7AnJu2XUa6BVuGesh