### PR TITLE
feat: styled audit log with severity grid

### DIFF
--- a/frontend/src/pages/CheckResultsGrid.test.tsx
+++ b/frontend/src/pages/CheckResultsGrid.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { CheckResult } from "../types/api";
+import { CheckResultsGrid } from "./SkillDetailPage";
+import { formatCheckName } from "./auditUtils";
+
+const CHECKS: CheckResult[] = [
+  { severity: "pass", check_name: "manifest_schema", message: "Schema is valid" },
+  { severity: "fail", check_name: "safety_scan", message: "Found unsafe pattern in code" },
+  { severity: "warn", check_name: "dependency_audit", message: "Outdated dependency detected" },
+];
+
+describe("formatCheckName", () => {
+  it("maps known check names to labels", () => {
+    expect(formatCheckName("manifest_schema")).toBe("Manifest Schema");
+    expect(formatCheckName("embedded_credentials")).toBe("Credentials Scan");
+    expect(formatCheckName("safety_scan")).toBe("Safety Scan");
+  });
+
+  it("title-cases unknown check names", () => {
+    expect(formatCheckName("some_new_check")).toBe("Some New Check");
+  });
+});
+
+describe("CheckResultsGrid", () => {
+  it("renders all check cards with labels and messages", () => {
+    render(<CheckResultsGrid checks={CHECKS} />);
+
+    expect(screen.getByText("Safety Checks")).toBeInTheDocument();
+    expect(screen.getByText("Manifest Schema")).toBeInTheDocument();
+    expect(screen.getByText("Safety Scan")).toBeInTheDocument();
+    expect(screen.getByText("Dependency Audit")).toBeInTheDocument();
+    expect(screen.getByText("Schema is valid")).toBeInTheDocument();
+    expect(screen.getByText("Found unsafe pattern in code")).toBeInTheDocument();
+  });
+
+  it("renders nothing when checks is empty", () => {
+    const { container } = render(<CheckResultsGrid checks={[]} />);
+    // Grid exists but has no cards
+    expect(container.querySelectorAll("[class*=checkCard]")).toHaveLength(0);
+  });
+
+  it("handles missing fields gracefully", () => {
+    const sparse: CheckResult[] = [
+      { severity: undefined, check_name: undefined, message: undefined },
+      {},
+    ];
+    render(<CheckResultsGrid checks={sparse} />);
+    // Falls back to "unknown" for check_name -> title-cased
+    const labels = screen.getAllByText("Unknown");
+    expect(labels).toHaveLength(2);
+  });
+
+  it("expands a card message on click and collapses on second click", async () => {
+    const user = userEvent.setup();
+    render(<CheckResultsGrid checks={CHECKS} />);
+
+    const firstCard = screen.getByText("Schema is valid").closest("[class*=checkCard]")!;
+    const messageSpan = screen.getByText("Schema is valid");
+
+    // Initially not expanded
+    expect(messageSpan.className).not.toMatch(/checkMessageExpanded/);
+
+    // Click to expand
+    await user.click(firstCard);
+    expect(messageSpan.className).toMatch(/checkMessageExpanded/);
+
+    // Click again to collapse
+    await user.click(firstCard);
+    expect(messageSpan.className).not.toMatch(/checkMessageExpanded/);
+  });
+
+  it("collapses previous card when a different card is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CheckResultsGrid checks={CHECKS} />);
+
+    const firstMessage = screen.getByText("Schema is valid");
+    const secondMessage = screen.getByText("Found unsafe pattern in code");
+    const firstCard = firstMessage.closest("[class*=checkCard]")!;
+    const secondCard = secondMessage.closest("[class*=checkCard]")!;
+
+    // Expand first
+    await user.click(firstCard);
+    expect(firstMessage.className).toMatch(/checkMessageExpanded/);
+
+    // Click second — first collapses, second expands
+    await user.click(secondCard);
+    expect(firstMessage.className).not.toMatch(/checkMessageExpanded/);
+    expect(secondMessage.className).toMatch(/checkMessageExpanded/);
+  });
+});

--- a/frontend/src/pages/SkillDetailPage.module.css
+++ b/frontend/src/pages/SkillDetailPage.module.css
@@ -340,6 +340,7 @@ a.metaItem:hover {
   background: var(--bg-dark);
   border: 1px solid var(--border-color);
   overflow: hidden;
+  cursor: pointer;
 }
 
 .checkHeader {
@@ -375,7 +376,8 @@ a.metaItem:hover {
   overflow: hidden;
 }
 
-.checkCard:hover .checkMessage {
+.checkCard:hover .checkMessage,
+.checkMessageExpanded {
   -webkit-line-clamp: unset;
 }
 

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -28,12 +28,13 @@ import {
 } from "../api/client";
 import { useApi } from "../hooks/useApi";
 import { useSEO } from "../hooks/useSEO";
-import type { SkillSummary, EvalReport, AuditLogEntry, PaginatedAuditLogResponse, SkillFile } from "../types/api";
+import type { SkillSummary, EvalReport, AuditLogEntry, CheckResult, PaginatedAuditLogResponse, SkillFile } from "../types/api";
 import NeonCard from "../components/NeonCard";
 import GradeBadge from "../components/GradeBadge";
 import LoadingSpinner from "../components/LoadingSpinner";
 import EvalReportView from "../components/EvalReportView";
 import FileBrowser from "../components/FileBrowser";
+import { formatCheckName } from "./auditUtils";
 import styles from "./SkillDetailPage.module.css";
 
 type Tab = "overview" | "evals" | "files" | "audit";
@@ -404,22 +405,49 @@ function FilesTab({
   return <FileBrowser files={files} />;
 }
 
-const CHECK_NAME_LABELS: Record<string, string> = {
-  manifest_schema: "Manifest Schema",
-  embedded_credentials: "Credentials Scan",
-  safety_scan: "Safety Scan",
-  prompt_safety: "Prompt Safety",
-  pipeline_taint: "Pipeline Taint",
-  tool_consistency: "Tool Consistency",
-  dependency_audit: "Dependency Audit",
-  unscanned_files: "Unscanned Files",
-  source_size: "Source Size",
-  llm_coverage: "LLM Coverage",
-  functional_tests: "Functional Tests",
-};
+export function CheckResultsGrid({ checks }: { checks: CheckResult[] }) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
-function formatCheckName(raw: string): string {
-  return CHECK_NAME_LABELS[raw] ?? raw.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return (
+    <div className={styles.auditChecks}>
+      <h5 className={styles.auditCheckTitle}>Safety Checks</h5>
+      <div className={styles.checkGrid}>
+        {checks.map((check, i) => {
+          const severity = check.severity ?? "";
+          const checkName = check.check_name ?? "unknown";
+          const message = check.message ?? "";
+          const SeverityIcon =
+            severity === "pass"
+              ? CheckCircle
+              : severity === "fail"
+                ? XCircle
+                : AlertTriangle;
+          const severityClass =
+            severity === "pass"
+              ? styles.severityPass
+              : severity === "fail"
+                ? styles.severityFail
+                : styles.severityWarn;
+          const isExpanded = expandedIndex === i;
+          return (
+            <div
+              key={i}
+              className={`${styles.checkCard} ${severityClass}`}
+              onClick={() => setExpandedIndex(isExpanded ? null : i)}
+            >
+              <div className={styles.checkHeader}>
+                <SeverityIcon size={14} className={styles.checkIcon} />
+                <span className={styles.checkName}>{formatCheckName(checkName)}</span>
+              </div>
+              <span className={`${styles.checkMessage} ${isExpanded ? styles.checkMessageExpanded : ""}`}>
+                {message}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 function AuditTab({
@@ -463,37 +491,7 @@ function AuditTab({
             </div>
 
             {entry.check_results.length > 0 && (
-              <div className={styles.auditChecks}>
-                <h5 className={styles.auditCheckTitle}>Safety Checks</h5>
-                <div className={styles.checkGrid}>
-                {entry.check_results.map((check, i) => {
-                  const severity = String(check.severity ?? "");
-                  const checkName = String(check.check_name ?? "unknown");
-                  const message = String(check.message ?? "");
-                  const SeverityIcon =
-                    severity === "pass"
-                      ? CheckCircle
-                      : severity === "fail"
-                        ? XCircle
-                        : AlertTriangle;
-                  const severityClass =
-                    severity === "pass"
-                      ? styles.severityPass
-                      : severity === "fail"
-                        ? styles.severityFail
-                        : styles.severityWarn;
-                  return (
-                    <div key={i} className={`${styles.checkCard} ${severityClass}`}>
-                      <div className={styles.checkHeader}>
-                        <SeverityIcon size={14} className={styles.checkIcon} />
-                        <span className={styles.checkName}>{formatCheckName(checkName)}</span>
-                      </div>
-                      <span className={styles.checkMessage}>{message}</span>
-                    </div>
-                  );
-                })}
-                </div>
-              </div>
+              <CheckResultsGrid checks={entry.check_results} />
             )}
 
             {entry.quarantine_s3_key && (

--- a/frontend/src/pages/auditUtils.ts
+++ b/frontend/src/pages/auditUtils.ts
@@ -1,0 +1,17 @@
+const CHECK_NAME_LABELS: Record<string, string> = {
+  manifest_schema: "Manifest Schema",
+  embedded_credentials: "Credentials Scan",
+  safety_scan: "Safety Scan",
+  prompt_safety: "Prompt Safety",
+  pipeline_taint: "Pipeline Taint",
+  tool_consistency: "Tool Consistency",
+  dependency_audit: "Dependency Audit",
+  unscanned_files: "Unscanned Files",
+  source_size: "Source Size",
+  llm_coverage: "LLM Coverage",
+  functional_tests: "Functional Tests",
+};
+
+export function formatCheckName(raw: string): string {
+  return CHECK_NAME_LABELS[raw] ?? raw.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -74,6 +74,13 @@ export interface EvalReport {
   created_at: string | null;
 }
 
+export interface CheckResult {
+  severity?: string;
+  check_name?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
 export interface AuditLogEntry {
   id: string;
   org_slug: string;
@@ -81,7 +88,7 @@ export interface AuditLogEntry {
   semver: string;
   grade: string;
   version_id: string | null;
-  check_results: Record<string, unknown>[];
+  check_results: CheckResult[];
   llm_reasoning: Record<string, unknown> | null;
   publisher: string;
   quarantine_s3_key: string | null;

--- a/server/migrations/20260226_163218_recreate_eval_audit_logs.sql
+++ b/server/migrations/20260226_163218_recreate_eval_audit_logs.sql
@@ -1,4 +1,4 @@
--- Recreate eval_audit_logs table (previously dropped by 20260224_205716)
+-- Recreate eval_audit_logs table (was manually dropped on dev)
 CREATE TABLE IF NOT EXISTS eval_audit_logs (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     org_slug TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- Replace raw JSON audit log display with a responsive 3-column grid of styled check result cards
- Each card shows a severity icon (pass/warn/fail), a labeled badge (e.g. "Manifest Schema"), and a message truncated to 2 lines (expandable on hover)
- Colors use the site's neon palette: green for pass, pink for fail, yellow for warn
- Recreates the `eval_audit_logs` table on dev (previously dropped by a migration)
- Responsive: 3 cols desktop, 2 cols tablet, 1 col mobile

## Before / After

**Before:** Raw JSON blobs for each safety check
**After:** Clean grid with color-coded severity badges

## Test plan
- [x] Deployed to dev and verified visually at https://hub-dev.decision.ai/skills/a-church-ai/church
- [x] TypeScript compiles clean
- [x] Frontend lint passes
- [ ] Verify mobile layout at 480px and 768px breakpoints
- [ ] Verify hover-to-expand works on long messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)