### PR TITLE
feat(#328): surface "pending" eval_status distinctly in read paths and UI

### DIFF
--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -177,7 +177,8 @@ export default function SkillDetailPage() {
     setZipLoading(true);
     setZipError(null);
     try {
-      const allowRisky = skill?.safety_rating === "C";
+      const rating = skill?.safety_rating;
+      const allowRisky = rating === "C" || rating === "pending";
       const buf = await downloadSkillZip(orgSlug, skillName, "latest", allowRisky);
       const zip = await JSZip.loadAsync(buf);
 
@@ -226,7 +227,8 @@ export default function SkillDetailPage() {
     if (!orgSlug || !skillName) return;
     setDownloading(true);
     try {
-      const allowRisky = skill?.safety_rating === "C";
+      const rating = skill?.safety_rating;
+      const allowRisky = rating === "C" || rating === "pending";
       const zipData = await downloadSkillZip(orgSlug, skillName, "latest", allowRisky);
       const blob = new Blob([zipData], { type: "application/zip" });
       saveAs(blob, `${orgSlug}-${skillName}.zip`);

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -143,7 +143,7 @@ export default function SkillDetailPage() {
 
   const seoTitle = `${orgSlug}/${skillName}`;
   const seoDescription = skill
-    ? `${skill.description} — Safety grade: ${skill.safety_rating}, v${skill.latest_version}. Install with: dhub install ${orgSlug}/${skillName}`
+    ? `${skill.description} — Safety grade: ${skill.safety_rating}, v${skill.latest_version}. Install with: dhub install ${orgSlug}/${skillName}${skill.safety_rating === "C" || skill.safety_rating === "pending" ? " --allow-risky" : ""}`
     : `View the ${orgSlug}/${skillName} skill on Decision Hub.`;
   const jsonLd = useMemo(
     () =>
@@ -240,7 +240,12 @@ export default function SkillDetailPage() {
   };
 
   const handleCopyInstall = () => {
-    navigator.clipboard.writeText(`dhub install ${orgSlug}/${skillName} --agent all`);
+    const rating = skill?.safety_rating;
+    const risky = rating === "C" || rating === "pending";
+    const cmd = risky
+      ? `dhub install ${orgSlug}/${skillName} --allow-risky --agent all`
+      : `dhub install ${orgSlug}/${skillName} --agent all`;
+    navigator.clipboard.writeText(cmd);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/server/src/decision_hub/domain/search.py
+++ b/server/src/decision_hub/domain/search.py
@@ -77,7 +77,8 @@ def resolve_author_display(published_by: str) -> str:
 def format_trust_score(eval_status: str) -> str:
     """Map an evaluation status to a human-readable trust grade.
 
-    Handles both new A/B/C/F grades and legacy passed/pending/failed values.
+    Handles both new A/B/C/F grades, legacy passed/failed values, and
+    the "pending" state used when the gauntlet is disabled.
     """
     scores = {
         "A": "A",
@@ -85,7 +86,7 @@ def format_trust_score(eval_status: str) -> str:
         "C": "C",
         "F": "F",
         "passed": "A",
-        "pending": "C",
+        "pending": "pending",
         "failed": "F",
     }
     return scores.get(eval_status, "?")

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1768,7 +1768,7 @@ def _build_skills_filters(
         grade_statuses = {
             "A": ["A", "passed"],
             "B": ["B"],
-            "C": ["C"],
+            "C": ["C", "pending"],
         }
         statuses = grade_statuses.get(grade, [grade])
         base = base.where(skills_table.c.latest_eval_status.in_(statuses))
@@ -1873,9 +1873,10 @@ def fetch_all_skills_for_index(
             (col.in_(["A", "passed"]), 1),
             (col == "B", 2),
             (col == "C", 3),
-            (col == "D", 4),
-            (col == "F", 5),
-            else_=6,
+            (col == "pending", 4),
+            (col == "D", 5),
+            (col == "F", 6),
+            else_=7,
         )
         base = base.order_by(
             is_unrated.asc(),

--- a/server/tests/test_domain/test_docx_skill_integration.py
+++ b/server/tests/test_domain/test_docx_skill_integration.py
@@ -171,4 +171,4 @@ class TestSearchIndexEntry:
             latest_version="0.1.0",
             eval_status="pending",
         )
-        assert entry.trust_score == "C"
+        assert entry.trust_score == "pending"

--- a/server/tests/test_domain/test_search.py
+++ b/server/tests/test_domain/test_search.py
@@ -12,7 +12,7 @@ def test_format_trust_score_passed():
 
 
 def test_format_trust_score_pending():
-    assert format_trust_score("pending") == "C"
+    assert format_trust_score("pending") == "pending"
 
 
 def test_format_trust_score_failed():


### PR DESCRIPTION
## What this does

Teaches the server and frontend to distinguish `eval_status = "pending"` from `"C"` in read paths and UI.

## Why now

Once `ENABLE_GAUNTLET=false` is flipped in dev (to run #329's Cisco validation in isolation), every newly-published skill lands with `eval_status = "pending"`. Without this PR:

- `format_trust_score("pending")` returns `"C"` — the `GradeBadge` shows a fake **C (risky)** for skills that are simply ungraded.
- The copy-install button suggests `dhub install … --allow-risky` for those same skills, prompting users to opt into risk for something that was never evaluated.
- The skills-page grade filter silently drops `"pending"` skills from the `"C"` bucket.

That makes dev look broken to anyone evaluating Cisco, and it's also the state `prod` will be in the moment `ENABLE_GAUNTLET=false` is flipped there (step 1 of #337's retirement path). This PR is what makes both cutovers legible.

Independent of #337: before #337 lands, no new versions get `"pending"`, so these code paths are exercised only for the handful of legacy `pending` rows that already exist in the DB (where they previously rendered as a fake `C` too — this PR fixes that too).

## Changes

### Server (`342172e`)

- `format_trust_score("pending") → "pending"` (was silently mapped to `"C"`).
- Skills grade filter: `grade="C"` now matches `["C", "pending"]` so filtered views don't drop ungraded skills.
- Skills safety sort: `"pending"` ranks between `C` and `D` instead of landing in the unrated bucket.
- `test_domain/test_search.py` and `test_domain/test_docx_skill_integration.py`: assertions updated to match the new mapping.

### Frontend (`5593b62`, `ff620ee`) — `SkillDetailPage.tsx`

- `allowRisky` for the ZIP preview and download paths accepts `safety_rating === "pending"` alongside `"C"`. Without this a pending-latest skill resolves without `allow_risky` and either fetches a stale version or 404s.
- `handleCopyInstall` and the SEO `<meta description>` emit `dhub install … --allow-risky` when the page is showing a pending or C skill. The old output copied a command that would resolve a different (older) version or 404.

## Test plan

- [x] CI green (ruff, ruff format, server + frontend tests)
- [x] `test_search.py` and `test_docx_skill_integration.py` assert the new `"pending"` mapping
- [ ] Dev-only: once #337 is deployed with the flag flipped, visit a pending skill and confirm badge, copy-install text, and download all behave

Part of #328.