### PR TITLE
Fix incorrect dhub-cli skill name on landing page

### DIFF
--- a/docs/superpowers/plans/2026-03-12-landing-page-redesign.md
+++ b/docs/superpowers/plans/2026-03-12-landing-page-redesign.md
@@ -687,7 +687,7 @@ Insert after the `{/* Value Props */}` section closing tag and before `{/* Featu
         </span>
         <h3 className={styles.agentStepTitle}>Add the dhub skill</h3>
         <div className={styles.agentStepCommand}>
-          <code>dhub install decision-ai/dhub-cli</code>
+          <code>dhub install pymc-labs/dhub-cli</code>
         </div>
         <p className={styles.agentStepDesc}>
           Makes your agent more token-efficient and proficient with the registry.

--- a/docs/superpowers/specs/2026-03-12-landing-page-redesign.md
+++ b/docs/superpowers/specs/2026-03-12-landing-page-redesign.md
@@ -60,7 +60,7 @@ Three NeonCard pillars in a 3-column grid (responsive to 1-col on mobile):
 
 **Left column (steps)**:
 1. **Install the CLI** — `pip install dhub-cli` — "Your agent can already use dhub commands after this."
-2. **Add the dhub skill** — `dhub install decision-ai/dhub-cli` — "Makes your agent more token-efficient and proficient with the registry."
+2. **Add the dhub skill** — `dhub install pymc-labs/dhub-cli` — "Makes your agent more token-efficient and proficient with the registry."
 3. **Just ask** — "Tell your agent what you need. It searches the registry, installs the right skill, and gets to work."
 
 **Right column**: The existing `AnimatedTerminal` component with its current script (claude → user prompt → loads dhub skill → searches → installs domain skill → ready).

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -232,7 +232,7 @@ export default function HomePage() {
               </span>
               <h3 className={styles.agentStepTitle}>Add the dhub skill</h3>
               <div className={styles.agentStepCommand}>
-                <code>dhub install decision-ai/dhub-cli</code>
+                <code>dhub install pymc-labs/dhub-cli</code>
               </div>
               <p className={styles.agentStepDesc}>
                 Makes your agent more token-efficient and proficient with the registry.


### PR DESCRIPTION
## Summary
- The landing page install command references `decision-ai/dhub-cli`, which doesn't exist in the registry
- Users running `dhub install decision-ai/dhub-cli` get `Error: Skill 'decision-ai/dhub-cli' not found.`
- Fixed all 3 occurrences to use the correct name `pymc-labs/dhub-cli`

## Files changed
- `frontend/src/pages/HomePage.tsx` — the actual rendered landing page
- `docs/superpowers/specs/2026-03-12-landing-page-redesign.md` — spec doc
- `docs/superpowers/plans/2026-03-12-landing-page-redesign.md` — plan doc

## Test plan
- [ ] Verify `dhub install pymc-labs/dhub-cli` works correctly
- [ ] Check the landing page renders the correct command

🤖 Generated with [Claude Code](https://claude.com/claude-code)