### PR TITLE
Add structured scan report UI to audit log tab

### DIFF
--- a/frontend/src/pages/SkillDetailPage.module.css
+++ b/frontend/src/pages/SkillDetailPage.module.css
@@ -342,6 +342,143 @@ a.metaItem:hover {
   overflow-y: auto;
 }
 
+.scanSummaryLine {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+}
+
+.scanSummaryDot {
+  color: var(--text-muted);
+}
+
+.scanReportToggle {
+  background: none;
+  border: none;
+  color: var(--neon-cyan);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.scanReportToggle:hover {
+  text-decoration: underline;
+}
+
+.scanReportDetail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+
+.scanReportMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.scanReportLoading {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.analyzersList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.analyzerChip {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+.scanReportRaw {
+  margin: 0;
+  padding: 12px;
+  background: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  overflow-x: auto;
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre;
+}
+
+.findingsList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.findingRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg-dark);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.severityBadge {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 60px;
+}
+
+.findingContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.findingTitle {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.findingFile {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--neon-cyan);
+}
+
+.findingRemediation {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .auditQuarantine {
   font-family: 'Share Tech Mono', monospace;
   font-size: 0.75rem;
@@ -425,5 +562,19 @@ a.metaItem:hover {
     flex-direction: column;
     align-items: flex-start;
     gap: 8px;
+  }
+
+  .scanSummaryLine {
+    flex-wrap: wrap;
+    font-size: 0.75rem;
+  }
+
+  .findingRow {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .severityBadge {
+    min-width: 0;
   }
 }

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -401,6 +401,220 @@ function FilesTab({
   return <FileBrowser files={files} />;
 }
 
+const SEVERITY_COLORS: Record<string, string> = {
+  CRITICAL: "var(--neon-pink)",
+  HIGH: "var(--neon-orange)",
+  MEDIUM: "#e8c547",
+  LOW: "var(--neon-cyan)",
+  INFO: "var(--text-muted)",
+};
+
+interface ScanReportDetail {
+  grade: string;
+  is_safe: boolean;
+  max_severity: string;
+  findings_count: number;
+  analyzers_used: string[];
+  analyzability_score: number | null;
+  findings: Record<string, unknown>[];
+  findings_total: number;
+}
+
+function ScanSummary({ entry }: { entry: AuditLogEntry }) {
+  const [report, setReport] = useState<ScanReportDetail | null>(null);
+  const [fullJson, setFullJson] = useState<string | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
+  const [reportFetched, setReportFetched] = useState(false);
+
+  const check = entry.check_results[0] as
+    | { check_name?: string; message?: string; severity?: string }
+    | undefined;
+  const reasoning = entry.llm_reasoning as
+    | { scanner_findings?: Record<string, unknown>[]; meta_analysis?: Record<string, unknown> }
+    | null;
+  const inlineFindings = reasoning?.scanner_findings ?? [];
+
+  const isScanner = check?.check_name === "skill_scanner";
+  const reportApiPath = `/v1/skills/${encodeURIComponent(entry.org_slug)}/${encodeURIComponent(entry.skill_name)}/scan-report`;
+
+  useEffect(() => {
+    if (!isScanner) return;
+    let cancelled = false;
+    fetch(`${reportApiPath}?page_size=100`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (!cancelled && data) setReport(data); })
+      .finally(() => { if (!cancelled) setReportFetched(true); });
+    return () => { cancelled = true; };
+  }, [isScanner, reportApiPath]);
+
+  const loading = isScanner && !reportFetched;
+
+  if (!check && inlineFindings.length === 0) return null;
+
+  const handleRawToggle = async () => {
+    if (showRaw) {
+      setShowRaw(false);
+      return;
+    }
+    setShowRaw(true);
+    if (fullJson) return;
+    try {
+      const res = await fetch(`${reportApiPath}/download`);
+      if (res.ok) {
+        const data = await res.json();
+        setFullJson(JSON.stringify(data, null, 2));
+      }
+    } catch { /* non-critical */ }
+  };
+
+  const findings = report?.findings ?? inlineFindings;
+
+  return (
+    <div className={styles.auditChecks}>
+      <h5 className={styles.auditCheckTitle}>
+        {isScanner ? "Scan Report" : "Safety Checks"}
+      </h5>
+
+      {isScanner && check?.message && (
+        <ScanSummaryLine message={check.message} />
+      )}
+
+      {!isScanner && check && (
+        <div className={styles.auditCheck}>
+          <pre className={styles.auditPre}>
+            {JSON.stringify(check, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {isScanner && (
+        <div className={styles.scanReportDetail}>
+          {loading && <span className={styles.scanReportLoading}>Loading report…</span>}
+
+          {report && (
+            <div className={styles.scanReportMeta}>
+              <span>Grade: <strong>{report.grade}</strong></span>
+              <span className={styles.scanSummaryDot}>·</span>
+              <span>Safe: {report.is_safe ? "Yes" : "No"}</span>
+              {report.analyzability_score != null && (
+                <>
+                  <span className={styles.scanSummaryDot}>·</span>
+                  <span>Analyzability: {(report.analyzability_score * 100).toFixed(0)}%</span>
+                </>
+              )}
+            </div>
+          )}
+
+          {report && report.analyzers_used.length > 0 && (
+            <div className={styles.analyzersList}>
+              {report.analyzers_used.map((a) => (
+                <span key={a} className={styles.analyzerChip}>{a.replace(/_/g, " ")}</span>
+              ))}
+            </div>
+          )}
+
+          {findings.length > 0 && (
+            <div className={styles.findingsList}>
+              {findings.map((f, i) => (
+                <FindingRow key={i} finding={f} />
+              ))}
+            </div>
+          )}
+
+          {!loading && findings.length === 0 && report && (
+            <span className={styles.scanReportLoading}>No findings</span>
+          )}
+
+          {isScanner && (
+            <button
+              type="button"
+              onClick={handleRawToggle}
+              className={styles.scanReportToggle}
+            >
+              {showRaw ? "Hide full report ▴" : "Full report ▾"}
+            </button>
+          )}
+
+          {showRaw && fullJson && (
+            <pre className={styles.scanReportRaw}>{fullJson}</pre>
+          )}
+
+          {showRaw && !fullJson && (
+            <span className={styles.scanReportLoading}>Loading…</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function parseScanMessage(message: string) {
+  const grade = message.match(/grade=(\w+)/)?.[1];
+  const maxSeverity = message.match(/max_severity=(\w+)/)?.[1];
+  const findings = message.match(/findings=(\d+)/)?.[1];
+  const analyzerList = message.match(/analyzers=\[([^\]]*)\]/)?.[1];
+  const analyzers = analyzerList
+    ?.split(",")
+    .map((a) => a.trim().replace(/'/g, ""))
+    .filter(Boolean) ?? [];
+  return { grade, maxSeverity, findings, analyzers };
+}
+
+function ScanSummaryLine({ message }: { message: string }) {
+  const { maxSeverity, findings, analyzers } = parseScanMessage(message);
+
+  return (
+    <div className={styles.scanSummaryLine}>
+      <span>
+        {analyzers.length} analyzer{analyzers.length !== 1 ? "s" : ""} ran
+      </span>
+      <span className={styles.scanSummaryDot}>·</span>
+      <span>{findings ?? "0"} finding{findings !== "1" ? "s" : ""}</span>
+      {maxSeverity && maxSeverity !== "SAFE" && (
+        <>
+          <span className={styles.scanSummaryDot}>·</span>
+          <span
+            className={styles.severityBadge}
+            style={{ color: SEVERITY_COLORS[maxSeverity] ?? "var(--text-muted)" }}
+          >
+            {maxSeverity}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FindingRow({ finding }: { finding: Record<string, unknown> }) {
+  const severity = String(finding.severity ?? "INFO");
+  const title = String(finding.title ?? finding.rule_id ?? "Unknown");
+  const filePath = finding.file_path ? String(finding.file_path) : null;
+  const lineNumber = finding.line_number ? Number(finding.line_number) : null;
+  const remediation = finding.remediation ? String(finding.remediation) : null;
+
+  return (
+    <div className={styles.findingRow}>
+      <span
+        className={styles.severityBadge}
+        style={{ color: SEVERITY_COLORS[severity] ?? "var(--text-muted)" }}
+      >
+        {severity}
+      </span>
+      <div className={styles.findingContent}>
+        <span className={styles.findingTitle}>{title}</span>
+        {filePath && (
+          <span className={styles.findingFile}>
+            {filePath}{lineNumber ? `:${lineNumber}` : ""}
+          </span>
+        )}
+        {remediation && (
+          <span className={styles.findingRemediation}>{remediation}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function AuditTab({
   entries,
   loading,
@@ -441,18 +655,7 @@ function AuditTab({
               )}
             </div>
 
-            {entry.check_results.length > 0 && (
-              <div className={styles.auditChecks}>
-                <h5 className={styles.auditCheckTitle}>Safety Checks</h5>
-                {entry.check_results.map((check, i) => (
-                  <div key={i} className={styles.auditCheck}>
-                    <pre className={styles.auditPre}>
-                      {JSON.stringify(check, null, 2)}
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            )}
+            <ScanSummary entry={entry} />
 
             {entry.quarantine_s3_key && (
               <span className={styles.auditQuarantine}>


### PR DESCRIPTION
Closes #184

## Summary

- Replace the raw JSON dump of `check_results` in the audit log with a structured scan report view
- Summary line shows analyzer count, finding count, and max severity (with correct parsing of the analyzer list)
- Report detail card (always visible) shows grade, safe/unsafe, analyzability score, analyzer chips, and color-coded finding rows
- "Full report" toggle fetches the complete raw JSON from `/scan-report/download` and renders it in a scrollable `<pre>` block inline
- Mobile-responsive styles at 480px breakpoint

Made with [Cursor](https://cursor.com)