### PR TITLE
feat(#328): add enable_gauntlet flag; gate publish + crawler pipelines

### DIFF
--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -621,26 +621,32 @@ def execute_publish(
     description = extract_description(skill_md_content)
     skill_md_body = extract_body(skill_md_content)
 
-    # 3. Run gauntlet security pipeline
-    report, check_results_dicts, llm_reasoning = run_gauntlet_pipeline(
-        skill_md_content,
-        lockfile_content,
-        source_files,
-        skill_name,
-        description,
-        skill_md_body,
-        settings,
-        allowed_tools=allowed_tools,
-        unscanned_files=unscanned_files,
-    )
-    logger.info(
-        "Gauntlet result for {}/{} v{}: grade={} passed={}",
-        org_slug,
-        skill_name,
-        version,
-        report.grade,
-        report.passed,
-    )
+    # 3. Run gauntlet security pipeline (when enabled)
+    if settings.enable_gauntlet:
+        report, check_results_dicts, llm_reasoning = run_gauntlet_pipeline(
+            skill_md_content,
+            lockfile_content,
+            source_files,
+            skill_name,
+            description,
+            skill_md_body,
+            settings,
+            allowed_tools=allowed_tools,
+            unscanned_files=unscanned_files,
+        )
+        logger.info(
+            "Gauntlet result for {}/{} v{}: grade={} passed={}",
+            org_slug,
+            skill_name,
+            version,
+            report.grade,
+            report.passed,
+        )
+    else:
+        logger.info("Gauntlet disabled — skipping for {}/{} v{}", org_slug, skill_name, version)
+        report = None
+        check_results_dicts = []
+        llm_reasoning = None
 
     # 3b. Run Cisco scanner in parallel (observational only, never blocks publish)
     scan_data: dict | None = None
@@ -651,29 +657,37 @@ def execute_publish(
             scan_data = scan_skill_zip(file_bytes, settings)
         except Exception:
             logger.opt(exception=True).warning(
-                "Cisco scanner failed for {}/{} — continuing with gauntlet only",
+                "Cisco scanner failed for {}/{} — continuing",
                 org_slug,
                 skill_name,
             )
 
-    # 4. Quarantine if rejected
-    if not report.passed:
-        _try_store_scan_result(conn, scan_data, None, org_slug, skill_name, version)
-        quarantine_and_log_rejection(
-            conn,
-            s3_client,
-            settings.s3_bucket,
-            file_bytes,
-            org_slug=org_slug,
-            skill_name=skill_name,
-            version=version,
-            report=report,
-            check_results=check_results_dicts,
-            llm_reasoning=llm_reasoning,
-            publisher=publisher,
-            checksum=checksum,
-        )
-        raise GauntletRejectionError(report.summary)
+    # 4. Quarantine if gauntlet rejected
+    if settings.enable_gauntlet:
+        assert report is not None
+        if not report.passed:
+            _try_store_scan_result(conn, scan_data, None, org_slug, skill_name, version)
+            quarantine_and_log_rejection(
+                conn,
+                s3_client,
+                settings.s3_bucket,
+                file_bytes,
+                org_slug=org_slug,
+                skill_name=skill_name,
+                version=version,
+                report=report,
+                check_results=check_results_dicts,
+                llm_reasoning=llm_reasoning,
+                publisher=publisher,
+                checksum=checksum,
+            )
+            raise GauntletRejectionError(report.summary)
+
+        eval_status = report.grade
+        gauntlet_summary = report.gauntlet_summary
+    else:
+        eval_status = "pending"
+        gauntlet_summary = None
 
     # 5. Classify category (non-critical, graceful fallback)
     category = classify_skill_category(skill_name, description, skill_md_body, settings)
@@ -727,8 +741,8 @@ def execute_publish(
             checksum=checksum,
             runtime_config=runtime_config_dict,
             published_by=publisher,
-            eval_status=report.grade,
-            gauntlet_summary=report.gauntlet_summary,
+            eval_status=eval_status,
+            gauntlet_summary=gauntlet_summary,
         )
     except IntegrityError:
         raise VersionConflictError(org_slug, skill_name, version) from None
@@ -739,7 +753,7 @@ def execute_publish(
         org_slug=org_slug,
         skill_name=skill_name,
         semver=version,
-        grade=report.grade,
+        grade=eval_status,
         check_results=check_results_dicts,
         publisher=publisher,
         version_id=version_record.id,
@@ -800,7 +814,7 @@ def execute_publish(
         skill_name,
         version,
         version_record.id,
-        report.grade,
+        eval_status,
         eval_run_id,
     )
 
@@ -810,7 +824,7 @@ def execute_publish(
         version=version,
         s3_key=s3_key,
         checksum=checksum,
-        eval_status=report.grade,
+        eval_status=eval_status,
         eval_report_status=eval_report_status,
         eval_run_id=eval_run_id,
     )

--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -45,7 +45,7 @@ from decision_hub.infra.database import (
 )
 from decision_hub.infra.embeddings import generate_and_store_skill_embedding
 from decision_hub.infra.storage import upload_skill_zip
-from decision_hub.models import GauntletReport
+from decision_hub.models import GauntletReport, VersionEvalStatus
 from decision_hub.settings import Settings
 
 # ---------------------------------------------------------------------------
@@ -683,7 +683,7 @@ def execute_publish(
             )
             raise GauntletRejectionError(report.summary)
 
-        eval_status = report.grade
+        eval_status: VersionEvalStatus = report.grade
         gauntlet_summary = report.gauntlet_summary
     else:
         eval_status = "pending"

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1524,10 +1524,12 @@ def resolve_version(
     granted = list_granted_skill_ids(conn, user_org_ids) if user_org_ids else None
     base = _apply_visibility_filter(base, user_org_ids, granted)
 
-    # Filter by grade: A/B (and legacy "passed") by default, add C if allow_risky
+    # Filter by grade: A/B (and legacy "passed") by default.
+    # allow_risky adds C (warnings) and "pending" (not yet graded, e.g. when
+    # the gauntlet is disabled).
     allowed_statuses = ["A", "B", "passed"]
     if allow_risky:
-        allowed_statuses.append("C")
+        allowed_statuses.extend(["C", "pending"])
     base = base.where(versions_table.c.eval_status.in_(allowed_statuses))
 
     if spec == "latest":

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2307,6 +2307,10 @@ def get_api_keys_for_eval(conn: Connection, user_id: UUID, key_names: list[str])
 # ---------------------------------------------------------------------------
 
 
+_AUDIT_GRADE_TO_DB = {"pending": "P"}
+_AUDIT_GRADE_FROM_DB = {v: k for k, v in _AUDIT_GRADE_TO_DB.items()}
+
+
 def _row_to_audit_log_entry(row: sa.Row) -> AuditLogEntry:
     """Map a database row to an AuditLogEntry model."""
     return AuditLogEntry(
@@ -2314,7 +2318,7 @@ def _row_to_audit_log_entry(row: sa.Row) -> AuditLogEntry:
         org_slug=row.org_slug,
         skill_name=row.skill_name,
         semver=row.semver,
-        grade=row.grade,
+        grade=_AUDIT_GRADE_FROM_DB.get(row.grade, row.grade),
         version_id=row.version_id,
         check_results=row.check_results,
         llm_reasoning=row.llm_reasoning,
@@ -2347,7 +2351,7 @@ def insert_audit_log(
         org_slug: Organization slug (denormalized).
         skill_name: Skill name (denormalized).
         semver: Version string.
-        grade: A/B/C/F.
+        grade: A/B/C/F/pending (pending is stored as "P" in the DB).
         check_results: Serialized list of EvalResult dicts.
         publisher: GitHub username of the publisher.
         version_id: UUID of the version record (None for F-rejected).
@@ -2362,7 +2366,7 @@ def insert_audit_log(
         "org_slug": org_slug,
         "skill_name": skill_name,
         "semver": semver,
-        "grade": grade,
+        "grade": _AUDIT_GRADE_TO_DB.get(grade, grade),
         "check_results": check_results,
         "publisher": publisher,
     }

--- a/server/src/decision_hub/models.py
+++ b/server/src/decision_hub/models.py
@@ -18,6 +18,7 @@ from dhub_core.models import (  # noqa: F401
 # Status vocabularies — single source of truth for magic strings
 CheckSeverity = Literal["pass", "warn", "fail"]
 SafetyGrade = Literal["A", "B", "C", "F"]
+VersionEvalStatus = Literal["A", "B", "C", "F", "pending"]
 EvalReportStatus = Literal["pending", "completed", "failed", "error"]
 EvalRunStatus = Literal["pending", "provisioning", "running", "judging", "completed", "failed"]
 

--- a/server/src/decision_hub/scripts/crawler/processing.py
+++ b/server/src/decision_hub/scripts/crawler/processing.py
@@ -367,23 +367,35 @@ def _publish_one_skill(
         return prep  # "skipped" or "failed"
 
     # Phase 2: gauntlet pipeline — NO DB connection held
-    from decision_hub.api.registry_service import classify_skill_category, run_gauntlet_pipeline
+    from decision_hub.api.registry_service import classify_skill_category
 
-    report, check_results, llm_reasoning = run_gauntlet_pipeline(
-        prep.skill_md_content,
-        prep.lockfile_content,
-        prep.source_files,
-        prep.name,
-        prep.desc,
-        prep.skill_md_body,
-        settings,
-        allowed_tools=prep.allowed_tools,
-        unscanned_files=prep.unscanned_files,
-    )
+    if settings.enable_gauntlet:
+        from decision_hub.api.registry_service import run_gauntlet_pipeline
+
+        report, check_results, llm_reasoning = run_gauntlet_pipeline(
+            prep.skill_md_content,
+            prep.lockfile_content,
+            prep.source_files,
+            prep.name,
+            prep.desc,
+            prep.skill_md_body,
+            settings,
+            allowed_tools=prep.allowed_tools,
+            unscanned_files=prep.unscanned_files,
+        )
+        gauntlet_passed = report.passed
+        eval_status = report.grade
+        gauntlet_summary = report.gauntlet_summary
+    else:
+        check_results = []
+        llm_reasoning = None
+        gauntlet_passed = True
+        eval_status = "pending"
+        gauntlet_summary = None
 
     # Category classification only for passing skills (also hits Gemini API)
     category = ""
-    if report.passed:
+    if gauntlet_passed:
         category = classify_skill_category(prep.name, prep.desc, prep.skill_md_body, settings)
 
     # Phase 3: write results — DB writes + S3 upload (short connection)
@@ -394,10 +406,12 @@ def _publish_one_skill(
             settings,
             org,
             prep,
-            report,
-            check_results,
-            llm_reasoning,
-            category,
+            gauntlet_passed=gauntlet_passed,
+            eval_status=eval_status,
+            gauntlet_summary=gauntlet_summary,
+            check_results=check_results,
+            llm_reasoning=llm_reasoning,
+            category=category,
             bot_user_id=bot_user_id,
             set_tracker=set_tracker,
             source_repo_url=source_repo_url,
@@ -494,11 +508,13 @@ def _finalize_skill(
     settings,
     org,
     prep: _SkillPrep,
-    report,
-    check_results,
-    llm_reasoning,
-    category: str,
     *,
+    gauntlet_passed: bool,
+    eval_status: str,
+    gauntlet_summary: str | None,
+    check_results: list,
+    llm_reasoning: dict | None,
+    category: str,
     bot_user_id: UUID | None = None,
     set_tracker: bool = False,
     source_repo_url: str | None = None,
@@ -511,15 +527,14 @@ def _finalize_skill(
     )
     from decision_hub.infra.storage import upload_skill_zip
 
-    if not report.passed:
-        # Grade F — quarantine
+    if not gauntlet_passed:
         q_key = build_quarantine_s3_key(org.slug, prep.name, prep.version)
         insert_audit_log(
             conn,
             org_slug=org.slug,
             skill_name=prep.name,
             semver=prep.version,
-            grade=report.grade,
+            grade=eval_status,
             check_results=check_results,
             publisher=BOT_USERNAME,
             version_id=None,
@@ -530,10 +545,8 @@ def _finalize_skill(
         upload_skill_zip(s3_client, settings.s3_bucket, q_key, prep.zip_data)
         return "quarantined"
 
-    # Grade A/B/C — publish
     update_skill_category(conn, prep.skill_id, category)
 
-    # Generate embedding (fail-open: never blocks publish)
     from decision_hub.infra.embeddings import generate_and_store_skill_embedding
 
     generate_and_store_skill_embedding(conn, prep.skill_id, prep.name, org.slug, category, prep.description, settings)
@@ -549,12 +562,10 @@ def _finalize_skill(
             checksum=prep.checksum,
             runtime_config=None,
             published_by=BOT_USERNAME,
-            eval_status=report.grade,
-            gauntlet_summary=report.gauntlet_summary,
+            eval_status=eval_status,
+            gauntlet_summary=gauntlet_summary,
         )
     except sqlalchemy.exc.IntegrityError:
-        # Race condition: tracker or concurrent crawler already published
-        # this version between our checksum check and insert.
         raise VersionConflictError(
             org.slug,
             prep.name,
@@ -565,7 +576,7 @@ def _finalize_skill(
         org_slug=org.slug,
         skill_name=prep.name,
         semver=prep.version,
-        grade=report.grade,
+        grade=eval_status,
         check_results=check_results,
         publisher=BOT_USERNAME,
         version_id=version_record.id,

--- a/server/src/decision_hub/scripts/crawler/processing.py
+++ b/server/src/decision_hub/scripts/crawler/processing.py
@@ -36,6 +36,7 @@ from decision_hub.domain.repo_utils import (
     discover_skills,
 )
 from decision_hub.domain.skill_manifest import extract_body, extract_description
+from decision_hub.models import VersionEvalStatus
 from dhub_core.validation import _SLUG_PATTERN
 
 CLONE_TIMEOUT_SECONDS = 120
@@ -384,7 +385,7 @@ def _publish_one_skill(
             unscanned_files=prep.unscanned_files,
         )
         gauntlet_passed = report.passed
-        eval_status = report.grade
+        eval_status: VersionEvalStatus = report.grade
         gauntlet_summary = report.gauntlet_summary
     else:
         check_results = []

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -124,6 +124,10 @@ class Settings(BaseSettings):
     # Set to 0 to disable (always re-evaluate).
     tracker_quarantine_skip_hours: int = 24
 
+    # Gauntlet safety pipeline. When disabled, publish and crawler skip the
+    # Gauntlet entirely and store versions with eval_status="pending".
+    enable_gauntlet: bool = True
+
     # Cache TTLs (seconds) for hot read paths. Set to 0 to disable.
     cache_ttl_taxonomy: int = 300  # taxonomy is static — 5 min
     cache_ttl_org_profiles: int = 60  # org profile listings

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -210,6 +210,8 @@ class TestPublishSkill:
         assert data["eval_status"] == "pending"
         mock_insert_version.assert_called_once()
         assert mock_insert_version.call_args.kwargs["eval_status"] == "pending"
+        mock_insert_audit.assert_called_once()
+        assert mock_insert_audit.call_args.kwargs["grade"] == "pending"
 
     @patch("decision_hub.api.registry_service.find_org_by_slug")
     def test_publish_org_not_found(

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -159,6 +159,58 @@ class TestPublishSkill:
         # Audit log inserted for successful publish
         mock_insert_audit.assert_called_once()
 
+    @patch("decision_hub.domain.publish_pipeline.classify_skill_category", return_value="Other & Utilities")
+    @patch("decision_hub.domain.publish_pipeline.insert_audit_log")
+    @patch("decision_hub.domain.publish_pipeline.update_skill_category")
+    @patch("decision_hub.domain.publish_pipeline.update_skill_description")
+    @patch("decision_hub.domain.publish_pipeline.insert_version")
+    @patch("decision_hub.domain.publish_pipeline.find_version")
+    @patch("decision_hub.domain.publish_pipeline.find_skill")
+    @patch("decision_hub.domain.publish_pipeline.upload_skill_zip")
+    @patch("decision_hub.api.registry_routes.compute_checksum")
+    @patch("decision_hub.api.registry_service.find_org_member")
+    @patch("decision_hub.api.registry_service.find_org_by_slug")
+    def test_publish_skips_gauntlet_when_disabled(
+        self,
+        mock_find_org: MagicMock,
+        mock_find_member: MagicMock,
+        mock_checksum: MagicMock,
+        mock_upload: MagicMock,
+        mock_find_skill: MagicMock,
+        mock_find_version: MagicMock,
+        mock_insert_version: MagicMock,
+        mock_update_desc: MagicMock,
+        mock_update_cat: MagicMock,
+        mock_insert_audit: MagicMock,
+        _mock_classify: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        sample_user_id: UUID,
+        test_settings: MagicMock,
+    ) -> None:
+        """When enable_gauntlet=False, publish skips the gauntlet and stores eval_status='pending'."""
+        test_settings.google_api_key = "test-key"
+        test_settings.enable_gauntlet = False
+        org = _make_org(sample_user_id)
+        skill = _make_skill(org)
+        version = _make_version(skill, eval_status="pending")
+
+        mock_find_org.return_value = org
+        mock_find_member.return_value = _make_member(org, sample_user_id)
+        mock_checksum.return_value = "abc123def456"
+        mock_find_skill.return_value = skill
+        mock_find_version.return_value = None
+        mock_insert_version.return_value = version
+
+        zip_bytes = _make_skill_zip()
+        resp = _publish_request(client, auth_headers, zip_bytes=zip_bytes)
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["eval_status"] == "pending"
+        mock_insert_version.assert_called_once()
+        assert mock_insert_version.call_args.kwargs["eval_status"] == "pending"
+
     @patch("decision_hub.api.registry_service.find_org_by_slug")
     def test_publish_org_not_found(
         self,

--- a/server/tests/test_infra/test_audit_grade_mapping.py
+++ b/server/tests/test_infra/test_audit_grade_mapping.py
@@ -1,0 +1,19 @@
+"""Tests for audit log grade ↔ DB mapping (VARCHAR(1) constraint)."""
+
+from decision_hub.infra.database import _AUDIT_GRADE_FROM_DB, _AUDIT_GRADE_TO_DB
+
+
+class TestAuditGradeMapping:
+    def test_pending_maps_to_single_char(self):
+        assert _AUDIT_GRADE_TO_DB["pending"] == "P"
+        assert len(_AUDIT_GRADE_TO_DB["pending"]) == 1
+
+    def test_roundtrip_pending(self):
+        db_val = _AUDIT_GRADE_TO_DB.get("pending", "pending")
+        app_val = _AUDIT_GRADE_FROM_DB.get(db_val, db_val)
+        assert app_val == "pending"
+
+    def test_standard_grades_pass_through(self):
+        for grade in ("A", "B", "C", "F"):
+            assert _AUDIT_GRADE_TO_DB.get(grade, grade) == grade
+            assert _AUDIT_GRADE_FROM_DB.get(grade, grade) == grade

--- a/server/tests/test_scripts/test_crawler_processing.py
+++ b/server/tests/test_scripts/test_crawler_processing.py
@@ -333,6 +333,41 @@ class TestPublishOneSkillReturnsStatus:
         )
         assert status == "failed"
 
+    def test_publishes_without_gauntlet_when_disabled(self, mock_skill_deps, tmp_path):
+        """When enable_gauntlet=False, skips Gauntlet and publishes with eval_status='pending'."""
+        engine = _make_engine_mock()
+        org = make_org()
+
+        skill_mock = MagicMock()
+        skill_mock.id = uuid4()
+        skill_mock.source_repo_url = None
+        mock_skill_deps["find_skill"].return_value = skill_mock
+        mock_skill_deps["resolve_latest_version"].return_value = None
+        mock_skill_deps["find_version"].return_value = None
+        mock_skill_deps["classify_skill_category"].return_value = "devops"
+        mock_skill_deps["insert_version"].return_value = MagicMock(id=uuid4())
+
+        settings = MagicMock()
+        settings.enable_gauntlet = False
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Test Skill\nA test skill")
+
+        status = _publish_one_skill(
+            engine,
+            MagicMock(),
+            settings,
+            org,
+            skill_dir,
+        )
+        assert status == "published"
+        mock_skill_deps["run_gauntlet_pipeline"].assert_not_called()
+        mock_skill_deps["insert_version"].assert_called_once()
+        call_kwargs = mock_skill_deps["insert_version"].call_args
+        actual = call_kwargs.kwargs.get("eval_status") or call_kwargs[1].get("eval_status")
+        assert actual == "pending"
+
 
 # ---------------------------------------------------------------------------
 # Parallel processing result collection


### PR DESCRIPTION
## What this does

Adds the off-switch for the Gauntlet. Today the Gauntlet is hardwired into `execute_publish()` and the crawler's `_finalize_skill()` — every published version runs it, and `eval_status` comes directly from the Gauntlet's A/B/C/F verdict. With this PR, setting `enable_gauntlet=False` skips the Gauntlet entirely and publishes the version with `eval_status="pending"` instead. Default is `True` — `main` behavior is unchanged until someone flips the flag.

## Why now

The Cisco scanner is already deployed in dev (#307) and running alongside the Gauntlet. To decide whether Cisco can replace the Gauntlet we need to run #329's validation batch in a state where Cisco is the only safety signal — otherwise we're just measuring Cisco on top of Gauntlet. This PR lets us do that by flipping `ENABLE_GAUNTLET=false` in `server/.env.dev` without touching `main`.

Once #329 concludes and Luca signs off on Cisco, the retirement is two concrete steps:

1. Flip `ENABLE_GAUNTLET=false` in `server/.env.prod`, redeploy.
2. Delete the Gauntlet code paths gated by this flag.

Doing both in one PR would have to touch the publish pipeline, crawler, DB, search index, CLI, frontend, and the Gemini prompt (see #328's touchpoint list) — too much to land and roll back safely. The flag is the seam that makes step 1 independent of step 2.

## What's in here

- `enable_gauntlet: bool = True` setting.
- `execute_publish()` and `_finalize_skill()` branch on the flag. Disabled path: skip `run_gauntlet_pipeline()`, skip quarantine, store `eval_status="pending"`, `gauntlet_summary=None`.
- `VersionEvalStatus = Literal["A", "B", "C", "F", "pending"]` so mypy accepts the new branch. `SafetyGrade` stays narrow — it's still what the Gauntlet actually produces.
- `eval_audit_logs.grade` is `VARCHAR(1)`, so `"pending" ↔ "P"` is mapped at the `insert_audit_log` / `_row_to_audit_log_entry` boundary. Everything above the infra layer keeps seeing `"pending"`.
- `resolve_version(..., allow_risky=True)` accepts `"pending"` alongside `"C"`, so ungraded versions are installable via `--allow-risky` rather than being orphaned.
- Tests: crawler skip path, publish skip path (including audit-log assertion), `"pending" ↔ "P"` round-trip.

Downstream read paths (`format_trust_score`, safety filter, copy-install command, frontend badge) are in #342 — intentionally split to keep this PR to just the gate.

## Test plan

- [x] CI green (ruff, ruff format, mypy, server tests)
- [x] `enable_gauntlet=True` (default): publish flow unchanged against existing fixtures
- [x] `enable_gauntlet=False`: publish writes `eval_status="pending"`, audit log stores `"P"`, `run_gauntlet_pipeline` is not called
- [x] Crawler skip path with `enable_gauntlet=False`
- [x] Audit grade round-trip (`test_audit_grade_mapping.py`)
- [ ] Dev-only validation: deploy with `ENABLE_GAUNTLET=false` and confirm #329's validation batch runs clean

Part of #328.