### PR TITLE
fix: reduce GraphQL batch chunk and silence Modal deprecation

### DIFF
--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -379,6 +379,7 @@ def _dispatch_changed_trackers(
             known_shas,
             return_exceptions=True,
             order_outputs=False,
+            wrap_returned_exceptions=False,
         ):
             # Process the already-received result before checking the deadline —
             # the for-loop already blocked to receive it, so discarding it would

--- a/server/src/decision_hub/infra/github_client.py
+++ b/server/src/decision_hub/infra/github_client.py
@@ -15,7 +15,7 @@ GITHUB_API = "https://api.github.com"
 GITHUB_GRAPHQL = "https://api.github.com/graphql"
 
 # Maximum aliases per GraphQL request (GitHub hard-limits at 500 nodes).
-_GRAPHQL_BATCH_CHUNK = 250
+_GRAPHQL_BATCH_CHUNK = 50
 
 
 class GitHubClient:


### PR DESCRIPTION
## Summary
- Reduce `_GRAPHQL_BATCH_CHUNK` from 250 → 50 in `github_client.py` — a single GitHub API 502 at 22:02 UTC caused `errored=225` because all trackers fit in one GraphQL query. Smaller chunks limit blast radius to ~50 per transient failure.
- Add `wrap_returned_exceptions=False` to `fn.map()` in `tracker_service.py` to silence Modal `DeprecationWarning` about `UserCodeException` wrapping.

Closes #269

## Test plan
- [ ] Verify next tracker tick splits 225+ trackers across 5 chunks
- [ ] Confirm Modal deprecation warning is gone from logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)