### PR TITLE
Fix check_trackers timeout: switch from blocking fn.map() to fire-and-forget fn.spawn()

### DIFF
--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -282,47 +282,52 @@ def _dispatch_changed_trackers(
     settings: Settings,
     engine: Any,
 ) -> tuple[int, int]:
-    """Fan out processing of changed trackers via Modal, with sequential fallback.
+    """Fan out processing of changed trackers via Modal fire-and-forget, with sequential fallback.
 
-    Returns (processed_count, failed_count).
+    Uses fn.spawn() (fire-and-forget) instead of fn.map() so the orchestrator
+    does not block waiting for all containers to complete.  This prevents
+    check_trackers from timing out when many repos change simultaneously (e.g.
+    after the nightly crawler adds a large batch of new trackers).
+
+    Returns (spawned_count, spawn_failed_count).  The spawned containers update
+    the DB themselves (last_commit_sha, last_published_at, last_error), so
+    correctness is not affected by not awaiting their results.
+
     Each Modal container mints its own GitHub App token from environment
     credentials, so no token passthrough is needed.
     """
-    processed = 0
+    spawned = 0
     failed = 0
 
     try:
         import modal
 
         fn = modal.Function.from_name(settings.modal_app_name, "tracker_process_repo")
-        tracker_dicts = [tracker_to_dict(t) for t, _ in changed_trackers]
-        known_shas = [sha for _, sha in changed_trackers]
 
-        for batch_result in fn.map(
-            tracker_dicts,
-            known_shas,
-            return_exceptions=True,
-        ):
-            if isinstance(batch_result, Exception):
-                logger.opt(exception=batch_result).error("Modal tracker_process_repo failed")
+        for tracker, known_sha in changed_trackers:
+            try:
+                fn.spawn(tracker_to_dict(tracker), known_sha)
+                spawned += 1
+            except Exception:
+                logger.opt(exception=True).error(
+                    "Modal spawn failed tracker_id={} repo={}",
+                    tracker.id,
+                    tracker.repo_url,
+                )
                 failed += 1
-            else:
-                if batch_result.get("status") == "ok":
-                    processed += 1
-                else:
-                    failed += 1
-                    logger.error(
-                        "tracker_process_repo error: repo={} error={}",
-                        batch_result.get("repo_url", "?"),
-                        batch_result.get("error", "unknown"),
-                    )
+
+        logger.info(
+            "fire-and-forget dispatch: spawned={} spawn_failed={}",
+            spawned,
+            failed,
+        )
     except Exception as modal_err:
         # Modal unavailable (local dev, import error, lookup failure) — fall back to sequential
         logger.info("Modal fan-out unavailable ({}), falling back to sequential processing", modal_err)
         for tracker, known_sha in changed_trackers:
             try:
                 process_tracker(tracker, settings, engine, known_sha=known_sha)
-                processed += 1
+                spawned += 1
             except Exception:
                 logger.opt(exception=True).error(
                     "tracker_id={} repo={} status=failed",
@@ -331,7 +336,7 @@ def _dispatch_changed_trackers(
                 )
                 failed += 1
 
-    return processed, failed
+    return spawned, failed
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -554,6 +554,42 @@ class TestDispatchChangedTrackers:
         assert processed == 0
         assert failed == 1
 
+    def test_modal_spawn_fire_and_forget(self):
+        """When Modal is available, should spawn each tracker without blocking (fire-and-forget)."""
+        tracker1 = self._make_tracker()
+        tracker2 = self._make_tracker()
+        changed = [(tracker1, "sha1"), (tracker2, "sha2")]
+        mock_settings = MagicMock()
+        mock_settings.modal_app_name = "decision-hub"
+        mock_engine = MagicMock()
+
+        mock_fn = MagicMock()
+        with patch("modal.Function.from_name", return_value=mock_fn):
+            spawned, failed = _dispatch_changed_trackers(changed, mock_settings, mock_engine)
+
+        assert spawned == 2
+        assert failed == 0
+        assert mock_fn.spawn.call_count == 2
+        # Verify map() was NOT called (old blocking approach)
+        mock_fn.map.assert_not_called()
+
+    def test_modal_spawn_failure_counted(self):
+        """When fn.spawn() raises, the failure should be counted without aborting other spawns."""
+        tracker1 = self._make_tracker()
+        tracker2 = self._make_tracker()
+        changed = [(tracker1, "sha1"), (tracker2, "sha2")]
+        mock_settings = MagicMock()
+        mock_settings.modal_app_name = "decision-hub"
+        mock_engine = MagicMock()
+
+        mock_fn = MagicMock()
+        mock_fn.spawn.side_effect = [RuntimeError("quota exceeded"), None]
+        with patch("modal.Function.from_name", return_value=mock_fn):
+            spawned, failed = _dispatch_changed_trackers(changed, mock_settings, mock_engine)
+
+        assert spawned == 1
+        assert failed == 1
+
 
 class TestCheckAllDueTrackersLoopSignal:
     """Verify check_all_due_trackers returns len(trackers) so the caller loop continues."""


### PR DESCRIPTION
## Problem

`check_trackers` is consistently timing out at 600s (the Modal hard timeout). Luca noticed this in the Modal failure emails.

## Root Cause

`_dispatch_changed_trackers()` used `fn.map()` which **blocks** until all Modal containers report back. With `max_containers=50` and many changed trackers — especially after the nightly crawler adds new orgs (PyData, etc.) where all newly-created trackers have `last_commit_sha = NULL` — the fan-out queues:

```
ceil(N_changed / 50) batches × up to 300s each
```

Example: 200 newly-added trackers → 4 batches × 300s = 1200s. Hard timeout at 600s every single run, forever (because SHA is never saved due to the timeout).

## Fix

Switch to `fn.spawn()` (fire-and-forget) per changed tracker. The orchestrator submits all containers and returns immediately. Each `tracker_process_repo` container already handles its own DB state updates (`last_commit_sha`, `last_published_at`, `last_error`), so correctness is unaffected.

## Tradeoff

The `tracker_metrics` row `processed` field now reflects **spawned count** (optimistic) rather than confirmed successes. Container-level failures are still recorded via `update_skill_tracker()` inside each container — just not aggregated in the orchestrator metrics row.

## Tests

- Added 2 new tests: Modal spawn happy path + spawn failure counting
- All 4 existing `TestDispatchChangedTrackers` tests pass
- Full suite: 44/44 pass