### PR TITLE
fix: resolve relative markdown links to GitHub source repo

### DIFF
--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -395,7 +395,7 @@ function resolveRelativeUrl(
   if (!sourceRepoUrl || /^(https?:\/\/|#|mailto:)/.test(href)) return href;
 
   // Determine the directory containing SKILL.md in the repo
-  const dir = manifestPath
+  const dir = manifestPath?.includes("/")
     ? manifestPath.replace(/\/[^/]+$/, "") // strip filename
     : "";
   const base = dir


### PR DESCRIPTION
## Summary

- Relative links in SKILL.md content (e.g. `references/patterns.md`) were resolving against the app's URL (`/skills/org/name/`), producing 404 pages
- Now rewrites relative `<a>` hrefs and `<img>` srcs to absolute GitHub URLs using `source_repo_url` and `manifest_path` from the skill metadata
- Images use `/raw/` instead of `/blob/` so GitHub serves the actual file

Closes #241

## Test plan

- [ ] Navigate to https://hub.decision.ai/skills/pymc-labs/pymc-testing and verify "Common Testing Patterns" link points to GitHub
- [ ] Verify absolute links (https://...) and anchors (#...) are unchanged
- [ ] Verify skills without `source_repo_url` still render links as-is
- [ ] Existing SkillDetailPage tests pass (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)