### PR TITLE
Fix skill title copy-paste inserting line breaks around slash

### DIFF
--- a/frontend/src/pages/SkillDetailPage.module.css
+++ b/frontend/src/pages/SkillDetailPage.module.css
@@ -17,7 +17,6 @@
 .headerTitle {
   display: flex;
   align-items: baseline;
-  gap: 8px;
   margin-bottom: 8px;
   flex-wrap: wrap;
 }
@@ -31,6 +30,7 @@
 .slash {
   font-size: var(--text-lg);
   color: var(--text-muted);
+  padding: 0 2px;
 }
 
 .name {

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -267,9 +267,7 @@ export default function SkillDetailPage() {
         <div className={styles.headerTitle}>
           <Link to={`/orgs/${orgSlug}`} className={styles.org}>
             {orgSlug}
-          </Link>
-          <span className={styles.slash}>/</span>
-          <h1 className={styles.name}>{skillName}</h1>
+          </Link><span className={styles.slash}>/</span><h1 className={styles.name}>{skillName}</h1>
         </div>
         <p className={styles.desc}>{skill.description}</p>
       </div>


### PR DESCRIPTION
## Summary
- Copying the skill page title produced `galaxy-dawn\n/\nskill-development` instead of `galaxy-dawn/skill-development`
- Root cause: flex `gap: 8px` between separate elements made browsers treat each as a block for copy
- Fix: removed the gap, eliminated JSX whitespace between elements, and used inline padding on the slash instead

## Changes
- `SkillDetailPage.tsx`: removed whitespace between org link, slash span, and skill name h1
- `SkillDetailPage.module.css`: replaced `gap: 8px` with `padding: 0 2px` on the slash

Closes #324

## Test plan
- [ ] Select the title on a skill page and Cmd+C / Ctrl+C → should copy as `org/skill` on one line
- [ ] Visual layout should look the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)