### PR TITLE
Update Decision Hub tagline and description

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
       name: "Decision Hub",
       url: "https://hub.decision.ai",
       description:
-        "The skill registry for AI coding agents. Every skill is automatically evaluated, security-graded, and searchable in natural language.",
+        "Trusted Skills for AI Agents in Data Science and Beyond",
     }),
     [],
   );
@@ -88,9 +88,7 @@ export default function HomePage() {
           <span className={styles.heroMain}>HUB</span>
         </h1>
         <p className={styles.heroSub}>
-          The skill registry for AI coding agents.
-          Every skill is automatically evaluated, security-graded, and searchable
-          in natural language.
+          Trusted Skills for AI Agents in Data Science and Beyond
         </p>
         <div className={styles.heroCta}>
           <button


### PR DESCRIPTION
## What changed
Updated the tagline and description for Decision Hub from a technical focus on "skill registry for AI coding agents" to a broader positioning as "Trusted Skills for AI Agents in Data Science and Beyond". Changes applied to both the metadata description and the hero section subtitle on the HomePage.

## Why
Closes #

## How to test
Verify that the updated text appears correctly on the homepage hero section and in page metadata.

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01VZqVrE9EwNzXs3uqWj9rAj