### PR TITLE
fix: raise LLM body review cap from 30KB to 50KB

### DIFF
--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -15,7 +15,7 @@ _GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 LLM_PER_FILE_CAP = 50_000  # 50 KB max per file in analyze_code_safety
 LLM_STAGE2_TOTAL_CAP = 150_000  # 150 KB total in analyze_code_safety
 LLM_HOLISTIC_TOTAL_CAP = 300_000  # 300 KB total in review_code_body_safety
-LLM_BODY_REVIEW_CAP = 30_000  # body truncation in review_prompt_body_safety
+LLM_BODY_REVIEW_CAP = 50_000  # body truncation in review_prompt_body_safety
 
 
 class CodeSafetyJudgment(BaseModel):

--- a/server/tests/test_domain/test_gauntlet.py
+++ b/server/tests/test_domain/test_gauntlet.py
@@ -1453,19 +1453,19 @@ class TestLlmScanCoverage:
         assert "holistic review" in result.message
 
     def test_body_exceeds_prompt_cap(self):
-        """SKILL.md body > 30KB triggers prompt review warning."""
-        result = check_llm_scan_coverage([], skill_md_body="x" * 35_000)
+        """SKILL.md body > 50KB triggers prompt review warning."""
+        result = check_llm_scan_coverage([], skill_md_body="x" * 55_000)
         assert result.severity == "warn"
         assert "body" in result.message
 
     def test_multiple_issues_all_reported(self):
         """Multiple cap violations are all listed in the message."""
         # 350KB total exceeds holistic cap (300KB), big.py exceeds per-file (50KB),
-        # body exceeds prompt cap (30KB)
+        # body exceeds prompt cap (50KB)
         files = [("big.py", "x" * 60_000)] + [(f"f{i}.py", "x" * 49_000) for i in range(6)]
         result = check_llm_scan_coverage(
             files,
-            skill_md_body="x" * 35_000,
+            skill_md_body="x" * 55_000,
         )
         assert result.severity == "warn"
         assert "per-file" in result.message


### PR DESCRIPTION
## Summary

- Raise `LLM_BODY_REVIEW_CAP` from 30KB to 50KB in `gemini.py`
- Skills with SKILL.md bodies between 30-50KB were getting grade C solely because the body exceeded the prompt review cap, with no actual safety issues
- 50KB aligns with the existing `LLM_PER_FILE_CAP`
- Updated tests to use 55KB bodies (above new cap)

## Test plan

- [x] All 7 `TestLlmScanCoverage` tests pass with updated thresholds
- [x] Full gauntlet test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)