### PR TITLE
fix: increase check_trackers timeout from 600s to 900s

### DIFF
--- a/server/modal_app.py
+++ b/server/modal_app.py
@@ -265,15 +265,15 @@ def crawl_trusted_orgs_nightly() -> None:
 
 # Budget for the outer while-loop that claims batches of trackers.
 # fn.map() blocks the thread while waiting for tracker_process_repo results
-# (up to 300s container timeout + ~60s cold start = 360s worst case).  The
+# (up to 600s container timeout + ~60s cold start = 660s worst case).  The
 # deadline check inside the for-loop only fires BETWEEN results, so a single
-# blocking wait can consume the entire 360s.  The budget must satisfy:
+# blocking wait can consume the entire 660s.  The budget must satisfy:
 #   max_loop_entry + pre_dispatch_overhead + max_fn_map_block < hard_timeout
-#   (180 - 30) + ~30 + 360 = 540 < 600  ✓
+#   (180 - 30) + ~30 + 660 = 840 < 900  ✓
 _TRACKER_LOOP_BUDGET_SECONDS = 180
 
 
-@app.function(image=crawler_image, timeout=600, schedule=modal.Period(seconds=600))
+@app.function(image=crawler_image, timeout=900, schedule=modal.Period(seconds=600))
 def check_trackers():
     """Poll GitHub repos for skill updates every 10 minutes.
 


### PR DESCRIPTION
## Summary

- Increases `check_trackers` Modal function timeout from 600s to 900s to accommodate the `tracker_process_repo` child timeout (600s + ~60s cold start)
- Updates the budget comment to reflect the corrected math

## Problem

When `tracker_process_repo` timeout was raised from 300s → 600s (a5ee4c0), the parent `check_trackers` timeout and budget math weren't updated. A single slow child container can now block `fn.map()` for up to 660s, exceeding the parent's 600s hard timeout and cascading cancellation to all in-flight containers.

**Observed in production at 18:02 UTC:**
```
Task's current input hit its timeout of 600s
Parent input in-01KK798T7S2JG9P920YWSVN1DH failed
```

## Fix

```
Old: (180-30) + ~30 + (300+60) = 540 < 600  ✓
New: (180-30) + ~30 + (600+60) = 840 < 900  ✓
```

Fixes #278

## Test plan

- [ ] CI passes (no code logic changes, only timeout config)
- [ ] Deploy to dev and verify check_trackers runs without hitting timeout
- [ ] Monitor next few production ticks after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)