### PR TITLE
Reorganize docs and update GitHub org references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <p align="center">
-  <img src="assets/banner.png" alt="Decision Hub — The AI Skill Manager for Data Science Agents" width="100%">
+  <img src="assets/banner.png" alt="Decision Hub — The AI Skill Manager" width="100%">
 </p>
 
-**Decision Hub** is a CLI-first registry for publishing, discovering, and installing *Skills* — modular packages of code and prompts that AI coding agents (Claude, Cursor, Codex, Gemini, OpenCode) can use. Publish a skill once, install it into any supported agent with one command.
+**Decision Hub** is a registry for publishing, discovering, and installing *Skills* — modular packages of code and prompts that AI coding agents (Claude, Cursor, Codex, Gemini, OpenCode) can use. Publish a skill once, install it into any supported agent with one command.
+
+**Browse the registry at [hub.decision.ai](https://hub.decision.ai)** or use the CLI below.
 
 ## Installation
 
@@ -37,7 +39,7 @@ dhub publish ./my-skill
 
 **Publish from anywhere.** Point `dhub publish` at a local directory or a GitHub repo URL and every `SKILL.md` inside is discovered, versioned, and published automatically.
 
-**Private skills for your team.** Skills scoped to your GitHub organization are only visible to members — proprietary tooling stays internal while using the same registry workflow.
+**Private skills for your team.** Publish with `--private` to scope skills to your GitHub organization. Grant cross-org access selectively with `dhub access grant`. Proprietary tooling stays internal while using the same registry workflow.
 
 **Install once, use everywhere.** A single `dhub install` downloads a skill and symlinks it into every detected agent's skill directory. No duplication, no per-agent setup.
 
@@ -46,6 +48,8 @@ dhub publish ./my-skill
 **Automated evals.** Skills ship with eval cases that run on publish — each executes in an isolated sandbox, an LLM judge scores the output, and results are published as a report.
 
 **Zero-config namespaces.** Your GitHub username and org memberships become publishing namespaces on login. No accounts to create, no orgs to manage.
+
+**Auto-tracking.** Publish from a GitHub URL and a tracker automatically republishes skills on future commits. No CI setup required.
 
 ## SKILL.md Format
 
@@ -80,32 +84,27 @@ Eval cases live in `evals/*.yaml` files inside the skill directory and are inclu
 
 ## CLI Reference
 
-### Authentication
+Run `dhub <command> --help` for full usage of any command.
+
+### Core Commands
 
 | Command | Description |
 |---------|-------------|
 | `dhub login` | Authenticate via GitHub Device Flow |
 | `dhub logout` | Remove stored token |
 | `dhub env` | Show active environment, config path, and API URL |
+| `dhub upgrade` | Upgrade the CLI to the latest version |
 
-### Publishing
+### Publishing & Versioning
 
 ```bash
-# Publish all skills found under a directory
-# Org is auto-detected from login; skill name comes from SKILL.md
-dhub publish ./path/to/skills
-
-# Publish from a GitHub repo URL
-dhub publish https://github.com/org/repo
-
-# Version control (default: auto-bump patch from 0.1.0)
-dhub publish ./my-skill --patch          # 1.2.3 → 1.2.4 (default)
-dhub publish ./my-skill --minor          # 1.2.3 → 1.3.0
-dhub publish ./my-skill --major          # 1.2.3 → 2.0.0
-dhub publish ./my-skill --version 2.0.0  # explicit version
-
-# Publish a specific branch/tag from a git repo
-dhub publish https://github.com/org/repo --ref v1.0
+dhub publish ./path/to/skills                        # from a local directory
+dhub publish https://github.com/org/repo             # from a GitHub URL (auto-tracks)
+dhub publish https://github.com/org/repo --ref v1.0  # specific branch/tag
+dhub publish ./my-skill --minor                      # version bump: --patch (default) | --minor | --major
+dhub publish ./my-skill --version 2.0.0              # explicit version
+dhub publish ./my-skill --private                    # org-private visibility
+dhub publish https://github.com/org/repo --no-track  # skip auto-tracking
 ```
 
 ### Installing & Running
@@ -123,10 +122,11 @@ dhub publish https://github.com/org/repo --ref v1.0
 
 | Command | Description |
 |---------|-------------|
-| `dhub list` | List all published skills (sorted by downloads) |
+| `dhub list` | List all published skills |
 | `dhub list --org ORG` | Filter by organization |
-| `dhub list --skill NAME` | Filter by skill name (substring match) |
-| `dhub ask "QUERY"` | Search for skills using natural language |
+| `dhub list --skill NAME` | Filter by skill name |
+| `dhub ask "QUERY"` | Natural language search |
+| `dhub ask "QUERY" --category "Backend & APIs"` | Search within a category |
 | `dhub init [PATH]` | Scaffold a new skill project |
 
 ### Evals
@@ -136,27 +136,9 @@ dhub publish https://github.com/org/repo --ref v1.0
 | `dhub eval-report ORG/SKILL@VERSION` | View the evaluation report for a version |
 | `dhub logs` | List recent eval runs |
 | `dhub logs ORG/SKILL [--follow]` | Tail eval logs for the latest version |
-| `dhub logs ORG/SKILL@VERSION --follow` | Tail eval logs for a specific version |
 | `dhub logs RUN_ID --follow` | Tail a specific eval run by ID |
 
-### Auto-Tracking
-
-When you publish from a GitHub URL, a tracker is automatically created to republish skills on future commits:
-
-```bash
-# Publish + auto-track (default)
-dhub publish https://github.com/org/skills-repo
-
-# Publish without tracking
-dhub publish https://github.com/org/repo --no-track
-
-# Re-enable tracking on a previously paused tracker
-dhub publish https://github.com/org/repo --track
-```
-
-**Private repos:** Tracker polling uses a system-level GitHub token. Private repos will only sync if the system token has access. Public repos work without any additional configuration.
-
-### Organizations & Config
+### Organizations, Keys & Config
 
 | Command | Description |
 |---------|-------------|
@@ -165,6 +147,19 @@ dhub publish https://github.com/org/repo --track
 | `dhub keys add KEY_NAME` | Add an API key (prompts for value securely) |
 | `dhub keys list` | List stored API key names |
 | `dhub keys remove KEY_NAME` | Remove a stored API key |
+
+### Private Skills & Access
+
+| Command | Description |
+|---------|-------------|
+| `dhub publish ./skill --private` | Publish as org-private |
+| `dhub visibility ORG/SKILL public` | Change visibility to public |
+| `dhub visibility ORG/SKILL org` | Change visibility to org-only |
+| `dhub access grant ORG/SKILL OTHER_ORG` | Grant another org access to a private skill |
+| `dhub access revoke ORG/SKILL OTHER_ORG` | Revoke access |
+| `dhub access list ORG/SKILL` | List access grants |
+| `dhub delete ORG/SKILL` | Delete all versions of a skill |
+| `dhub delete ORG/SKILL -v VERSION` | Delete a specific version |
 
 ## Supported Agents
 
@@ -211,53 +206,39 @@ This is a **uv workspace monorepo** with four components:
 
 | Component | Directory | Import path | Description |
 |-----------|-----------|-------------|-------------|
-| `dhub-cli` | `client/` | `dhub.*` | Open-source CLI (published to PyPI) |
-| `decision-hub-server` | `server/` | `decision_hub.*` | Backend API (deployed on Modal) |
-| `dhub-core` | `shared/` | `dhub_core.*` | Shared domain models and validation |
-| Frontend | `frontend/` | — | React + TypeScript web UI |
+| `dhub-cli` | `client/` | `dhub.*` | Open-source CLI, published to [PyPI](https://pypi.org/project/dhub-cli/) |
+| `decision-hub-server` | `server/` | `decision_hub.*` | Backend API, deployed on [Modal](https://modal.com/) |
+| `dhub-core` | `shared/` | `dhub_core.*` | Shared domain models and SKILL.md parsing |
+| Frontend | `frontend/` | — | React + TypeScript web UI at [hub.decision.ai](https://hub.decision.ai) |
 
-**Tech stack:** Python 3.11+ / Typer + Rich (CLI) / FastAPI (API) / PostgreSQL (database) / S3 (artifact storage) / Modal (sandboxed evals) / Gemini (natural language search)
+**Tech stack:** Python 3.11+ / Typer + Rich (CLI) / FastAPI (API) / PostgreSQL (database) / S3 (artifact storage) / Modal (compute & sandboxed evals) / Gemini (natural language search)
 
 ## Development
 
 ```bash
-# Install all dependencies
+# Install all workspace dependencies
 uv sync --all-packages --all-extras
 
-# Run tests
-make test              # all tests
-make test-client       # client only
-make test-server       # server only
-make test-frontend     # frontend only
+# Install pre-commit hooks (once after cloning)
+make install-hooks
+```
 
-# Lint and type check
-make lint              # ruff check + format
+The `Makefile` at the repo root has targets for all common operations — run `make help` to see them:
+
+```bash
+make test              # run all tests (client + server + frontend)
+make lint              # ruff check + format + frontend lint
 make typecheck         # mypy
 make fmt               # auto-fix + format
-
-# Start local dev server (must run from server/)
-cd server && DHUB_ENV=dev uv run --package decision-hub-server \
-  uvicorn decision_hub.api.app:create_app --factory --reload
 ```
 
 ### Configuration
 
-Copy `server/.env.example` to `server/.env.dev` and fill in your values. Schema changes are managed through SQL migration files in `server/migrations/` — see CLAUDE.md for details.
+Copy `server/.env.example` to `server/.env.dev` and fill in your values. The project has two independent stacks controlled by `DHUB_ENV` (`dev` | `prod`). The CLI defaults to `prod`; the server defaults to `dev` for safety.
 
-### Environments
+### Contributing
 
-The project has two independent stacks controlled by `DHUB_ENV` (`dev` | `prod`):
-
-| | Dev | Prod |
-|---|---|---|
-| `DHUB_ENV` | `dev` | `prod` (CLI default) |
-| Server env file | `server/.env.dev` | `server/.env.prod` |
-| CLI config | `~/.dhub/config.dev.json` | `~/.dhub/config.prod.json` |
-
-```bash
-DHUB_ENV=dev dhub login    # dev token
-dhub login                 # prod token (default)
-```
+See [`CLAUDE.md`](CLAUDE.md) for detailed development guidelines including: coding standards, database migration rules, deployment procedures, environment setup, and CI workflows.
 
 ## License
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,8 @@
-# dhub-cli: The AI Skill Manager for Data Science Agents
+# dhub-cli: The AI Skill Manager
 
-**Decision Hub** is a CLI-first registry for publishing, discovering, and installing *Skills* — modular packages of code and prompts that AI coding agents (Claude, Cursor, Codex, Gemini, OpenCode) can use.
+**Decision Hub** is a registry for publishing, discovering, and installing *Skills* — modular packages of code and prompts that AI coding agents (Claude, Cursor, Codex, Gemini, OpenCode) can use.
+
+**Browse the registry at [hub.decision.ai](https://hub.decision.ai)** or use the CLI below.
 
 ## Why Decision Hub?
 
@@ -54,9 +56,10 @@ Skills are installed as symlinks into each agent's skill directory, making them 
 
 - **Claude:** `~/.claude/skills`
 - **Cursor:** `~/.cursor/skills`
+- **Codex:** `~/.codex/skills`
 - **Gemini:** `~/.gemini/skills`
 - **OpenCode:** `~/.config/opencode/skills`
 
 ## Documentation
 
-For full documentation on creating skills, the `SKILL.md` format, and running your own registry server, see the [main repository](https://github.com/lfiaschi/decision-hub).
+For full documentation on creating skills, the `SKILL.md` format, and running your own registry server, see the [main repository](https://github.com/pymc-labs/decision-hub).

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -43,9 +43,9 @@ build-backend = "hatchling.build"
 packages = ["src/dhub"]
 
 [project.urls]
-Homepage = "https://github.com/lfiaschi/decision-hub"
-Repository = "https://github.com/lfiaschi/decision-hub"
-Issues = "https://github.com/lfiaschi/decision-hub/issues"
+Homepage = "https://github.com/pymc-labs/decision-hub"
+Repository = "https://github.com/pymc-labs/decision-hub"
+Issues = "https://github.com/pymc-labs/decision-hub/issues"
 
 [tool.uv.sources]
 dhub-core = { workspace = true }


### PR DESCRIPTION
## What changed
Updated README documentation structure, reorganized CLI reference sections, and changed GitHub organization references from `lfiaschi` to `pymc-labs` across the project.

## Why
- Clarify that Decision Hub is a registry (not exclusively CLI-first) with a web interface at hub.decision.ai
- Reorganize CLI commands into logical groupings (Core, Publishing & Versioning, Installing & Running, Discovery, Evals, Organizations & Config, Private Skills & Access)
- Consolidate auto-tracking documentation into the publishing section rather than as a separate section
- Update all GitHub URLs to reflect the correct organization ownership
- Improve discoverability by highlighting the web registry upfront

## How to test
- Verify all GitHub URLs in README and client/pyproject.toml point to `pymc-labs/decision-hub`
- Confirm CLI reference sections are logically organized and all commands are documented
- Check that the web registry URL (hub.decision.ai) is prominently mentioned

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01MJ2e3NkX7rJxis3pkLDFsx