### PR TITLE
Move featured orgs logic from frontend constants to API

### DIFF
--- a/frontend/src/constants/featuredOrgs.ts
+++ b/frontend/src/constants/featuredOrgs.ts
@@ -1,9 +1,0 @@
-export const FEATURED_ORGS = [
-  "pymc-labs",
-  "anthropics",
-  "openai",
-  "getcursor",
-  "google-deepmind",
-];
-
-export const FEATURED_SET = new Set(FEATURED_ORGS);

--- a/frontend/src/pages/OrgDetailPage.tsx
+++ b/frontend/src/pages/OrgDetailPage.tsx
@@ -9,7 +9,6 @@ import NeonCard from "../components/NeonCard";
 import GradeBadge from "../components/GradeBadge";
 import LoadingSpinner from "../components/LoadingSpinner";
 import OrgAvatar from "../components/OrgAvatar";
-import { FEATURED_SET } from "../constants/featuredOrgs";
 import styles from "./OrgDetailPage.module.css";
 
 const PAGE_SIZE = 24;
@@ -68,7 +67,7 @@ function OrgDetailPageInner({ orgSlug }: { orgSlug: string }) {
         <div>
           <div className={styles.titleRow}>
             <h1 className={styles.title}>{orgSlug}</h1>
-            {FEATURED_SET.has(orgSlug) && (
+            {profile?.is_featured && (
               <span className={styles.featuredBadge}>
                 <Star size={12} />
                 Featured

--- a/frontend/src/pages/OrgsPage.tsx
+++ b/frontend/src/pages/OrgsPage.tsx
@@ -8,7 +8,6 @@ import type { OrgStatsResponse } from "../types/api";
 import NeonCard from "../components/NeonCard";
 import OrgAvatar from "../components/OrgAvatar";
 import LoadingSpinner from "../components/LoadingSpinner";
-import { FEATURED_ORGS, FEATURED_SET } from "../constants/featuredOrgs";
 import styles from "./OrgsPage.module.css";
 
 type OrgType = "orgs" | "users" | "all";
@@ -52,13 +51,8 @@ export default function OrgsPage() {
   const orgs = useMemo(() => {
     const items = data?.items ?? [];
     return [...items].sort((a, b) => {
-      const aFeatured = FEATURED_SET.has(a.slug);
-      const bFeatured = FEATURED_SET.has(b.slug);
-      if (aFeatured && !bFeatured) return -1;
-      if (!aFeatured && bFeatured) return 1;
-      if (aFeatured && bFeatured) {
-        return FEATURED_ORGS.indexOf(a.slug) - FEATURED_ORGS.indexOf(b.slug);
-      }
+      if (a.is_featured && !b.is_featured) return -1;
+      if (!a.is_featured && b.is_featured) return 1;
       return 0;
     });
   }, [data]);
@@ -172,9 +166,9 @@ export default function OrgsPage() {
                 to={`/orgs/${org.slug}`}
                 className={styles.orgLink}
               >
-                <NeonCard glow={FEATURED_SET.has(org.slug) ? "purple" : "cyan"}>
+                <NeonCard glow={org.is_featured ? "purple" : "cyan"}>
                   <div className={styles.card}>
-                    {FEATURED_SET.has(org.slug) && (
+                    {org.is_featured && (
                       <div className={styles.featuredBadge}>
                         <Star size={12} />
                         Featured

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -37,6 +37,7 @@ export interface OrgSummary {
 export interface OrgProfile {
   slug: string;
   is_personal: boolean;
+  is_featured: boolean;
   avatar_url: string | null;
   description: string | null;
   blog: string | null;
@@ -117,6 +118,7 @@ export interface RegistryStats {
 export interface OrgStatsEntry {
   slug: string;
   is_personal: boolean;
+  is_featured: boolean;
   avatar_url: string | null;
   skill_count: number;
   total_downloads: number;

--- a/server/src/decision_hub/api/org_routes.py
+++ b/server/src/decision_hub/api/org_routes.py
@@ -21,6 +21,7 @@ from decision_hub.infra.database import (
     org_has_public_skills,
 )
 from decision_hub.models import User
+from decision_hub.scripts.crawler.discovery import TRUSTED_ORGS
 
 org_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
 org_public_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
@@ -58,6 +59,7 @@ class OrgProfile(BaseModel):
 
     slug: str
     is_personal: bool
+    is_featured: bool = False
     avatar_url: str | None = None
     description: str | None = None
     blog: str | None = None
@@ -137,6 +139,7 @@ class OrgStatsEntry(BaseModel):
 
     slug: str
     is_personal: bool
+    is_featured: bool = False
     avatar_url: str | None = None
     skill_count: int
     total_downloads: int
@@ -161,6 +164,7 @@ def get_org_stats(
         OrgStatsEntry(
             slug=row["slug"],
             is_personal=row["is_personal"],
+            is_featured=row["slug"].lower() in TRUSTED_ORGS,
             avatar_url=row["avatar_url"],
             skill_count=row["skill_count"],
             total_downloads=row["total_downloads"],
@@ -181,6 +185,7 @@ def list_org_profiles(
         OrgProfile(
             slug=o.slug,
             is_personal=o.is_personal,
+            is_featured=o.slug.lower() in TRUSTED_ORGS,
             avatar_url=o.avatar_url,
             description=o.description,
             blog=o.blog,
@@ -203,6 +208,7 @@ def get_org_profile(
     return OrgProfile(
         slug=org.slug,
         is_personal=org.is_personal,
+        is_featured=org.slug.lower() in TRUSTED_ORGS,
         avatar_url=org.avatar_url,
         description=org.description,
         blog=org.blog,


### PR DESCRIPTION
## What changed
Moved the featured organizations list from a hardcoded frontend constant to the backend API. The `is_featured` field is now computed server-side based on the `TRUSTED_ORGS` list and returned in API responses, eliminating the need for frontend-side featured org tracking.

## Why
Closes #(issue number)

This change centralizes featured organization management on the backend, making it easier to update the featured list without requiring frontend changes or deployments. It also ensures consistency across all clients consuming the API.

## How to test
1. Run `make test` to verify all tests pass
2. Verify that organizations in the `TRUSTED_ORGS` list display with the purple glow and featured badge on the orgs page
3. Verify that non-featured organizations display with the cyan glow
4. Check that the org detail page correctly shows the featured badge for featured organizations

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01GVre4B6rfHVddvMft6URY8