### PR TITLE
fix: strip markdown code fences before elevated permission scanning

### DIFF
--- a/server/src/decision_hub/domain/gauntlet.py
+++ b/server/src/decision_hub/domain/gauntlet.py
@@ -409,6 +409,11 @@ def check_pipeline_taint(
     )
 
 
+# Matches markdown code fence opening/closing lines (e.g. ```bash, ```python, ```)
+# to strip them before permission scanning — fence language annotations like
+# ```bash are documentation syntax, not actual shell usage.
+_CODE_FENCE_RE = re.compile(r"^\s*`{3,}\w*\s*$", re.MULTILINE)
+
 # Permission categories that elevate a skill from A to B
 _ELEVATED_PERMISSION_PATTERNS: dict[str, list[re.Pattern]] = {
     "shell": [
@@ -1028,6 +1033,9 @@ def detect_elevated_permissions(
     Returns a list of permission category strings (e.g. "shell", "network").
     """
     all_content = "\n".join(content for _, content in source_files)
+    # Strip markdown code fence lines so language annotations (```bash,
+    # ```shell, etc.) don't trigger false positives.
+    all_content = _CODE_FENCE_RE.sub("", all_content)
     if allowed_tools:
         all_content += "\n" + allowed_tools
 

--- a/server/tests/test_domain/test_gauntlet.py
+++ b/server/tests/test_domain/test_gauntlet.py
@@ -549,6 +549,30 @@ class TestDetectElevatedPermissions:
         result = detect_elevated_permissions(files, "bash, shell, read")
         assert "shell" in result
 
+    def test_ignores_markdown_code_fence_bash(self):
+        """```bash code fence annotations should not trigger shell detection."""
+        files = [("README.md", "Install:\n```bash\npip install foo\n```\n")]
+        result = detect_elevated_permissions(files, None)
+        assert "shell" not in result
+
+    def test_ignores_markdown_code_fence_shell(self):
+        """```shell code fence annotations should not trigger shell detection."""
+        files = [("guide.md", "Run:\n```shell\necho hello\n```\n")]
+        result = detect_elevated_permissions(files, None)
+        assert "shell" not in result
+
+    def test_detects_bash_in_prose(self):
+        """Actual mention of bash in prose should still trigger detection."""
+        files = [("SKILL.md", "This skill uses bash to run commands.\n")]
+        result = detect_elevated_permissions(files, None)
+        assert "shell" in result
+
+    def test_detects_subprocess_inside_code_fence(self):
+        """Code inside a fenced block should still be scanned."""
+        files = [("example.md", "```python\nimport subprocess\n```\n")]
+        result = detect_elevated_permissions(files, None)
+        assert "shell" in result
+
 
 class TestComputeGrade:
     def test_grade_a_all_pass_minimal(self):


### PR DESCRIPTION
## Summary

- Strip markdown code fence lines (`\`\`\`bash`, `\`\`\`shell`, `\`\`\``) before running `detect_elevated_permissions()` pattern matching
- Code fence language annotations are documentation syntax, not actual shell usage
- Code **inside** fenced blocks is still scanned normally

**Impact**: 696 skills are graded B solely due to this false positive. 1,263 total have `shell` as a contributing flag. Example: `pymc-labs/pymc-modeling` dropped from A to B at v0.1.10.

**Root cause**: Since `.md` was added to `_SECURITY_SCAN_EXTENSIONS` (Feb 27), `\bbash\b` matches `\`\`\`bash` in markdown files.

Closes #287

## Test plan

- [x] Added test: `\`\`\`bash` code fence does NOT trigger shell detection
- [x] Added test: `\`\`\`shell` code fence does NOT trigger shell detection
- [x] Added test: "bash" in prose DOES still trigger detection
- [x] Added test: `subprocess` inside a fenced block DOES still trigger detection
- [x] All 174 gauntlet tests pass
- [x] Full server suite: 844 passed (1 pre-existing LLM-dependent failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)