### PR TITLE
Add nightly cron to crawl trusted orgs

### DIFF
--- a/server/modal_app.py
+++ b/server/modal_app.py
@@ -179,6 +179,18 @@ def crawl_process_repo(
     settings = create_settings()
     setup_logging(settings.log_level)
 
+    # Mint a fresh token per container when none is supplied (nightly crawl path).
+    # This avoids passing a token minted in the orchestrator that may have aged
+    # significantly by the time this container is scheduled.
+    if github_token is None and settings.github_app_id:
+        from decision_hub.infra.github_app_token import mint_installation_token
+
+        github_token = mint_installation_token(
+            settings.github_app_id,
+            settings.github_app_private_key,
+            settings.github_app_installation_id,
+        )
+
     return process_repo_on_modal(repo_dict, bot_user_id, github_token, set_tracker=set_tracker)
 
 
@@ -202,9 +214,10 @@ def tracker_process_repo(
 def crawl_trusted_orgs_nightly() -> None:
     """Crawl all TRUSTED_ORGS for new SKILL.md files every night at 2am UTC.
 
-    Mints a short-lived GitHub App installation token so no PAT is required.
-    Discovers repos via search_trusted_orgs, then fans out processing to
-    crawl_process_repo containers — the same pipeline as the manual crawler.
+    Mints a short-lived GitHub App installation token for discovery; each
+    crawl_process_repo container mints its own fresh token to avoid expiry
+    during long fan-outs. Discovers repos via search_trusted_orgs, then fans
+    out processing — the same pipeline as the manual crawler.
     """
     import time
 
@@ -221,6 +234,7 @@ def crawl_trusted_orgs_nightly() -> None:
     settings = create_settings()
     setup_logging(settings.log_level)
 
+    # Token for the discovery phase only; worker containers mint their own.
     github_token = mint_installation_token(
         settings.github_app_id,
         settings.github_app_private_key,
@@ -238,8 +252,7 @@ def crawl_trusted_orgs_nightly() -> None:
     try:
         all_repos: list[DiscoveredRepo] = []
         for batch in search_trusted_orgs(gh, stats):
-            for repo in batch.values():
-                repo.is_trusted = True
+            # search_trusted_orgs already sets is_trusted=True on every repo it yields.
             all_repos.extend(batch.values())
     finally:
         gh.close()
@@ -252,29 +265,30 @@ def crawl_trusted_orgs_nightly() -> None:
     start = time.monotonic()
 
     repo_dicts = [repo_to_dict(r) for r in all_repos]
-    published = skipped = failed = quarantined = 0
+    published = skipped = repos_failed = skills_failed = quarantined = 0
     for result in crawl_process_repo.map(
         repo_dicts,
-        kwargs={"bot_user_id": bot_user_id, "github_token": github_token},
+        kwargs={"bot_user_id": bot_user_id},
         return_exceptions=True,
         wrap_returned_exceptions=False,
     ):
         if isinstance(result, BaseException):
-            failed += 1
+            repos_failed += 1
             logger.warning("crawl_trusted_orgs_nightly: repo error: {}", str(result)[:200])
         else:
             published += result.get("skills_published", 0)
             skipped += result.get("skills_skipped", 0)
-            failed += result.get("skills_failed", 0)
+            skills_failed += result.get("skills_failed", 0)
             quarantined += result.get("skills_quarantined", 0)
 
     elapsed = time.monotonic() - start
     logger.info(
-        "crawl_trusted_orgs_nightly done in {:.1f}s — pub:{} skip:{} fail:{} quar:{}",
+        "crawl_trusted_orgs_nightly done in {:.1f}s — pub:{} skip:{} repos_failed:{} skills_failed:{} quar:{}",
         elapsed,
         published,
         skipped,
-        failed,
+        repos_failed,
+        skills_failed,
         quarantined,
     )
 


### PR DESCRIPTION
Closes #161

## Summary

- Adds `crawl_trusted_orgs_nightly()` to `modal_app.py` — a Modal scheduled function running every night at **2am UTC**
- Mints a short-lived GitHub App installation token from existing secrets — no PAT needed
- Discovers repos via `search_trusted_orgs` (same as `--trusted-only` flag), fans out to `crawl_process_repo.map()`
- Logs a summary line with pub/skip/fail/quarantine counts

## Test plan

- [ ] Deploy to dev and verify the function appears in the Modal dashboard
- [ ] Trigger manually via `modal run` to confirm it discovers trusted org repos and publishes skills
- [ ] Confirm no PAT is needed (GitHub App token is minted from secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)