### PR TITLE
fix: add retry with backoff to Gemini API for transient errors

### DIFF
--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -1,6 +1,7 @@
 """Gemini LLM client for skill search."""
 
 import json
+import random
 import time
 from dataclasses import dataclass
 
@@ -101,7 +102,7 @@ def _gemini_post(
             response=resp,
         )
         if attempt < max_retries:
-            delay = 2**attempt  # 1s, 2s, 4s
+            delay = 2**attempt + random.uniform(0, 0.5)  # ~1s, ~2s, ~4s
             logger.warning(
                 "Gemini API returned {} for {}, retrying in {}s (attempt {}/{})",
                 resp.status_code,
@@ -239,7 +240,7 @@ def parse_query_with_guard(
     }
 
     try:
-        data = _gemini_post(client, model, payload, timeout=10)
+        data = _gemini_post(client, model, payload, timeout=10, max_retries=1)
         text = _extract_text(data)
         result = json.loads(text)
 
@@ -429,7 +430,7 @@ def ask_conversational(
     }
 
     logger.debug("Gemini ask query: '{}' model={}", query[:100], model)
-    data = _gemini_post(client, model, payload, timeout=30)
+    data = _gemini_post(client, model, payload, timeout=30, max_retries=1)
 
     text = _extract_text(data)
     if not text:

--- a/server/tests/test_infra/test_gemini.py
+++ b/server/tests/test_infra/test_gemini.py
@@ -38,11 +38,14 @@ class TestGeminiPostRetry:
                 httpx.Response(200, json={"candidates": []}),
             ]
         )
-        with patch("decision_hub.infra.gemini.time.sleep") as mock_sleep:
+        with (
+            patch("decision_hub.infra.gemini.time.sleep") as mock_sleep,
+            patch("decision_hub.infra.gemini.random.uniform", return_value=0.25),
+        ):
             result = _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
         assert result == {"candidates": []}
         assert route.call_count == 2
-        mock_sleep.assert_called_once_with(1)
+        mock_sleep.assert_called_once_with(1.25)
 
     @respx.mock
     def test_retries_on_429_with_backoff(self, gemini_client: dict) -> None:
@@ -53,13 +56,16 @@ class TestGeminiPostRetry:
                 httpx.Response(200, json={"candidates": []}),
             ]
         )
-        with patch("decision_hub.infra.gemini.time.sleep") as mock_sleep:
+        with (
+            patch("decision_hub.infra.gemini.time.sleep") as mock_sleep,
+            patch("decision_hub.infra.gemini.random.uniform", return_value=0.25),
+        ):
             result = _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
         assert result == {"candidates": []}
         assert route.call_count == 3
         assert mock_sleep.call_args_list == [
-            ((1,),),
-            ((2,),),
+            ((1.25,),),
+            ((2.25,),),
         ]
 
     @respx.mock


### PR DESCRIPTION
## Summary
- Adds exponential backoff retry (1s, 2s, 4s) in `_gemini_post` for retriable HTTP status codes (403, 429, 500, 502, 503)
- Non-retriable errors (400, 401) propagate immediately without retry
- Fixes false grade=F quarantines caused by transient Gemini 403 Forbidden errors during gauntlet safety checks
- Centralizes retry logic for all 7 callers of `_gemini_post`

Observed in production at 16:07 UTC — skills `mcp-create-declarative-agent`, `mcp-deploy-manage-agents`, and `noob-mode` were all quarantined due to Gemini 403s, not actual safety issues.

Closes #265

## Test plan
- [x] All 16 gemini tests pass (`pytest server/tests/test_infra/test_gemini.py`)
- [x] 4 new tests: retry on 403, backoff on 429, exhaust retries on 503, immediate raise on 400
- [ ] Deploy to dev and verify gauntlet doesn't quarantine skills during transient Gemini outages

🤖 Generated with [Claude Code](https://claude.com/claude-code)