### PR TITLE
fix: handle version race in crawler as skip, not failure

### DIFF
--- a/server/src/decision_hub/scripts/crawler/processing.py
+++ b/server/src/decision_hub/scripts/crawler/processing.py
@@ -27,6 +27,7 @@ from decision_hub.domain.publish import (
     extract_for_evaluation,
     validate_skill_name,
 )
+from decision_hub.domain.publish_pipeline import VersionConflictError
 from decision_hub.domain.repo_utils import (
     bump_version,
     clone_repo,
@@ -281,6 +282,14 @@ def process_repo_on_modal(
                         set_tracker=set_tracker,
                         force=force,
                     )
+                except VersionConflictError:
+                    # Race: tracker or another crawler container published this
+                    # version between our checksum check and insert.
+                    logger.info(
+                        "Skill {} already published (version race), skipping",
+                        skill_dir.name,
+                    )
+                    return "skipped"
                 except Exception:
                     logger.opt(exception=True).warning(
                         "Failed to process skill dir {}",


### PR DESCRIPTION
## Summary

- Catches `VersionConflictError` specifically in the crawler's `_process_skill` before the broad `except Exception`
- Logs at INFO level and returns "skipped" instead of "failed"
- Eliminates noisy `UniqueViolation` tracebacks during nightly crawl

## Problem

When the nightly crawl and tracker system process the same repo concurrently, the tracker may publish a version first. The crawler then hits a `VersionConflictError` (wrapping `UniqueViolation`) which was caught by a broad `except Exception`, logged as a WARNING with full traceback, and counted as "failed".

The tracker path already handles this gracefully (PR #272) — this brings the crawler path to parity.

**Observed in production at 02:08 UTC:**
```
WARNING | Failed to process skill dir nextflow-development
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "versions_skill_id_semver_key"
```

Fixes #280

## Test plan

- [ ] CI passes
- [ ] Monitor next nightly crawl (2am UTC) for clean logs without `UniqueViolation` tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)