### PR TITLE
fix: persist last_error for trackers that timeout on Modal

### DIFF
--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -507,8 +507,14 @@ def _dispatch_changed_trackers(
     preventing the orchestrator from hitting the hard Modal timeout.
     Unprocessed trackers will be retried on the next tick.
     """
+    from uuid import UUID
+
     processed = 0
     failed = 0
+    # Track which trackers completed (success or handled error) so we can
+    # persist last_error for any that failed silently (timeout, OOM, etc.)
+    completed_tracker_ids: set[UUID] = set()
+    all_tracker_ids = {t.id for t, _ in changed_trackers}
 
     try:
         import modal
@@ -534,6 +540,9 @@ def _dispatch_changed_trackers(
                 logger.opt(exception=batch_result).error("Modal tracker_process_repo failed")
                 failed += 1
             else:
+                tracker_id_str = batch_result.get("tracker_id")
+                if tracker_id_str:
+                    completed_tracker_ids.add(UUID(tracker_id_str))
                 if batch_result.get("status") == "ok":
                     processed += 1
                 else:
@@ -551,6 +560,17 @@ def _dispatch_changed_trackers(
                     len(changed_trackers),
                 )
                 break
+
+        # Persist last_error for trackers that failed without a result dict
+        # (timeout, OOM, container crash). These never reached the
+        # process_tracker exception handler that normally writes last_error.
+        _persist_orphaned_tracker_errors(
+            all_tracker_ids - completed_tracker_ids,
+            changed_trackers,
+            engine,
+            error_msg="Modal container failed (timeout/OOM) before writing result",
+        )
+
     except Exception as modal_err:
         # Modal unavailable (local dev, import error, lookup failure) — fall back to sequential
         logger.info("Modal fan-out unavailable ({}), falling back to sequential processing", modal_err)
@@ -570,6 +590,42 @@ def _dispatch_changed_trackers(
                 failed += 1
 
     return processed, failed
+
+
+def _persist_orphaned_tracker_errors(
+    orphaned_ids: set,
+    changed_trackers: list[tuple[SkillTracker, str]],
+    engine: Any,
+    *,
+    error_msg: str,
+) -> None:
+    """Update last_error for trackers whose Modal containers died before writing a result."""
+    from decision_hub.infra.database import update_skill_tracker
+
+    if not orphaned_ids:
+        return
+
+    now = datetime.now(UTC)
+    tracker_by_id = {t.id: t for t, _ in changed_trackers}
+    try:
+        with engine.connect() as conn:
+            for tid in orphaned_ids:
+                tracker = tracker_by_id.get(tid)
+                logger.warning(
+                    "tracker_id={} repo={} status=orphaned_failure error={}",
+                    tid,
+                    tracker.repo_url if tracker else "?",
+                    error_msg,
+                )
+                update_skill_tracker(
+                    conn,
+                    tid,
+                    last_checked_at=now,
+                    last_error=error_msg,
+                )
+            conn.commit()
+    except Exception:
+        logger.opt(exception=True).error("Failed to persist orphaned tracker errors")
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -16,6 +16,7 @@ from decision_hub.domain.repo_utils import (
 )
 from decision_hub.domain.tracker_service import (
     _dispatch_changed_trackers,
+    _persist_orphaned_tracker_errors,
     check_all_due_trackers,
     dict_to_tracker,
     process_tracker,
@@ -553,6 +554,45 @@ class TestDispatchChangedTrackers:
 
         assert processed == 0
         assert failed == 1
+
+    @patch("decision_hub.infra.database.update_skill_tracker")
+    def test_persist_orphaned_tracker_errors(self, mock_update):
+        """When Modal containers die (timeout/OOM), last_error should be persisted."""
+        tracker = self._make_tracker()
+        changed = [(tracker, "new_sha")]
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        _persist_orphaned_tracker_errors(
+            {tracker.id},
+            changed,
+            mock_engine,
+            error_msg="Modal container failed (timeout/OOM)",
+        )
+
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args
+        assert call_kwargs[0][1] == tracker.id
+        assert "timeout" in call_kwargs[1]["last_error"]
+        assert call_kwargs[1]["last_checked_at"] is not None
+        mock_conn.commit.assert_called_once()
+
+    @patch("decision_hub.infra.database.update_skill_tracker")
+    def test_persist_orphaned_no_op_when_all_completed(self, mock_update):
+        """When all trackers completed, no DB update should happen."""
+        mock_engine = MagicMock()
+
+        _persist_orphaned_tracker_errors(
+            set(),  # no orphaned IDs
+            [],
+            mock_engine,
+            error_msg="should not be written",
+        )
+
+        mock_update.assert_not_called()
+        mock_engine.connect.assert_not_called()
 
 
 class TestCheckAllDueTrackersLoopSignal:


### PR DESCRIPTION
## Summary

- When a `tracker_process_repo` Modal container times out (600s), the container is killed before `process_tracker`'s exception handler can write `last_error` to the DB
- The orchestrator caught the `FunctionTimeoutError` but only logged it — the tracker row was never updated, making the failure invisible in the DB/UI
- The tracker would silently retry on the next cycle with no indication of prior failure

**Fix:** After `fn.map()` completes, diff completed tracker IDs (from result dicts) against all dispatched trackers. Any "orphaned" trackers get their `last_error` updated with a descriptive message.

Closes #289

## Test plan

- [x] New test: `test_persist_orphaned_tracker_errors` — verifies `last_error` is written for orphaned trackers
- [x] New test: `test_persist_orphaned_no_op_when_all_completed` — verifies no DB writes when all complete
- [x] Full server test suite passes (895 tests)
- [x] Linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)