### PR TITLE
perf: fail fast on oversized zips before uploading

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -580,7 +580,7 @@ def _create_zip(path: Path) -> bytes:
             if entry_count > _MAX_ZIP_ENTRIES:
                 raise ValueError(
                     f"Skill contains more than {_MAX_ZIP_ENTRIES} files. "
-                    f"Use a .gitignore or reduce the number of files."
+                    f"Remove unnecessary files or exclude them from the skill directory."
                 )
             zf.write(file, relative)
     return buf.getvalue()

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 import httpx
+import pytest
 import respx
 from typer.testing import CliRunner
 
 from dhub.cli.app import app
+from dhub.cli.registry import _MAX_ZIP_ENTRIES, _create_zip
 
 runner = CliRunner()
 
@@ -393,21 +395,15 @@ class TestPublishCommand:
 class TestCreateZip:
     def test_rejects_oversized_directory(self, tmp_path: Path) -> None:
         """_create_zip raises ValueError when entry count exceeds the limit."""
-        from dhub.cli.registry import _MAX_ZIP_ENTRIES, _create_zip
-
         # Create more files than the limit
         for i in range(_MAX_ZIP_ENTRIES + 1):
             (tmp_path / f"file_{i}.txt").write_text(f"content {i}")
-
-        import pytest
 
         with pytest.raises(ValueError, match="more than"):
             _create_zip(tmp_path)
 
     def test_accepts_directory_at_limit(self, tmp_path: Path) -> None:
         """_create_zip succeeds when entry count is exactly at the limit."""
-        from dhub.cli.registry import _MAX_ZIP_ENTRIES, _create_zip
-
         for i in range(_MAX_ZIP_ENTRIES):
             (tmp_path / f"file_{i}.txt").write_text(f"content {i}")
 


### PR DESCRIPTION
## Summary
- Adds a client-side entry count check in `_create_zip()` matching the server's 500-entry limit (`_MAX_ZIP_ENTRIES`)
- Oversized skills (like `babysit`) now fail immediately with a clear error instead of uploading the full zip to the server
- Saves network bandwidth, server extraction time, and avoids unnecessary Gemini API calls

## Test plan
- [x] New `TestCreateZip` tests verify rejection at 501 entries and acceptance at 500
- [x] Full client test suite passes (254 tests)
- [x] Lint clean

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)