### PR TITLE
feat: add --repo flag to dhub install

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -913,6 +913,10 @@ def _install_from_repo(
     # Normalize repo_ref to full URL if it's owner/repo format
     repo_url = f"https://github.com/{repo_ref}" if not repo_ref.startswith("http") else repo_ref
 
+    if len(repo_url) > 500:
+        console.print("[red]Error: Repository URL is too long (max 500 characters).[/]")
+        raise typer.Exit(1)
+
     # Fetch all skills from the repo
     with console.status(f"Fetching skills from {repo_ref}..."), httpx.Client(timeout=60) as client:
         resp = client.get(
@@ -941,7 +945,7 @@ def _install_from_repo(
         try:
             _install_single_skill(ref, version=version, agent=agent, allow_risky=allow_risky)
             succeeded += 1
-        except (typer.Exit, SystemExit):
+        except typer.Exit:
             failed += 1
             console.print(f"[yellow]Warning: Failed to install {ref}, continuing...[/]")
 

--- a/client/tests/test_cli/test_install_repo.py
+++ b/client/tests/test_cli/test_install_repo.py
@@ -119,6 +119,14 @@ class TestInstallRepo:
         assert result.exit_code == 1
         assert "Provide a skill reference" in result.output
 
+    def test_install_repo_url_too_long(self) -> None:
+        """--repo with a URL exceeding 500 chars is rejected client-side."""
+        long_repo = "a" * 501
+        result = runner.invoke(app, ["install", "--repo", long_repo])
+
+        assert result.exit_code == 1
+        assert "too long" in result.output
+
     @respx.mock
     @patch("dhub.core.install.verify_checksum")
     @patch("dhub.core.install.get_dhub_skill_path")

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -585,6 +585,32 @@ def get_registry_stats(
     return fetch_registry_stats(conn)
 
 
+def _row_to_skill_summary_model(row: dict) -> SkillSummary:
+    """Convert a DB row dict to a SkillSummary response model."""
+    return SkillSummary(
+        org_slug=row["org_slug"],
+        skill_name=row["skill_name"],
+        description=row.get("description", ""),
+        latest_version=row["latest_version"],
+        updated_at=row["created_at"].strftime("%Y-%m-%d %H:%M:%S") if row.get("created_at") else "",
+        safety_rating=format_trust_score(row["eval_status"]),
+        author=resolve_author_display(row.get("published_by", "")),
+        download_count=row.get("download_count", 0),
+        is_personal_org=row.get("is_personal_org", False),
+        category=row.get("category", ""),
+        visibility=row.get("visibility", "public"),
+        source_repo_url=row.get("source_repo_url"),
+        manifest_path=row.get("manifest_path"),
+        source_repo_removed=row.get("source_repo_removed", False),
+        github_stars=row.get("github_stars"),
+        github_forks=row.get("github_forks"),
+        github_watchers=row.get("github_watchers"),
+        github_is_archived=row.get("github_is_archived"),
+        github_license=row.get("github_license"),
+        is_auto_synced=row.get("has_tracker", False),
+    )
+
+
 @public_router.get(
     "/skills",
     response_model=PaginatedSkillsResponse,
@@ -624,31 +650,7 @@ def list_skills(
         sort_dir=sort_dir,
     )
     total_pages = math.ceil(total / page_size) if total > 0 else 1
-    items = [
-        SkillSummary(
-            org_slug=row["org_slug"],
-            skill_name=row["skill_name"],
-            description=row.get("description", ""),
-            latest_version=row["latest_version"],
-            updated_at=row["created_at"].strftime("%Y-%m-%d %H:%M:%S") if row.get("created_at") else "",
-            safety_rating=format_trust_score(row["eval_status"]),
-            author=resolve_author_display(row.get("published_by", "")),
-            download_count=row.get("download_count", 0),
-            is_personal_org=row.get("is_personal_org", False),
-            category=row.get("category", ""),
-            visibility=row.get("visibility", "public"),
-            source_repo_url=row.get("source_repo_url"),
-            manifest_path=row.get("manifest_path"),
-            source_repo_removed=row.get("source_repo_removed", False),
-            github_stars=row.get("github_stars"),
-            github_forks=row.get("github_forks"),
-            github_watchers=row.get("github_watchers"),
-            github_is_archived=row.get("github_is_archived"),
-            github_license=row.get("github_license"),
-            is_auto_synced=row.get("has_tracker", False),
-        )
-        for row in rows
-    ]
+    items = [_row_to_skill_summary_model(row) for row in rows]
     return PaginatedSkillsResponse(
         items=items,
         total=total,
@@ -671,30 +673,7 @@ def list_skills_by_repo(
     """List all published skills from a specific source repository."""
     user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
     rows = fetch_skills_by_repo(conn, repo_url, user_org_ids=user_org_ids)
-    items = [
-        SkillSummary(
-            org_slug=row["org_slug"],
-            skill_name=row["skill_name"],
-            description=row.get("description", ""),
-            latest_version=row["latest_version"],
-            updated_at=row["created_at"].strftime("%Y-%m-%d %H:%M:%S") if row.get("created_at") else "",
-            safety_rating=format_trust_score(row["eval_status"]),
-            author=resolve_author_display(row.get("published_by", "")),
-            download_count=row.get("download_count", 0),
-            is_personal_org=row.get("is_personal_org", False),
-            category=row.get("category", ""),
-            visibility=row.get("visibility", "public"),
-            source_repo_url=row.get("source_repo_url"),
-            manifest_path=row.get("manifest_path"),
-            source_repo_removed=row.get("source_repo_removed", False),
-            github_stars=row.get("github_stars"),
-            github_forks=row.get("github_forks"),
-            github_watchers=row.get("github_watchers"),
-            github_is_archived=row.get("github_is_archived"),
-            github_license=row.get("github_license"),
-        )
-        for row in rows
-    ]
+    items = [_row_to_skill_summary_model(row) for row in rows]
     return RepoSkillsResponse(items=items, total=len(items), repo_url=repo_url)
 
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1873,8 +1873,21 @@ def fetch_skills_by_repo(
     """
     normalized = _normalize_repo_url(repo_url)
 
+    tracker_exists = (
+        sa.select(sa.literal(True))
+        .where(
+            sa.and_(
+                skill_trackers_table.c.repo_url == skills_table.c.source_repo_url,
+                skill_trackers_table.c.enabled.is_(True),
+            )
+        )
+        .correlate(skills_table)
+        .exists()
+        .label("has_tracker")
+    )
+
     base = (
-        sa.select(*_SKILL_SUMMARY_COLUMNS)
+        sa.select(*_SKILL_SUMMARY_COLUMNS, tracker_exists)
         .select_from(
             skills_table.join(
                 organizations_table,
@@ -1899,7 +1912,7 @@ def fetch_skills_by_repo(
     base = _apply_visibility_filter(base, user_org_ids, granted)
 
     rows = conn.execute(base).all()
-    return [_row_to_skill_summary(row) for row in rows]
+    return [{**_row_to_skill_summary(row), "has_tracker": row.has_tracker} for row in rows]
 
 
 def search_skills_hybrid(

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -1357,6 +1357,7 @@ class TestSkillsByRepo:
                 "github_is_archived": None,
                 "github_license": None,
                 "is_personal_org": False,
+                "has_tracker": True,
             },
             {
                 "org_slug": "test-org",
@@ -1378,6 +1379,7 @@ class TestSkillsByRepo:
                 "github_is_archived": None,
                 "github_license": None,
                 "is_personal_org": False,
+                "has_tracker": False,
             },
         ]
 
@@ -1394,6 +1396,10 @@ class TestSkillsByRepo:
         assert "gws-drive" in names
         assert data["total"] == 2
         assert data["repo_url"] == "https://github.com/googleworkspace/cli"
+        # Verify is_auto_synced is populated from has_tracker
+        by_name = {s["skill_name"]: s for s in data["items"]}
+        assert by_name["gws-gmail"]["is_auto_synced"] is True
+        assert by_name["gws-drive"]["is_auto_synced"] is False
 
     @patch("decision_hub.api.registry_routes.fetch_skills_by_repo")
     def test_returns_empty_for_unknown_repo(

--- a/server/tests/test_infra/test_database_by_repo.py
+++ b/server/tests/test_infra/test_database_by_repo.py
@@ -58,6 +58,7 @@ class TestFetchSkillsByRepo:
             "published_by": "testuser",
             "is_personal_org": False,
         }
+        mock_row.has_tracker = True
 
         conn = MagicMock()
         conn.execute.return_value.all.return_value = [mock_row]
@@ -67,6 +68,7 @@ class TestFetchSkillsByRepo:
         assert len(results) == 1
         assert results[0]["org_slug"] == "acme"
         assert results[0]["skill_name"] == "skill-a"
+        assert results[0]["has_tracker"] is True
         conn.execute.assert_called_once()
 
     @patch("decision_hub.infra.database._apply_visibility_filter", side_effect=lambda stmt, *a, **kw: stmt)


### PR DESCRIPTION
## Summary
- Adds `dhub install --repo owner/repo` to install all skills from a GitHub repository at once
- New server endpoint `GET /v1/skills/by-repo?repo_url=...` returns all published skills for a repo
- New `fetch_skills_by_repo()` database function with URL normalization (.git suffix, trailing slashes)
- Refactored `install_command` to extract `_install_single_skill()` for reuse by the repo installer

## Test plan
- [ ] `dhub install --repo googleworkspace/cli` installs all Google Workspace skills
- [ ] `dhub install --repo owner/repo.git` normalizes URL correctly
- [ ] `dhub install --repo unknown/repo` shows "no skills found" error
- [ ] `dhub install org/skill` (existing flow) still works unchanged
- [ ] Cannot combine `--repo` with a skill reference
- [ ] Partial failures (one skill 404) continue installing remaining skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)