### PR TITLE
Fix card layout alignment and height consistency

### DIFF
--- a/frontend/src/components/NeonCard.module.css
+++ b/frontend/src/components/NeonCard.module.css
@@ -6,6 +6,9 @@
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .card::before {

--- a/frontend/src/pages/HomePage.module.css
+++ b/frontend/src/pages/HomePage.module.css
@@ -249,12 +249,14 @@
   text-decoration: none !important;
   color: inherit !important;
   text-shadow: none !important;
+  display: flex;
 }
 
 .skillCard {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
 }
 
 .skillHeader {
@@ -298,6 +300,8 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex: 1;
+  min-height: 3em;
 }
 
 .skillMeta {

--- a/frontend/src/pages/OrgDetailPage.module.css
+++ b/frontend/src/pages/OrgDetailPage.module.css
@@ -105,12 +105,14 @@
   text-decoration: none !important;
   color: inherit !important;
   text-shadow: none !important;
+  display: flex;
 }
 
 .card {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
 }
 
 .cardTop {
@@ -134,6 +136,8 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex: 1;
+  min-height: 3em;
 }
 
 .cardFooter {

--- a/frontend/src/pages/SkillsPage.module.css
+++ b/frontend/src/pages/SkillsPage.module.css
@@ -100,6 +100,7 @@
   text-decoration: none !important;
   color: inherit !important;
   text-shadow: none !important;
+  display: flex;
 }
 
 .card {
@@ -107,6 +108,7 @@
   flex-direction: column;
   gap: 8px;
   min-height: 140px;
+  flex: 1;
 }
 
 .cardTop {
@@ -141,6 +143,7 @@
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  min-height: 4.5em;
 }
 
 .cardFooter {


### PR DESCRIPTION
## What changed
Updated flexbox styling across card components to ensure consistent height and proper alignment. Added `display: flex` to card link wrappers, `flex: 1` to card containers, and minimum height constraints to description text elements.

## Why
Card layouts were not properly aligned vertically, causing inconsistent heights and misaligned content across different pages. These flexbox adjustments ensure cards stretch to fill available space and descriptions maintain consistent minimum heights for better visual uniformity.

## How to test
1. Navigate to HomePage, OrgDetailPage, and SkillsPage
2. Verify that all cards display with consistent heights
3. Confirm that card content (titles, descriptions, metadata) is properly aligned
4. Check that cards stretch to fill their container width appropriately

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01QGEwh9Ws7t5U475ajqdt1F