### PR TITLE
Display skill categories on homepage and support multi-category filtering

### DIFF
--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -231,6 +231,19 @@
   letter-spacing: 0;
 }
 
+.skillCategory {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--neon-pink);
+  border-radius: 4px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--neon-pink);
+  width: fit-content;
+}
+
 .skillDesc {
   font-size: 0.85rem;
   color: var(--text-secondary);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { Package, Building2, Users, Zap, ArrowRight, Download, Star, Bot, Terminal } from "lucide-react";
+import { Package, Building2, Users, Zap, ArrowRight, Download, Star, Bot, Terminal, Tag } from "lucide-react";
 import { getRegistryStats, listSkillsFiltered } from "../api/client";
 import { useApi } from "../hooks/useApi";
 import { useCountUp } from "../hooks/useCountUp";
@@ -11,14 +11,26 @@ import AnimatedTerminal from "../components/AnimatedTerminal";
 import TerminalBlock from "../components/TerminalBlock";
 import styles from "./HomePage.module.css";
 
+const DATA_CATEGORIES = "Data & Database,Data Science & Statistics";
+const HOME_PAGE_SIZE = 6;
+
 export default function HomePage() {
   const { data: stats } = useApi(() => getRegistryStats(), []);
-  const { data: latestSkills } = useApi(
-    () => listSkillsFiltered({ page: 1, pageSize: 6, sort: "updated" }),
+  const { data: categorySkills } = useApi(
+    () => listSkillsFiltered({ page: 1, pageSize: HOME_PAGE_SIZE, sort: "updated", category: DATA_CATEGORIES }),
+    []
+  );
+  const { data: allSkills } = useApi(
+    () => listSkillsFiltered({ page: 1, pageSize: HOME_PAGE_SIZE, sort: "updated" }),
     []
   );
 
-  const topSkills = latestSkills?.items ?? [];
+  // Prefer data/data-science skills; fall back to all skills if not enough
+  const topSkills = useMemo(() => {
+    const catItems = categorySkills?.items ?? [];
+    if (catItems.length >= HOME_PAGE_SIZE) return catItems;
+    return allSkills?.items ?? [];
+  }, [categorySkills, allSkills]);
   const totalSkills = stats?.total_skills ?? 0;
   const totalOrgs = stats?.total_orgs ?? 0;
   const totalPublishers = stats?.total_publishers ?? 0;
@@ -139,6 +151,12 @@ export default function HomePage() {
                       <GradeBadge grade={skill.safety_rating} size="sm" />
                     </div>
                     <h3 className={styles.skillName}>{skill.skill_name}</h3>
+                    {skill.category && (
+                      <div className={styles.skillCategory}>
+                        <Tag size={10} />
+                        {skill.category}
+                      </div>
+                    )}
                     <p className={styles.skillDesc}>{skill.description}</p>
                     <div className={styles.skillMeta}>
                       <span className={styles.skillVersion}>

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1450,7 +1450,11 @@ def _build_skills_filters(
     if org_slug:
         base = base.where(organizations_table.c.slug == org_slug)
     if category:
-        base = base.where(skills_table.c.category == category)
+        cats = [c.strip() for c in category.split(",") if c.strip()]
+        if len(cats) == 1:
+            base = base.where(skills_table.c.category == cats[0])
+        else:
+            base = base.where(skills_table.c.category.in_(cats))
     if grade:
         grade_statuses = {
             "A": ["A", "passed"],


### PR DESCRIPTION
## What changed
Updated the homepage to display skill categories with a styled badge, and enhanced the backend category filter to support comma-separated category values for multi-category queries.

## Why
This improves the homepage UX by showing users what category each skill belongs to, and enables filtering by multiple categories simultaneously (e.g., "Data & Database,Data Science & Statistics"). The homepage now prioritizes displaying data-related skills while falling back to all skills if insufficient data skills are available.

## How to test
1. Verify the homepage displays skill cards with category badges for skills that have categories
2. Test the API filter with comma-separated categories: `?category=Data%20%26%20Database,Data%20Science%20%26%20Statistics`
3. Confirm the homepage shows data/data-science skills when available, otherwise shows all skills
4. Verify category badges render with proper styling (pink border, monospace font)

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01TZG6aTnRC47hxoNB4wnaMJ