### PR TITLE
feat: add org-level blacklist to block banned orgs

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dhub-cli"
-version = "0.12.2"
+version = "0.12.3"
 description = "The AI Skill Manager for Data Science Agents"
 requires-python = ">=3.11"
 license = "MIT"
@@ -23,7 +23,7 @@ dependencies = [
     "rich>=13.0.0",
     "httpx>=0.27.0",
     "pyyaml>=6.0.0",
-    "dhub-core==0.2.9",
+    "dhub-core==0.2.10",
 ]
 
 [project.optional-dependencies]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dhub-cli"
-version = "0.12.1"
+version = "0.12.2"
 description = "The AI Skill Manager for Data Science Agents"
 requires-python = ">=3.11"
 license = "MIT"
@@ -23,7 +23,7 @@ dependencies = [
     "rich>=13.0.0",
     "httpx>=0.27.0",
     "pyyaml>=6.0.0",
-    "dhub-core==0.2.8",
+    "dhub-core==0.2.9",
 ]
 
 [project.optional-dependencies]

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -493,6 +493,10 @@ def publish_skill(
         validate_semver(version)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if org_slug.lower() in settings.blocked_orgs:
+        raise HTTPException(status_code=422, detail=f"Organization '{org_slug}' is blocked")
+
     logger.info(
         "Publishing {}/{} v{} visibility={} by {}", org_slug, skill_name, version, visibility, current_user.username
     )

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from decision_hub.api.deps import get_connection, get_current_user
+from decision_hub.api.deps import get_connection, get_current_user, get_settings
 from decision_hub.domain.tracker import (
     build_canonical_repo_url,
     check_repo_accessible,
@@ -27,6 +27,7 @@ from decision_hub.infra.database import (
     update_skill_tracker,
 )
 from decision_hub.models import User
+from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1/trackers", tags=["trackers"])
 
@@ -133,6 +134,7 @@ def create_tracker(
     body: CreateTrackerRequest,
     conn: Connection = Depends(get_connection),
     user: User = Depends(get_current_user),
+    settings: Settings = Depends(get_settings),
 ) -> TrackerResponse:
     """Create a new tracker for a GitHub repository."""
     # Validate and normalize GitHub URL to a canonical form
@@ -141,6 +143,10 @@ def create_tracker(
         owner, repo = parse_github_repo_url(body.repo_url)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
+
+    if owner.lower() in settings.blocked_orgs:
+        raise HTTPException(status_code=422, detail=f"Organization '{owner}' is blocked")
+
     canonical_url = build_canonical_repo_url(owner, repo)
 
     # Validate branch name (prevents GraphQL injection via string interpolation)

--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -601,6 +601,10 @@ def execute_publish(
         VersionConflictError: If the version already exists and
             *auto_bump_version* is ``False``.
     """
+    # 0. Block publish for blacklisted organizations
+    if org_slug.lower() in settings.blocked_orgs:
+        raise ValueError(f"Organization '{org_slug}' is blocked from publishing")
+
     # 1. Extract files for evaluation
     skill_md_content, source_files, lockfile_content, unscanned_files = extract_for_evaluation(file_bytes)
 

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -710,6 +710,14 @@ def process_tracker(
         github_token = _resolve_github_token(settings)
         owner, repo = parse_github_repo_url(tracker.repo_url)
 
+        if owner.lower() in settings.blocked_orgs:
+            logger.info(
+                "tracker_id={} repo={} status=skipped reason=blocked_org",
+                tracker.id,
+                tracker.repo_url,
+            )
+            return
+
         if known_sha is not None:
             # Caller already verified new commits via batch GraphQL
             current_sha = known_sha

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -142,6 +142,18 @@ class Settings(BaseSettings):
     scan_report_rate_limit: int = 30
     scan_report_rate_window: int = 60
 
+    # Blocked organizations: comma-separated list of GitHub org slugs.
+    # Skills from these orgs are rejected at publish, tracker creation,
+    # and tracker processing time. Used to permanently exclude bad actors.
+    blocked_org_slugs: str = ""
+
+    @property
+    def blocked_orgs(self) -> frozenset[str]:
+        """Parse comma-separated blocked org list into a frozenset of lowercase slugs."""
+        if not self.blocked_org_slugs:
+            return frozenset()
+        return frozenset(o.strip().lower() for o in self.blocked_org_slugs.split(",") if o.strip())
+
     # Logging level (DEBUG, INFO, WARNING, ERROR). Default: INFO.
     log_level: str = "INFO"
     # Logging format: "text" (human-readable, default) or "json" (structured).

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -496,6 +496,32 @@ class TestPublishSkill:
         assert resp.status_code == 422
         assert "Invalid skill name" in resp.json()["detail"]
 
+    def test_publish_blocked_org(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_settings: MagicMock,
+    ) -> None:
+        """Publishing from a blocked org returns 422."""
+        test_settings.google_api_key = "test-key"
+        test_settings.blocked_orgs = frozenset({"blocked-org"})
+        resp = _publish_request(client, auth_headers, org_slug="blocked-org")
+        assert resp.status_code == 422
+        assert "blocked" in resp.json()["detail"].lower()
+
+    def test_publish_blocked_org_case_insensitive(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_settings: MagicMock,
+    ) -> None:
+        """Blocked org check is case-insensitive."""
+        test_settings.google_api_key = "test-key"
+        test_settings.blocked_orgs = frozenset({"blocked-org"})
+        resp = _publish_request(client, auth_headers, org_slug="Blocked-Org")
+        assert resp.status_code == 422
+        assert "blocked" in resp.json()["detail"].lower()
+
     @patch("decision_hub.domain.publish_pipeline.classify_skill_category", return_value="Other & Utilities")
     @patch("decision_hub.domain.publish_pipeline._build_review_code_fn", return_value=None)
     @patch("decision_hub.domain.publish_pipeline._build_review_body_fn", return_value=None)

--- a/server/tests/test_api/test_tracker_routes.py
+++ b/server/tests/test_api/test_tracker_routes.py
@@ -103,6 +103,17 @@ class TestCreateTracker:
         )
         assert resp.status_code == 422
 
+    def test_create_tracker_blocked_org(self, tracker_client, auth_headers, test_settings):
+        """Creating a tracker for a blocked org returns 422."""
+        test_settings.blocked_orgs = frozenset({"blockedowner"})
+        resp = tracker_client.post(
+            "/v1/trackers",
+            headers=auth_headers,
+            json={"repo_url": "https://github.com/BlockedOwner/repo"},
+        )
+        assert resp.status_code == 422
+        assert "blocked" in resp.json()["detail"].lower()
+
     def test_create_tracker_interval_too_low(self, tracker_client, auth_headers):
         resp = tracker_client.post(
             "/v1/trackers",

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -359,6 +359,35 @@ class TestProcessTrackerAllFailed:
             assert kwargs["last_error"] is None
 
 
+class TestProcessTrackerBlockedOrg:
+    """Verify process_tracker silently skips blocked orgs."""
+
+    @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
+    def test_blocked_org_returns_immediately(self, _mock_token):
+        """When the repo owner is blocked, process_tracker returns without cloning or publishing."""
+        tracker = SkillTracker(
+            id=uuid4(),
+            user_id=uuid4(),
+            org_slug="badorg",
+            repo_url="https://github.com/badorg/repo",
+            branch="main",
+            enabled=True,
+            poll_interval_minutes=5,
+            last_commit_sha="some_sha",
+            last_checked_at=None,
+            last_published_at=None,
+            last_error=None,
+            created_at=datetime.now(UTC),
+        )
+        mock_settings = MagicMock()
+        mock_settings.blocked_orgs = frozenset({"badorg"})
+        mock_engine = MagicMock()
+
+        # Should return without touching the engine (no clone, no publish, no DB update)
+        process_tracker(tracker, mock_settings, mock_engine)
+        mock_engine.connect.assert_not_called()
+
+
 class TestProcessTrackerKnownSha:
     """Verify process_tracker skips REST check when known_sha is provided."""
 

--- a/server/tests/test_settings.py
+++ b/server/tests/test_settings.py
@@ -1,0 +1,31 @@
+"""Unit tests for Settings properties."""
+
+from decision_hub.settings import Settings
+
+
+class TestBlockedOrgs:
+    """Verify blocked_orgs property parses the comma-separated slug list."""
+
+    def test_empty_string(self):
+        s = Settings.model_construct(blocked_org_slugs="")
+        assert s.blocked_orgs == frozenset()
+
+    def test_single_org(self):
+        s = Settings.model_construct(blocked_org_slugs="badorg")
+        assert s.blocked_orgs == frozenset({"badorg"})
+
+    def test_multiple_orgs(self):
+        s = Settings.model_construct(blocked_org_slugs="openclaw,steipete")
+        assert s.blocked_orgs == frozenset({"openclaw", "steipete"})
+
+    def test_whitespace_trimmed(self):
+        s = Settings.model_construct(blocked_org_slugs=" openclaw , steipete ")
+        assert s.blocked_orgs == frozenset({"openclaw", "steipete"})
+
+    def test_lowercase_normalized(self):
+        s = Settings.model_construct(blocked_org_slugs="OpenClaw,STEIPETE")
+        assert s.blocked_orgs == frozenset({"openclaw", "steipete"})
+
+    def test_empty_segments_ignored(self):
+        s = Settings.model_construct(blocked_org_slugs="openclaw,,steipete,")
+        assert s.blocked_orgs == frozenset({"openclaw", "steipete"})

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dhub-core"
-version = "0.2.9"
+version = "0.2.10"
 description = "Shared domain models and manifest parsing for Decision Hub"
 authors = [
     { name = "PyMC Labs", email = "info@pymc-labs.com" },

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dhub-core"
-version = "0.2.8"
+version = "0.2.9"
 description = "Shared domain models and manifest parsing for Decision Hub"
 authors = [
     { name = "PyMC Labs", email = "info@pymc-labs.com" },


### PR DESCRIPTION
## Summary

- Adds `BLOCKED_ORG_SLUGS` setting (comma-separated, e.g. `openclaw,steipete`)
- Enforces the block at **four points** (defense in depth):
  1. **Tracker creation** (`POST /v1/trackers`) — returns 422
  2. **Tracker processing** (`process_tracker()`) — silently skips
  3. **Publish API** (`POST /v1/registry/skills`) — returns 422
  4. **Publish pipeline** (`execute_publish()`) — raises ValueError
- Case-insensitive matching via lowercase frozenset

## Context

Both `openclaw` and `steipete` orgs have been **immediately removed from prod** (81 skills, 24,295 versions, 2 trackers, 2 org records deleted). This PR adds the code-level block to prevent re-entry.

## Post-merge action required

After merging and before deploying, add to `server/.env.prod` and `server/.env.dev`:
```
BLOCKED_ORG_SLUGS=openclaw,steipete
```
Then deploy: `make deploy-prod`

Closes #335

## Test plan

- [x] All 909 server tests pass
- [x] Lint passes
- [ ] Verify setting parses correctly with empty/populated values
- [ ] Deploy to dev, attempt to create tracker for blocked org → 422
- [ ] Publish as blocked org → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)