### PR TITLE
fix: redact API keys from log output

### DIFF
--- a/server/src/decision_hub/logging.py
+++ b/server/src/decision_hub/logging.py
@@ -17,6 +17,8 @@ import uuid
 from loguru import logger
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+_SENSITIVE_URL_PARAM_RE = re.compile(r"(\bkey=)[^&\s\"']+")
+
 
 class _InterceptHandler(logging.Handler):
     """Bridge stdlib logging → loguru.
@@ -43,7 +45,8 @@ class _InterceptHandler(logging.Handler):
                 continue
             break
 
-        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+        msg = _SENSITIVE_URL_PARAM_RE.sub(r"\1[REDACTED]", record.getMessage())
+        logger.opt(depth=depth, exception=record.exc_info).log(level, msg)
 
 
 def _format_record(record: dict) -> str:

--- a/server/tests/test_api/test_logging.py
+++ b/server/tests/test_api/test_logging.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from decision_hub.logging import (
     _PATH_CONTEXT_RE,
+    _SENSITIVE_URL_PARAM_RE,
     _extract_username_from_jwt,
     setup_logging,
 )
@@ -125,6 +126,32 @@ class TestPathContextRegex:
         org, skill = _extract_org_skill(path)
         assert org == ""
         assert skill == ""
+
+
+class TestSensitiveUrlParamRedaction:
+    def test_redacts_gemini_api_key_in_url(self):
+        msg = 'HTTP Request: POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=AIzaSyCreSRWwVxshBxiy5ZnmlxrED7HmW-ouRs "HTTP/1.1 200 OK"'
+        result = _SENSITIVE_URL_PARAM_RE.sub(r"\1[REDACTED]", msg)
+        assert "AIzaSy" not in result
+        assert "key=[REDACTED]" in result
+
+    def test_redacts_key_preserving_other_params(self):
+        msg = "GET https://api.example.com/v1?key=secret123&other=value"
+        result = _SENSITIVE_URL_PARAM_RE.sub(r"\1[REDACTED]", msg)
+        assert "secret123" not in result
+        assert "key=[REDACTED]&other=value" in result
+
+    def test_no_change_when_no_key_param(self):
+        msg = "Normal log message with no sensitive data"
+        result = _SENSITIVE_URL_PARAM_RE.sub(r"\1[REDACTED]", msg)
+        assert result == msg
+
+    def test_redacts_multiple_keys(self):
+        msg = "key=abc123 and key=def456"
+        result = _SENSITIVE_URL_PARAM_RE.sub(r"\1[REDACTED]", msg)
+        assert "abc123" not in result
+        assert "def456" not in result
+        assert result.count("[REDACTED]") == 2
 
 
 class TestExtractUsernameFromJwt:


### PR DESCRIPTION
## Summary
- Adds regex-based redaction in `_InterceptHandler.emit()` to replace `key=<value>` URL query parameters with `key=[REDACTED]` before forwarding to loguru
- Prevents Gemini API keys from appearing in plaintext in Modal production logs (logged by `httpx` at INFO level)
- Adds 4 test cases for the redaction regex

Closes #263

## Test plan
- [x] All 22 logging tests pass (`pytest server/tests/test_api/test_logging.py`)
- [ ] Verify on dev deploy that Gemini request logs show `key=[REDACTED]` instead of the actual key

🤖 Generated with [Claude Code](https://claude.com/claude-code)