### PR TITLE
Add LLM judge for credential entropy false positives

### DIFF
--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -117,6 +117,7 @@ def run_gauntlet_pipeline(
         allowed_tools=allowed_tools,
         analyze_prompt_fn=_build_analyze_prompt_fn(settings),
         review_body_fn=_build_review_body_fn(settings),
+        analyze_credential_fn=_build_analyze_credential_fn(settings),
     )
 
     check_results_dicts = [
@@ -260,6 +261,31 @@ def _build_review_body_fn(settings: Settings):
         )
 
     return review_body_fn
+
+
+def _build_analyze_credential_fn(settings: Settings):
+    """Build a Gemini credential entropy review callback if google_api_key is configured.
+
+    Returns None if no API key is set, which causes the credential check
+    to run in strict mode (entropy hits fail automatically).
+    """
+    if not settings.google_api_key:
+        return None
+
+    from decision_hub.infra.gemini import analyze_credential_entropy, create_gemini_client
+
+    gemini_client = create_gemini_client(settings.google_api_key)
+
+    def analyze_credential_fn(entropy_hits, skill_name, skill_description):
+        return analyze_credential_entropy(
+            gemini_client,
+            entropy_hits,
+            skill_name,
+            skill_description,
+            model=settings.gemini_model,
+        )
+
+    return analyze_credential_fn
 
 
 def classify_skill_category(

--- a/server/src/decision_hub/domain/gauntlet.py
+++ b/server/src/decision_hub/domain/gauntlet.py
@@ -105,6 +105,15 @@ _ENTROPY_ALLOWLIST_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+# Type alias for the credential LLM judge callback.
+# Accepts (hits, skill_name, skill_description) -> list[dict]
+# Each returned dict has 'source', 'label', 'line', 'dangerous' (bool), 'reason'.
+AnalyzeCredentialFn = Callable[
+    [list[dict], str, str],
+    list[dict],
+]
+
 # Permission categories that elevate a skill from A to B
 _ELEVATED_PERMISSION_PATTERNS: dict[str, list[str]] = {
     "shell": [
@@ -267,19 +276,22 @@ def _shannon_entropy(s: str) -> float:
 def _find_credential_hits(
     content: str,
     source_label: str,
-) -> list[dict]:
+) -> tuple[list[dict], list[dict]]:
     """Scan content for embedded credentials (known patterns + entropy).
 
-    Returns a list of dicts with keys 'source', 'label', 'line'.
+    Returns (known_hits, entropy_hits). Each hit is a dict with keys
+    'source', 'label', 'line'. Known-pattern hits always fail; entropy
+    hits are candidates for LLM review.
     """
-    hits: list[dict] = []
-    seen_lines: set[int] = set()  # track line numbers already flagged
+    known_hits: list[dict] = []
+    entropy_hits: list[dict] = []
+    seen_lines: set[int] = set()
 
     for lineno, line in enumerate(content.splitlines()):
         # Layer 1: known-format patterns (high confidence, specific label)
         for pattern, label in _CREDENTIAL_PATTERNS:
             if re.search(pattern, line):
-                hits.append(
+                known_hits.append(
                     {
                         "source": source_label,
                         "label": label,
@@ -299,7 +311,7 @@ def _find_credential_hits(
                 # Charset-aware threshold: hex has lower max entropy
                 threshold = _ENTROPY_THRESHOLD_HEX if _HEX_RE.match(value) else _ENTROPY_THRESHOLD_DEFAULT
                 if _shannon_entropy(value) >= threshold:
-                    hits.append(
+                    entropy_hits.append(
                         {
                             "source": source_label,
                             "label": "high-entropy secret",
@@ -309,42 +321,105 @@ def _find_credential_hits(
                     seen_lines.add(lineno)
                     break  # one hit per line is enough
 
-    return hits
+    return known_hits, entropy_hits
 
 
 def check_embedded_credentials(
     skill_md_content: str,
     source_files: list[tuple[str, str]],
+    skill_name: str = "",
+    skill_description: str = "",
+    analyze_credential_fn: AnalyzeCredentialFn | None = None,
 ) -> EvalResult:
     """Scan all skill content for embedded credentials.
 
     Two detection layers:
     1. Known-format patterns (AWS keys, GitHub tokens, private keys, etc.)
+       — always fail, no LLM override.
     2. Shannon entropy analysis on string literals (catches unknown formats)
-
-    This check always fails when credentials are found — there is no LLM
-    override because embedding real secrets in a skill is never legitimate.
+       — if an LLM judge is available, entropy hits are sent for review.
+         Without LLM, entropy hits fail automatically (strict mode).
     """
-    all_hits: list[dict] = []
+    all_known: list[dict] = []
+    all_entropy: list[dict] = []
 
-    all_hits.extend(_find_credential_hits(skill_md_content, "SKILL.md"))
+    known, entropy = _find_credential_hits(skill_md_content, "SKILL.md")
+    all_known.extend(known)
+    all_entropy.extend(entropy)
 
     for filename, content in source_files:
-        all_hits.extend(_find_credential_hits(content, filename))
+        known, entropy = _find_credential_hits(content, filename)
+        all_known.extend(known)
+        all_entropy.extend(entropy)
 
-    if not all_hits:
+    # Known-pattern hits always fail — no LLM override
+    if all_known:
+        findings = [f"{h['source']}: {h['label']}" for h in all_known]
+        return EvalResult(
+            check_name="embedded_credentials",
+            severity="fail",
+            message=f"Embedded credentials detected: {'; '.join(findings)}",
+            details={"hits": all_known},
+        )
+
+    if not all_entropy:
         return EvalResult(
             check_name="embedded_credentials",
             severity="pass",
             message="No embedded credentials detected",
         )
 
-    findings = [f"{h['source']}: {h['label']}" for h in all_hits]
+    # --- LLM judge available: let it review entropy hits ---
+    if analyze_credential_fn is not None:
+        judgments = analyze_credential_fn(all_entropy, skill_name, skill_description)
+
+        # Fail-closed: any source file not covered by the LLM is marked dangerous
+        covered_sources = {j.get("source") for j in judgments}
+        for h in all_entropy:
+            if h["source"] not in covered_sources:
+                judgments.append(
+                    {
+                        "source": h["source"],
+                        "label": h["label"],
+                        "line": h["line"],
+                        "dangerous": True,
+                        "reason": "LLM did not return judgment for this finding",
+                    }
+                )
+
+        dangerous = [j for j in judgments if j.get("dangerous", True)]
+        cleared = [j for j in judgments if not j.get("dangerous", True)]
+
+        if dangerous:
+            findings = [
+                f"{d.get('source', '?')}: {d.get('label', 'high-entropy secret')} ({d.get('reason', 'flagged')})"
+                for d in dangerous
+            ]
+            return EvalResult(
+                check_name="embedded_credentials",
+                severity="fail",
+                message=f"Embedded credentials confirmed: {'; '.join(findings)}",
+                details={"judgments": judgments},
+            )
+
+        cleared_summary = "; ".join(
+            f"{c.get('source', '?')}: {c.get('label', 'high-entropy secret')} (ok: {c.get('reason', 'not a secret')})"
+            for c in cleared
+        )
+        return EvalResult(
+            check_name="embedded_credentials",
+            severity="pass",
+            message=f"Entropy hits reviewed and cleared: {cleared_summary}",
+            details={"judgments": judgments},
+        )
+
+    # --- No LLM: strict mode, entropy hits fail automatically ---
+    findings = [f"{h['source']}: {h['label']}" for h in all_entropy]
     return EvalResult(
         check_name="embedded_credentials",
         severity="fail",
         message=f"Embedded credentials detected: {'; '.join(findings)}",
-        details={"hits": all_hits},
+        details={"hits": all_entropy},
     )
 
 
@@ -707,6 +782,7 @@ def run_static_checks(
     allowed_tools: str | None = None,
     analyze_prompt_fn: AnalyzePromptFn | None = None,
     review_body_fn: ReviewBodyFn | None = None,
+    analyze_credential_fn: AnalyzeCredentialFn | None = None,
 ) -> GauntletReport:
     """Run all static analysis checks and return a GauntletReport.
 
@@ -720,13 +796,22 @@ def run_static_checks(
         skill_md_body: The body (system prompt) section of SKILL.md.
         allowed_tools: The allowed_tools field from the manifest.
         analyze_prompt_fn: Optional LLM callback for prompt safety scan.
+        analyze_credential_fn: Optional LLM callback for entropy credential review.
     """
     results = [check_manifest_schema(skill_md_content)]
 
     if lockfile_content is not None:
         results.append(check_dependency_audit(lockfile_content))
 
-    results.append(check_embedded_credentials(skill_md_content, source_files))
+    results.append(
+        check_embedded_credentials(
+            skill_md_content,
+            source_files,
+            skill_name=skill_name,
+            skill_description=skill_description,
+            analyze_credential_fn=analyze_credential_fn,
+        )
+    )
 
     results.append(
         check_safety_scan(

--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -28,6 +28,14 @@ class PromptSafetyJudgment(BaseModel):
     reason: str
 
 
+class CredentialJudgment(BaseModel):
+    """Schema for a single credential entropy judgment from the LLM."""
+
+    source: str
+    dangerous: bool
+    reason: str
+
+
 def create_gemini_client(api_key: str) -> dict:
     """Create a Gemini client configuration.
 
@@ -449,6 +457,121 @@ def analyze_code_safety(
         {"file": s["file"], "label": s["label"], "dangerous": True, "reason": "Could not parse LLM response"}
         for s in source_snippets
     ]
+
+
+def analyze_credential_entropy(
+    client: dict,
+    entropy_hits: list[dict],
+    skill_name: str,
+    skill_description: str,
+    model: str = "gemini-2.0-flash",
+) -> list[dict]:
+    """Ask Gemini to judge whether high-entropy strings are real secrets.
+
+    The entropy scanner flags string literals with high Shannon entropy as
+    potential embedded credentials. Many are false positives: SQL queries,
+    f-string templates, emoji-rich text, ANSI color codes, etc. This function
+    sends the flagged strings to an LLM to distinguish real secrets from
+    legitimate code.
+
+    Args:
+        client: Gemini client config dict.
+        entropy_hits: List of dicts with keys 'source', 'label', 'line'.
+        skill_name: Name of the skill being scanned.
+        skill_description: What the skill says it does.
+        model: Gemini model to use.
+
+    Returns:
+        List of dicts with keys 'source', 'label', 'line',
+        'dangerous' (bool), 'reason' (str).
+    """
+    prompt = (
+        "You are a security reviewer for Decision Hub, a package registry for "
+        "AI agent skills. An entropy scanner flagged the following string "
+        "literals as potential embedded secrets/credentials. Your job is to "
+        "decide whether each flagged string is a REAL secret (API key, token, "
+        "password, private key material) or a FALSE POSITIVE.\n\n"
+        "Common false positives (mark dangerous=false):\n"
+        "- Template/f-strings with {variable} placeholders\n"
+        "- SQL queries (SELECT, INSERT, etc.)\n"
+        "- Formatted text with emoji, ANSI color codes, or Unicode box-drawing\n"
+        "- Shell commands or bash variables (${VAR})\n"
+        "- Human-readable sentences or documentation\n"
+        "- File paths, XML namespaces, or structured data formats\n\n"
+        "Real secrets (mark dangerous=true):\n"
+        "- API keys, tokens, passwords hardcoded as string literals\n"
+        "- Base64-encoded keys or hex secrets\n"
+        "- Private key material\n\n"
+        f"Skill name: {skill_name}\n"
+        f"Skill description: {skill_description}\n\n"
+        "Flagged strings:\n"
+    )
+
+    for i, h in enumerate(entropy_hits):
+        prompt += f"{i + 1}. Source: {h['source']}, Line: {h['line']}\n"
+
+    prompt += (
+        "\nFor each finding, respond with a JSON array. Each element must have:\n"
+        '  {"source": "<source file>", "dangerous": true/false, '
+        '"reason": "<brief explanation>"}\n\n'
+        "Respond ONLY with the JSON array, no other text."
+    )
+
+    url = f"{client['base_url']}/{model}:generateContent"
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.0},
+    }
+
+    with httpx.Client(timeout=30) as http_client:
+        resp = http_client.post(
+            url,
+            params={"key": client["api_key"]},
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    candidates = data.get("candidates", [])
+    if not candidates:
+        return [{**h, "dangerous": True, "reason": "LLM returned no response"} for h in entropy_hits]
+
+    text = candidates[0].get("content", {}).get("parts", [{}])[0].get("text", "")
+    text = _strip_markdown_fences(text)
+
+    try:
+        results = json.loads(text)
+        if isinstance(results, list):
+            validated: list[dict] = []
+            for item in results:
+                try:
+                    judgment = CredentialJudgment.model_validate(item)
+                    validated.append(judgment.model_dump())
+                except (ValidationError, AttributeError):
+                    source_val = item.get("source", "unknown") if isinstance(item, dict) else "unknown"
+                    validated.append(
+                        {
+                            "source": source_val,
+                            "dangerous": True,
+                            "reason": "LLM response item failed schema validation",
+                        }
+                    )
+            # Merge original hit data (label, line) into judgments
+            source_to_hits: dict[str, list[dict]] = {}
+            for h in entropy_hits:
+                source_to_hits.setdefault(h["source"], []).append(h)
+            for j in validated:
+                j.setdefault("label", "high-entropy secret")
+                if "line" not in j:
+                    hits_for_source = source_to_hits.get(j["source"], [])
+                    if hits_for_source:
+                        j["line"] = hits_for_source[0]["line"]
+            return validated
+    except json.JSONDecodeError:
+        pass
+
+    logger.warning("Could not parse Gemini credential entropy response for '{}'", skill_name)
+    return [{**h, "dangerous": True, "reason": "Could not parse LLM response"} for h in entropy_hits]
 
 
 def analyze_prompt_safety(

--- a/server/tests/test_domain/test_gauntlet.py
+++ b/server/tests/test_domain/test_gauntlet.py
@@ -278,6 +278,93 @@ class TestCheckEmbeddedCredentials:
         assert "SKILL.md" in result.message
 
 
+class TestCredentialLlmReview:
+    """Tests for LLM-based entropy hit review."""
+
+    def _make_entropy_hit_files(self):
+        """Create source files with high-entropy strings (false positives)."""
+        return [("ui.py", 'msg = "{Colors.YELLOW}Reddit{Colors.RESET} Found {count} threads"\n')]
+
+    def test_llm_clears_false_positives(self):
+        """LLM judge can clear entropy hits that are not real secrets."""
+        files = self._make_entropy_hit_files()
+
+        def approve_all(hits, name, desc):
+            return [{"source": h["source"], "dangerous": False, "reason": "template string"} for h in hits]
+
+        result = check_embedded_credentials(
+            "---\nname: x\ndescription: y\n---\n",
+            files,
+            skill_name="test",
+            skill_description="test skill",
+            analyze_credential_fn=approve_all,
+        )
+        assert result.passed is True
+        assert "reviewed and cleared" in result.message
+
+    def test_llm_confirms_real_secret(self):
+        """LLM judge can confirm an entropy hit is a real secret."""
+        secret = "aB3xK9mP2qR7wL5nJ8vT4cY6uF0"
+        files = [("config.py", f'key = "{secret}"\n')]
+
+        def flag_all(hits, name, desc):
+            return [{"source": h["source"], "dangerous": True, "reason": "looks like an API key"} for h in hits]
+
+        result = check_embedded_credentials(
+            "---\nname: x\ndescription: y\n---\n",
+            files,
+            skill_name="test",
+            skill_description="test skill",
+            analyze_credential_fn=flag_all,
+        )
+        assert result.passed is False
+        assert "confirmed" in result.message
+
+    def test_no_llm_strict_mode(self):
+        """Without LLM judge, entropy hits fail automatically."""
+        secret = "aB3xK9mP2qR7wL5nJ8vT4cY6uF0"
+        files = [("config.py", f'key = "{secret}"\n')]
+        result = check_embedded_credentials(
+            "---\nname: x\ndescription: y\n---\n",
+            files,
+        )
+        assert result.passed is False
+
+    def test_known_patterns_bypass_llm(self):
+        """Known credential patterns (AWS keys etc.) always fail, even with LLM."""
+        files = [("config.py", 'key = "AKIAIOSFODNN7EXAMPLE1"\n')]
+
+        def approve_all(hits, name, desc):
+            return [{"source": h["source"], "dangerous": False, "reason": "not a secret"} for h in hits]
+
+        result = check_embedded_credentials(
+            "---\nname: x\ndescription: y\n---\n",
+            files,
+            skill_name="test",
+            skill_description="test skill",
+            analyze_credential_fn=approve_all,
+        )
+        assert result.passed is False
+        assert "AWS" in result.message
+
+    def test_llm_fail_closed_on_missing_judgments(self):
+        """Entropy hits not covered by LLM response are marked dangerous."""
+        secret = "aB3xK9mP2qR7wL5nJ8vT4cY6uF0"
+        files = [("config.py", f'key = "{secret}"\n')]
+
+        def return_empty(hits, name, desc):
+            return []
+
+        result = check_embedded_credentials(
+            "---\nname: x\ndescription: y\n---\n",
+            files,
+            skill_name="test",
+            skill_description="test skill",
+            analyze_credential_fn=return_empty,
+        )
+        assert result.passed is False
+
+
 class TestCheckPromptSafety:
     """Tests for prompt injection scanning."""
 


### PR DESCRIPTION
## Summary
- The entropy scanner flags high-Shannon-entropy string literals as potential embedded secrets, but generates many false positives (SQL queries, f-string templates, emoji text, ANSI color codes, XML namespaces)
- Follows the same two-stage pattern as `safety_scan`: regex pre-filter finds candidates, then an LLM judge (Gemini) reviews entropy hits to separate real secrets from legitimate code
- Known-pattern hits (AWS keys, GitHub tokens, private keys, etc.) still always fail with no LLM override — only entropy-based hits go through LLM review

## Test plan
- [x] All 100 gauntlet unit tests pass (5 new tests for LLM review behavior)
- [x] Full server test suite: 582 passed (1 pre-existing failure in docx integration test — will be fixed by this PR once deployed)
- [x] Lint + typecheck clean
- [ ] Deploy to dev and verify last30days skill passes gauntlet
- [ ] Verify real secrets (AWS keys, high-entropy API keys) still fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)