### PR TITLE
fix: handle tracker version race and Gemini read timeouts

### DIFF
--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -694,7 +694,7 @@ def _publish_skill_from_tracker(
     Returns True if a new version was actually published to S3,
     False if skipped (no content changes) or rejected by the gauntlet.
     """
-    from decision_hub.domain.publish_pipeline import GauntletRejectionError, execute_publish
+    from decision_hub.domain.publish_pipeline import GauntletRejectionError, VersionConflictError, execute_publish
     from decision_hub.infra.database import (
         find_org_by_slug,
         resolve_latest_version,
@@ -751,6 +751,16 @@ def _publish_skill_from_tracker(
         except GauntletRejectionError:
             logger.warning(
                 "tracker_id={} repo={} skill={}/{}@{} status=rejected",
+                tracker.id,
+                tracker.repo_url,
+                org_slug,
+                skill_name,
+                version,
+            )
+            return False
+        except VersionConflictError:
+            logger.warning(
+                "tracker_id={} repo={} skill={}/{}@{} status=version_conflict (race condition)",
                 tracker.id,
                 tracker.repo_url,
                 org_slug,

--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -82,13 +82,27 @@ def _gemini_post(
     params = {"key": client["api_key"]}
     shared = client.get("http_client")
 
-    last_exc: httpx.HTTPStatusError | None = None
+    last_exc: Exception | None = None
     for attempt in range(1 + max_retries):
-        if shared is not None:
-            resp = shared.post(url, params=params, json=payload, timeout=timeout)
-        else:
-            with httpx.Client(timeout=timeout) as http_client:
-                resp = http_client.post(url, params=params, json=payload)
+        try:
+            if shared is not None:
+                resp = shared.post(url, params=params, json=payload, timeout=timeout)
+            else:
+                with httpx.Client(timeout=timeout) as http_client:
+                    resp = http_client.post(url, params=params, json=payload)
+        except httpx.TimeoutException as exc:
+            last_exc = exc
+            if attempt < max_retries:
+                delay = 2**attempt + random.uniform(0, 0.5)
+                logger.warning(
+                    "Gemini API timeout for {}, retrying in {:.1f}s (attempt {}/{})",
+                    model,
+                    delay,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(delay)
+            continue
 
         if resp.status_code < 400:
             return resp.json()
@@ -104,7 +118,7 @@ def _gemini_post(
         if attempt < max_retries:
             delay = 2**attempt + random.uniform(0, 0.5)  # ~1s, ~2s, ~4s
             logger.warning(
-                "Gemini API returned {} for {}, retrying in {}s (attempt {}/{})",
+                "Gemini API returned {} for {}, retrying in {:.1f}s (attempt {}/{})",
                 resp.status_code,
                 model,
                 delay,


### PR DESCRIPTION
## Summary
- Catch `VersionConflictError` in `_publish_skill_from_tracker` — when two containers race on the same skill (e.g. mega-repo timeout + retry), the second one logs a warning instead of crashing
- Catch `httpx.TimeoutException` in `_gemini_post` retry loop — read timeouts now retry with exponential backoff like HTTP status errors

Closes #271

## Test plan
- [ ] Verify no more `IntegrityError` stacktraces in prod logs for version conflicts
- [ ] Verify Gemini read timeouts are retried (look for "Gemini API timeout" warning in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)