### PR TITLE
fix: pass deadline to tracker dispatch to prevent 600s timeout

### DIFF
--- a/server/modal_app.py
+++ b/server/modal_app.py
@@ -312,7 +312,7 @@ def check_trackers():
 
     from loguru import logger
 
-    from decision_hub.domain.tracker_service import check_all_due_trackers
+    from decision_hub.domain.tracker_service import DEADLINE_BUFFER_SECONDS, check_all_due_trackers
     from decision_hub.logging import setup_logging
     from decision_hub.settings import create_settings
 
@@ -332,7 +332,7 @@ def check_trackers():
     iterations = 0
 
     deadline = start + _TRACKER_LOOP_BUDGET_SECONDS
-    while time.monotonic() < deadline:
+    while time.monotonic() < deadline - DEADLINE_BUFFER_SECONDS:
         result = check_all_due_trackers(settings, deadline=deadline)
         total_checked += result.checked
         total_due += result.due

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -27,6 +27,11 @@ from decision_hub.domain.tracker import has_new_commits, parse_github_repo_url
 from decision_hub.models import SkillTracker, TrackerBatchResult
 from decision_hub.settings import Settings
 
+# How close to the deadline we stop accepting new work.  Used by both the
+# outer loop in modal_app.py (via check_all_due_trackers) and the dispatch
+# function to avoid overrunning the hard Modal timeout.
+DEADLINE_BUFFER_SECONDS = 30
+
 # ---------------------------------------------------------------------------
 # Serialization helpers for Modal transport
 # ---------------------------------------------------------------------------
@@ -297,8 +302,6 @@ def _dispatch_changed_trackers(
     """
     import time
 
-    _DEADLINE_BUFFER_SECONDS = 30
-
     processed = 0
     failed = 0
 
@@ -315,14 +318,9 @@ def _dispatch_changed_trackers(
             return_exceptions=True,
             order_outputs=False,
         ):
-            if deadline is not None and time.monotonic() > deadline - _DEADLINE_BUFFER_SECONDS:
-                logger.warning(
-                    "Deadline approaching, stopping fn.map consumption after {}/{} results",
-                    processed + failed,
-                    len(changed_trackers),
-                )
-                break
-
+            # Process the already-received result before checking the deadline —
+            # the for-loop already blocked to receive it, so discarding it would
+            # undercount processed/failed.
             if isinstance(batch_result, Exception):
                 logger.opt(exception=batch_result).error("Modal tracker_process_repo failed")
                 failed += 1
@@ -336,11 +334,19 @@ def _dispatch_changed_trackers(
                         batch_result.get("repo_url", "?"),
                         batch_result.get("error", "unknown"),
                     )
+
+            if deadline is not None and time.monotonic() > deadline - DEADLINE_BUFFER_SECONDS:
+                logger.warning(
+                    "Deadline approaching, stopping fn.map consumption after {}/{} results",
+                    processed + failed,
+                    len(changed_trackers),
+                )
+                break
     except Exception as modal_err:
         # Modal unavailable (local dev, import error, lookup failure) — fall back to sequential
         logger.info("Modal fan-out unavailable ({}), falling back to sequential processing", modal_err)
         for tracker, known_sha in changed_trackers:
-            if deadline is not None and time.monotonic() > deadline - _DEADLINE_BUFFER_SECONDS:
+            if deadline is not None and time.monotonic() > deadline - DEADLINE_BUFFER_SECONDS:
                 logger.warning("Deadline approaching, stopping sequential processing")
                 break
             try:


### PR DESCRIPTION
The check_trackers function has a 600s Modal timeout with a 480s loop budget, but the budget is only checked between iterations. A single iteration can block indefinitely inside fn.map() waiting for slow Modal containers (each with a 300s timeout).

Fix: pass a monotonic deadline from the loop into check_all_due_trackers and _dispatch_changed_trackers. The dispatch function now:

1. Uses order_outputs=False on fn.map to receive results as they complete (instead of waiting for all in order)
2. Breaks out of the fn.map consumption loop when within 30s of the deadline, allowing the orchestrator to exit cleanly
3. Applies the same deadline guard to the sequential fallback path

Unprocessed trackers are not lost — they will be picked up on the next tick since their next_check_at was already advanced by claim_due_trackers.

## What changed
<!-- 1-2 sentences -->

## Why
<!-- Link to issue -->
Closes #

## How to test
<!-- Steps to verify -->

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)
