### PR TITLE
Block search engine indexing on dev site

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,14 +4,6 @@ import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.tsx";
 
-// Block search-engine indexing on non-prod builds (e.g. hub-dev.decision.ai)
-if (import.meta.env.VITE_ENV !== "prod") {
-  const meta = document.createElement("meta");
-  meta.name = "robots";
-  meta.content = "noindex, nofollow";
-  document.head.appendChild(meta);
-}
-
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,24 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 
+/** Inject <meta name="robots" content="noindex, nofollow"> into the static
+ *  HTML when building for a non-prod environment so crawlers that don't
+ *  execute JavaScript still see the directive. */
+function noindexPlugin(): Plugin {
+  return {
+    name: "noindex-non-prod",
+    transformIndexHtml(html) {
+      if (process.env.VITE_ENV === "prod") return html;
+      return html.replace(
+        "</head>",
+        '    <meta name="robots" content="noindex, nofollow" />\n  </head>',
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), noindexPlugin()],
   build: {
     rollupOptions: {
       output: {

--- a/server/src/decision_hub/api/seo_routes.py
+++ b/server/src/decision_hub/api/seo_routes.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from xml.sax.saxutils import escape
 
 import sqlalchemy as sa
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import Response
 from sqlalchemy.engine import Connection
 
@@ -84,8 +84,14 @@ def sitemap_xml(conn: Connection = Depends(get_connection)) -> Response:
     return Response(content=xml, media_type="application/xml")
 
 
+_PROD_HOSTS = {"hub.decision.ai", "decisionhub.dev"}
+
+
 @router.get("/robots.txt", include_in_schema=False)
-def robots_txt() -> Response:
-    """Serve robots.txt with sitemap reference."""
-    content = f"User-agent: *\nAllow: /\n\nSitemap: {_BASE_URL}/sitemap.xml\n"
+def robots_txt(request: Request) -> Response:
+    """Serve robots.txt — disallow everything on non-prod to prevent indexing."""
+    if request.url.hostname not in _PROD_HOSTS:
+        content = "User-agent: *\nDisallow: /\n"
+    else:
+        content = f"User-agent: *\nAllow: /\n\nSitemap: {_BASE_URL}/sitemap.xml\n"
     return Response(content=content, media_type="text/plain")


### PR DESCRIPTION
## Summary
- Make `robots.txt` hostname-aware: returns `Disallow: /` for non-prod hosts (`hub-dev.decision.ai`), `Allow: /` with sitemap for prod (`hub.decision.ai`, `decisionhub.dev`)
- Add Vite `transformIndexHtml` plugin to inject `<meta name="robots" content="noindex, nofollow">` into static HTML at build time for non-prod builds, so crawlers that don't execute JavaScript still see the directive
- Remove the now-redundant JS-based noindex injection from `main.tsx`

### Verified live
| Layer | Dev | Prod |
|---|---|---|
| `robots.txt` | `Disallow: /` | `Allow: /` + sitemap |
| Static HTML `noindex` | Present | Absent |

## Test plan
- [x] `make test-frontend` — 26 passed
- [x] `make test-server` — 578 passed (1 pre-existing failure in docx integration test)
- [x] `VITE_ENV=dev npm run build` → noindex tag present in `dist/index.html`
- [x] `VITE_ENV=prod npm run build` → noindex tag absent from `dist/index.html`
- [x] `curl https://hub-dev.decision.ai/robots.txt` → `Disallow: /`
- [x] `curl https://hub.decision.ai/robots.txt` → `Allow: /` with sitemap
- [x] Deployed and verified on both dev and prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)