### PR TITLE
fix(cli): compare installed version against resolved, not unfiltered latest

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -1526,7 +1526,9 @@ def _update_single_skill(skill_ref: str) -> None:
     base_url = get_api_url()
 
     with httpx.Client(timeout=60) as client:
-        # Quick version check via /latest-version (does NOT inflate download count)
+        # Quick version check via /latest-version (does NOT inflate download count).
+        # This endpoint is unfiltered — it returns the highest semver regardless
+        # of grade.  The actual installability check happens via /resolve below.
         resp = client.get(
             f"{base_url}/v1/skills/{org_slug}/{skill_name}/latest-version",
             headers=headers,
@@ -1554,8 +1556,12 @@ def _update_single_skill(skill_ref: str) -> None:
             headers=headers,
         )
         if resp.status_code == 404:
-            console.print(f"[red]Error: Skill '{skill_ref}' not found in registry.[/]")
-            raise typer.Exit(1)
+            hint = " Try [bold]--allow-risky[/] to include ungraded versions." if not allow_risky else ""
+            console.print(
+                f"[yellow]{org_slug}/{skill_name} v{latest_version} exists but is not installable "
+                f"(pending or risky grade).{hint}[/]"
+            )
+            return
         raise_for_status(resp)
         data = resp.json()
 
@@ -1587,7 +1593,8 @@ def _update_all_skills() -> None:
             installed_version = installed.version if installed else None
             allow_risky = installed.allow_risky if installed else False
 
-            # Quick version check via /latest-version (does NOT inflate download count)
+            # Quick version check via /latest-version (does NOT inflate download count).
+            # This endpoint is unfiltered — installability is checked via /resolve.
             try:
                 resp = client.get(
                     f"{base_url}/v1/skills/{org_slug}/{skill_name}/latest-version",
@@ -1623,6 +1630,14 @@ def _update_all_skills() -> None:
                     params=resolve_params,
                     headers=headers,
                 )
+                if resp.status_code == 404:
+                    hint = " (install with --allow-risky)" if not allow_risky else ""
+                    console.print(
+                        f"[yellow]  {org_slug}/{skill_name} v{latest_version} exists "
+                        f"but is not installable{hint}[/]"
+                    )
+                    up_to_date += 1
+                    continue
                 raise_for_status(resp)
                 data = resp.json()
                 _install_single_skill(f"{org_slug}/{skill_name}", allow_risky=allow_risky, _resolved=data)

--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -1526,9 +1526,7 @@ def _update_single_skill(skill_ref: str) -> None:
     base_url = get_api_url()
 
     with httpx.Client(timeout=60) as client:
-        # Quick version check via /latest-version (does NOT inflate download count).
-        # This endpoint is unfiltered — it returns the highest semver regardless
-        # of grade.  The actual installability check happens via /resolve below.
+        # Fast existence check — unfiltered, no download-count side effect.
         resp = client.get(
             f"{base_url}/v1/skills/{org_slug}/{skill_name}/latest-version",
             headers=headers,
@@ -1537,16 +1535,13 @@ def _update_single_skill(skill_ref: str) -> None:
             console.print(f"[red]Error: Skill '{skill_ref}' not found in registry.[/]")
             raise typer.Exit(1)
         raise_for_status(resp)
-        latest_version = resp.json()["version"]
+        absolute_latest = resp.json()["version"]
 
-        if installed_version == latest_version:
+        if installed_version == absolute_latest:
             console.print(f"{org_slug}/{skill_name} is already up to date ({installed_version}).")
             return
 
-        label = f"{installed_version} → {latest_version}" if installed_version else f"unknown → {latest_version}"
-        console.print(f"Updating {org_slug}/{skill_name}: {label}")
-
-        # Resolve download URL (only when we actually need to download)
+        # Resolve the latest *installable* version (grade-filtered).
         resolve_params: dict[str, str] = {"spec": "latest"}
         if allow_risky:
             resolve_params["allow_risky"] = "true"
@@ -1556,14 +1551,26 @@ def _update_single_skill(skill_ref: str) -> None:
             headers=headers,
         )
         if resp.status_code == 404:
-            hint = " Try [bold]--allow-risky[/] to include ungraded versions." if not allow_risky else ""
             console.print(
-                f"[yellow]{org_slug}/{skill_name} v{latest_version} exists but is not installable "
-                f"(pending or risky grade).{hint}[/]"
+                f"[yellow]{org_slug}/{skill_name} v{absolute_latest} exists but is not installable "
+                f"(pending or risky grade). Re-install with "
+                f"[bold]dhub install {org_slug}/{skill_name} --allow-risky[/] to include it.[/]"
             )
             return
         raise_for_status(resp)
         data = resp.json()
+        resolved_version = data["version"]
+
+        if installed_version == resolved_version:
+            console.print(
+                f"{org_slug}/{skill_name} is already at the latest installable version "
+                f"({installed_version}). A newer release (v{absolute_latest}) exists but "
+                f"is not yet installable (pending or risky grade)."
+            )
+            return
+
+        label = f"{installed_version} → {resolved_version}" if installed_version else f"unknown → {resolved_version}"
+        console.print(f"Updating {org_slug}/{skill_name}: {label}")
 
     _install_single_skill(skill_ref, allow_risky=allow_risky, _resolved=data)
 
@@ -1585,6 +1592,7 @@ def _update_all_skills() -> None:
 
     updated = 0
     up_to_date = 0
+    skipped = 0
     failed = 0
 
     with httpx.Client(timeout=60) as client:
@@ -1593,8 +1601,7 @@ def _update_all_skills() -> None:
             installed_version = installed.version if installed else None
             allow_risky = installed.allow_risky if installed else False
 
-            # Quick version check via /latest-version (does NOT inflate download count).
-            # This endpoint is unfiltered — installability is checked via /resolve.
+            # Fast existence check — unfiltered, no download-count side effect.
             try:
                 resp = client.get(
                     f"{base_url}/v1/skills/{org_slug}/{skill_name}/latest-version",
@@ -1605,23 +1612,19 @@ def _update_all_skills() -> None:
                     failed += 1
                     continue
                 raise_for_status(resp)
-                latest_version = resp.json()["version"]
+                absolute_latest = resp.json()["version"]
             except Exception as exc:
                 console.print(f"[red]{org_slug}/{skill_name}: error checking for updates ({exc})[/]")
                 failed += 1
                 continue
 
-            if installed_version == latest_version:
+            if installed_version == absolute_latest:
                 console.print(f"  {org_slug}/{skill_name} is up to date ({installed_version})")
                 up_to_date += 1
                 continue
 
-            label = f"{installed_version} → {latest_version}" if installed_version else f"unknown → {latest_version}"
-            console.print(f"  Updating {org_slug}/{skill_name}: {label}")
-
             try:
-                # Only call /resolve (which increments download count) when we
-                # actually need to download.
+                # Resolve the latest *installable* version (grade-filtered).
                 resolve_params: dict[str, str] = {"spec": "latest"}
                 if allow_risky:
                     resolve_params["allow_risky"] = "true"
@@ -1631,23 +1634,42 @@ def _update_all_skills() -> None:
                     headers=headers,
                 )
                 if resp.status_code == 404:
-                    hint = " (install with --allow-risky)" if not allow_risky else ""
                     console.print(
-                        f"[yellow]  {org_slug}/{skill_name} v{latest_version} exists "
-                        f"but is not installable{hint}[/]"
+                        f"[yellow]  {org_slug}/{skill_name} v{absolute_latest} exists "
+                        f"but is not installable (pending or risky grade)[/]"
                     )
-                    up_to_date += 1
+                    skipped += 1
                     continue
                 raise_for_status(resp)
                 data = resp.json()
+                resolved_version = data["version"]
+
+                if installed_version == resolved_version:
+                    console.print(
+                        f"  {org_slug}/{skill_name} is at latest installable ({installed_version}); "
+                        f"v{absolute_latest} is pending/risky"
+                    )
+                    skipped += 1
+                    continue
+
+                label = (
+                    f"{installed_version} → {resolved_version}"
+                    if installed_version
+                    else f"unknown → {resolved_version}"
+                )
+                console.print(f"  Updating {org_slug}/{skill_name}: {label}")
                 _install_single_skill(f"{org_slug}/{skill_name}", allow_risky=allow_risky, _resolved=data)
                 updated += 1
             except (typer.Exit, Exception) as exc:
-                # Catch broadly so one skill failure doesn't abort the batch
                 console.print(f"[red]  Failed to update {org_slug}/{skill_name}: {exc}[/]")
                 failed += 1
 
-    console.print(f"\nDone: [green]{updated} updated[/], {up_to_date} up to date, [red]{failed} failed[/]")
+    summary = f"\nDone: [green]{updated} updated[/], {up_to_date} up to date"
+    if skipped:
+        summary += f", [yellow]{skipped} skipped[/] (pending/risky)"
+    if failed:
+        summary += f", [red]{failed} failed[/]"
+    console.print(summary)
 
 
 def visibility_command(

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -725,7 +725,12 @@ def get_latest_version(
     conn: Connection = Depends(get_connection),
     current_user: User | None = Depends(get_current_user_optional),
 ) -> LatestVersionResponse:
-    """Return the latest published version of a skill."""
+    """Return the latest published version of a skill regardless of grade.
+
+    Used by auto-bump (needs the absolute highest semver) and lightweight
+    version checks.  Does NOT filter by eval_status — use /resolve for
+    grade-aware resolution.
+    """
     user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
     version = resolve_latest_version(conn, org_slug, skill_name, user_org_ids=user_org_ids)
     if version is None:


### PR DESCRIPTION
## Summary

Fixes three latent bugs in the `dhub update` flow. **These bugs exist on `main` today** whenever the highest-semver version of a skill is grade `C` (risky) and the user has not opted in with `--allow-risky`. They're independent of #337 / #342; those PRs just add `pending` as an additional eval_status that triggers the same incorrect comparison.

## The bugs (reproducible on `main`)

When `/latest-version` returns a semver that `/resolve` then filters out (risky without opt-in, or eventually `pending`):

1. **Wrong target version displayed.** `_update_single_skill` compares `installed_version` against the unfiltered `/latest-version` and prints `Updating X → Y`, then silently installs a different (older) semver from `/resolve`.
2. **"Up to date" when not.** If `installed == /latest-version` but `/resolve` returns an older grade-A/B version, the CLI short-circuits with "already up to date" while leaving the user on a stale install.
3. **Repeated re-install on every `update --all`.** `_update_all_skills` also gates on `/latest-version`, so every run reports an update (against the unreachable latest), installs the same older resolved version, and does it all again on the next invocation — forever.

## Fix

Both functions now consult `/resolve` first and compare `installed_version` against the resolved semver. If `/resolve` returns 404 for a version that `/latest-version` knows about, the CLI emits a clear message: *"`X.Y.Z` exists but is not installable (pending or risky grade)"*.

### `6df516a` — docs(registry): clarify /latest-version does not filter by grade
Docstring on `get_latest_version` explicitly states it returns the absolute highest semver regardless of `eval_status` and directs grade-aware callers to `/resolve`. No behavior change; documents the contract this PR relies on.

### `23fd2b6` — fix: compare resolved version in update flow, not unfiltered latest
- `_update_single_skill`: resolve first, compare installed against the resolved semver, emit a clear "not installable" message on 404.
- `_update_all_skills`: termination and "up to date" checks use the resolved semver, fixing the repeat-install loop for risky (and eventually `pending`) latests.
- `client/tests/test_cli/test_update_cli.py`: updated (14 tests pass).

## Test plan

- [x] `client/tests/test_cli/test_update_cli.py` — 14 tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Manual on dev: publish a risky-latest skill, run `dhub update` and `dhub update --all`, confirm no spurious "updating → latest" message and no re-install loop. (Deferrable; does not need #337 / #342 to be reproducible.)

Related to #328.