### PR TITLE
Reorder skill publish to commit DB before S3 upload

### DIFF
--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -37,6 +37,7 @@ from decision_hub.domain.search import format_trust_score, resolve_author_displa
 from decision_hub.domain.skill_manifest import extract_body, extract_description
 from decision_hub.infra.database import (
     delete_all_versions,
+    delete_audit_logs_by_version_id,
     delete_skill_access_grant,
     delete_version,
     fetch_all_skills_for_index,
@@ -536,8 +537,12 @@ def publish_skill(
     except Exception:
         logger.opt(exception=True).error(
             "S3 upload failed for {}/{} v{} — rolling back version {}",
-            org_slug, skill_name, version, version_record.id,
+            org_slug,
+            skill_name,
+            version,
+            version_record.id,
         )
+        delete_audit_logs_by_version_id(conn, version_record.id)
         delete_version(conn, skill.id, version)
         conn.commit()
         raise

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2195,6 +2195,24 @@ def insert_audit_log(
     return _row_to_audit_log_entry(row)
 
 
+def delete_audit_logs_by_version_id(conn: Connection, version_id: UUID) -> int:
+    """Delete all audit log entries referencing a specific version.
+
+    Used during rollback when an S3 upload fails after the DB commit,
+    to avoid leaving orphaned audit entries with a NULL version_id.
+
+    Args:
+        conn: Active database connection.
+        version_id: UUID of the version whose audit entries should be removed.
+
+    Returns:
+        Number of deleted rows.
+    """
+    stmt = sa.delete(eval_audit_logs_table).where(eval_audit_logs_table.c.version_id == version_id)
+    result = conn.execute(stmt)
+    return result.rowcount
+
+
 def find_audit_logs(
     conn: Connection,
     org_slug: str,


### PR DESCRIPTION
## What changed
Reordered the skill publish workflow to commit database changes before uploading to S3, with rollback logic if the S3 upload fails. This prevents orphaned S3 objects when database commits fail.

## Why
The previous implementation uploaded to S3 before committing the version record to the database. If the database commit failed, the S3 object would be left orphaned. By reversing the order and adding exception handling, we ensure the database is committed first, and if S3 upload subsequently fails, we roll back the database changes to maintain consistency.

Closes #

## How to test
- Verify skill publish succeeds in normal cases (existing tests should cover this)
- Manual testing of S3 upload failure scenario: mock S3 client to raise an exception and verify that the version record is deleted and rolled back

## Checklist
- [ ] Tests pass (`make test`)
- [ ] No breaking API changes
- [ ] Database migration included (if schema changed)

https://claude.ai/code/session_01YT3RSLKsLqoegcd8J8L4s6