### PR TITLE
Validate --agent before download, add fuzzy name suggestions

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -959,9 +959,18 @@ def _install_single_skill(
         link_skill_to_agent,
         link_skill_to_all_agents,
         save_installed_version,
+        validate_agent,
         verify_checksum,
     )
     from dhub.core.validation import parse_skill_ref
+
+    # Validate --agent before doing any network requests or downloads
+    if agent:
+        try:
+            validate_agent(agent)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/]")
+            raise typer.Exit(1) from None
 
     # Parse skill reference
     try:

--- a/client/src/dhub/core/install.py
+++ b/client/src/dhub/core/install.py
@@ -79,15 +79,9 @@ def validate_agent(agent: str) -> None:
     known = sorted(AGENT_SKILL_PATHS)
     matches = get_close_matches(agent, known, n=3, cutoff=0.5)
 
-    if matches:
-        suggestion = f" Did you mean: {', '.join(repr(m) for m in matches)}?"
-    else:
-        suggestion = ""
+    suggestion = f" Did you mean: {', '.join(repr(m) for m in matches)}?" if matches else ""
 
-    raise ValueError(
-        f"Unknown agent '{agent}'.{suggestion}\n"
-        f"Known agents: {', '.join(known)}"
-    )
+    raise ValueError(f"Unknown agent '{agent}'.{suggestion}\nKnown agents: {', '.join(known)}")
 
 
 def compute_checksum(data: bytes) -> str:

--- a/client/src/dhub/core/install.py
+++ b/client/src/dhub/core/install.py
@@ -61,6 +61,35 @@ AGENT_SKILL_PATHS: dict[str, Path] = {
 }
 
 
+def validate_agent(agent: str) -> None:
+    """Validate that an agent name is recognized, with fuzzy suggestions on failure.
+
+    Args:
+        agent: The agent name to validate.
+
+    Raises:
+        ValueError: If the agent name is not recognized, with a suggestion
+            for the closest match if one exists.
+    """
+    if agent == "all" or agent in AGENT_SKILL_PATHS:
+        return
+
+    from difflib import get_close_matches
+
+    known = sorted(AGENT_SKILL_PATHS)
+    matches = get_close_matches(agent, known, n=3, cutoff=0.5)
+
+    if matches:
+        suggestion = f" Did you mean: {', '.join(repr(m) for m in matches)}?"
+    else:
+        suggestion = ""
+
+    raise ValueError(
+        f"Unknown agent '{agent}'.{suggestion}\n"
+        f"Known agents: {', '.join(known)}"
+    )
+
+
 def compute_checksum(data: bytes) -> str:
     """Compute SHA-256 hex digest of data."""
     return hashlib.sha256(data).hexdigest()
@@ -122,8 +151,7 @@ def link_skill_to_agent(org: str, skill_name: str, agent: str) -> Path:
         ValueError: If the agent name is not recognized.
         FileNotFoundError: If the canonical skill directory does not exist.
     """
-    if agent not in AGENT_SKILL_PATHS:
-        raise ValueError(f"Unknown agent '{agent}'. Known agents: {', '.join(sorted(AGENT_SKILL_PATHS))}.")
+    validate_agent(agent)
 
     canonical = get_dhub_skill_path(org, skill_name)
     if not canonical.exists():
@@ -154,8 +182,7 @@ def unlink_skill_from_agent(org: str, skill_name: str, agent: str) -> None:
         ValueError: If the agent name is not recognized.
         FileNotFoundError: If no symlink exists for this skill/agent combination.
     """
-    if agent not in AGENT_SKILL_PATHS:
-        raise ValueError(f"Unknown agent '{agent}'. Known agents: {', '.join(sorted(AGENT_SKILL_PATHS))}.")
+    validate_agent(agent)
 
     symlink_path = AGENT_SKILL_PATHS[agent] / skill_name
 

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -550,11 +550,11 @@ class TestInstallCommand:
         )
         respx.get("http://test:8000/download/skill.zip").mock(return_value=httpx.Response(200, content=zip_bytes))
 
-        result = runner.invoke(app, ["install", "myorg/my-skill", "--agent", "claude"])
+        result = runner.invoke(app, ["install", "myorg/my-skill", "--agent", "claude-code"])
 
         assert result.exit_code == 0
-        mock_link.assert_called_once_with("myorg", "my-skill", "claude")
-        assert "Linked to claude" in result.output
+        mock_link.assert_called_once_with("myorg", "my-skill", "claude-code")
+        assert "Linked to claude-code" in result.output
 
     @respx.mock
     @patch("dhub.core.install.verify_checksum")


### PR DESCRIPTION
## Summary
- `dhub install --agent claude` previously downloaded and extracted the skill, then crashed with a raw `ValueError` when trying to symlink
- Now validates the `--agent` flag **before** any network requests or file I/O
- Uses `difflib.get_close_matches` to suggest similar agent names on typos:
  ```
  Error: Unknown agent 'claude'. Did you mean: 'claude-code'?
  Known agents: adal, amp, antigravity, augment, claude-code, cline, ...
  ```

## Changes
- `client/src/dhub/core/install.py`: Added `validate_agent()` with fuzzy matching via `difflib.get_close_matches`. Updated `link_skill_to_agent` and `unlink_skill_from_agent` to use it.
- `client/src/dhub/cli/registry.py`: Call `validate_agent()` at the top of `_install_single_skill()`, before resolve/download.

Closes #322

## Test plan
- [ ] `dhub install pymc-labs/dhub-cli --agent claude` → fails immediately with suggestion for `claude-code`
- [ ] `dhub install pymc-labs/dhub-cli --agent claude-code` → works as before
- [ ] `dhub install pymc-labs/dhub-cli --agent xyznotreal` → fails with full agent list, no suggestion
- [ ] `dhub install pymc-labs/dhub-cli --agent all` → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)