### PR TITLE
fix: correctness fixes for tracker errors, LIMIT ordering, and zombie races

### DIFF
--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -58,9 +58,9 @@ from decision_hub.infra.database import (
     list_granted_skill_ids,
     list_skill_access_grants_with_names,
     list_user_org_ids,
+    mark_eval_run_failed_if_stale,
     resolve_latest_version,
     resolve_version,
-    update_eval_run_status,
     update_skill_visibility,
 )
 from decision_hub.infra.database import (
@@ -1100,8 +1100,13 @@ def _run_to_response(run) -> EvalRunResponse:
 def _check_zombie(conn: Connection, run) -> str:
     """Check if a running eval run has a stale heartbeat (zombie).
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, atomically
+    marks the run as failed (gated on the heartbeat not moving in the
+    meantime) and returns "failed". Otherwise returns run.status.
+
+    The UPDATE is conditional on ``heartbeat_at`` still equalling the
+    value we observed, so a live worker emitting a fresh heartbeat
+    between the read and the write is not clobbered.
     """
     if run.status not in ("running", "judging", "provisioning"):
         return run.status
@@ -1109,14 +1114,15 @@ def _check_zombie(conn: Connection, run) -> str:
         return run.status
     elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
     if elapsed > _STALE_HEARTBEAT_SECONDS:
-        update_eval_run_status(
+        marked = mark_eval_run_failed_if_stale(
             conn,
             run.id,
-            status="failed",
+            observed_heartbeat_at=run.heartbeat_at,
             error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
             completed_at=datetime.now(UTC),
         )
-        return "failed"
+        if marked:
+            return "failed"
     return run.status
 
 

--- a/server/src/decision_hub/domain/repo_utils.py
+++ b/server/src/decision_hub/domain/repo_utils.py
@@ -68,22 +68,28 @@ def clone_repo(
     return tmp_dir / "repo"
 
 
-def discover_skills(root: Path) -> list[Path]:
-    """Find skill directories (containing valid SKILL.md) under a root path.
+def discover_skills_with_names(root: Path) -> list[tuple[str, Path]]:
+    """Find skill directories with their parsed manifest names.
 
-    Skips hidden directories, node_modules, and __pycache__.
-    Only includes directories where SKILL.md parses successfully.
+    Returns ``(skill_name, directory_path)`` pairs.  Skips hidden
+    directories, node_modules, and __pycache__.  Only includes directories
+    where SKILL.md parses successfully.
 
     When multiple SKILL.md files declare the same skill name, only the
     shallowest one is kept (sorted() + rglob guarantee breadth-first order).
-    This prevents the same skill from being zipped from different directories,
-    which would produce different checksums and bypass quarantine dedup.
+    This prevents the same skill from being zipped from different
+    directories, which would produce different checksums and bypass
+    quarantine dedup.
+
+    Exposing the name here lets callers avoid re-parsing SKILL.md (the
+    tracker used to parse every file a second time just to extract the
+    skill name for removal detection).
     """
     import yaml
 
     from decision_hub.domain.skill_manifest import parse_skill_md
 
-    seen_names: dict[str, Path] = {}
+    seen: dict[str, Path] = {}
     # Sort by depth (fewest path components first) then alphabetically,
     # so the shallowest SKILL.md wins when names collide.
     candidates = sorted(root.rglob("SKILL.md"), key=lambda p: (len(p.relative_to(root).parts), p))
@@ -95,9 +101,19 @@ def discover_skills(root: Path) -> list[Path]:
             manifest = parse_skill_md(skill_md)
         except (ValueError, FileNotFoundError, yaml.YAMLError):
             continue
-        if manifest.name not in seen_names:
-            seen_names[manifest.name] = skill_md.parent
-    return list(seen_names.values())
+        if manifest.name not in seen:
+            seen[manifest.name] = skill_md.parent
+    return list(seen.items())
+
+
+def discover_skills(root: Path) -> list[Path]:
+    """Find skill directories (containing valid SKILL.md) under a root path.
+
+    Thin wrapper around :func:`discover_skills_with_names` that drops the
+    parsed skill name.  Prefer :func:`discover_skills_with_names` when you
+    also need the skill name, so you don't pay for parsing twice.
+    """
+    return [path for _name, path in discover_skills_with_names(root)]
 
 
 def create_zip(path: Path) -> bytes:

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -24,7 +24,7 @@ from decision_hub.domain.repo_utils import (
     bump_version,
     clone_repo,
     create_zip,
-    discover_skills,
+    discover_skills_with_names,
     parse_semver,
 )
 from decision_hub.domain.skill_manifest import parse_skill_md
@@ -751,7 +751,12 @@ def process_tracker(
         repo_root = clone_repo(tracker.repo_url, tracker.branch, github_token=github_token)
 
         try:
-            skill_dirs = discover_skills(repo_root)
+            # Parse each SKILL.md once here and keep both the directory
+            # and the resolved skill name.  The name is reused below for
+            # removal detection so we don't re-parse every manifest.
+            discovered = discover_skills_with_names(repo_root)
+            skill_dirs = [path for _, path in discovered]
+            discovered_names: set[str] = {name for name, _ in discovered}
             if not skill_dirs:
                 with engine.connect() as conn:
                     update_skill_tracker(
@@ -802,6 +807,10 @@ def process_tracker(
                     )
 
             all_failed = published_count == 0 and len(errors) > 0
+            # Record per-skill errors whenever anything failed, including
+            # partial-failure cases.  Previously only total failures wrote
+            # last_error, so a 1-of-3 failure vanished silently.
+            last_error_msg = "; ".join(errors)[:500] if errors else None
             with engine.connect() as conn:
                 update_skill_tracker(
                     conn,
@@ -811,13 +820,16 @@ def process_tracker(
                     last_commit_sha=current_sha if not all_failed else None,
                     last_checked_at=now,
                     last_published_at=now if published_count > 0 else None,
-                    last_error="; ".join(errors)[:500] if all_failed else None,
+                    last_error=last_error_msg,
                 )
                 conn.commit()
 
             # Detect skills removed from repo: compare discovered skill names
             # against DB skills for this org+repo and mark missing ones.
-            _detect_removed_skills(skill_dirs, tracker, engine)
+            # Names were already parsed during discover_skills_with_names
+            # above, so we hand them over instead of re-parsing every
+            # SKILL.md.
+            _detect_removed_skills(discovered_names, skill_dirs, tracker, engine)
 
             logger.info(
                 "tracker_id={} repo={}/{} status=changed published={} sha={}",
@@ -855,29 +867,26 @@ def process_tracker(
 
 
 def _detect_removed_skills(
+    discovered_names: set[str],
     skill_dirs: list[Path],
     tracker: SkillTracker,
     engine: Any,
 ) -> None:
     """Compare discovered skill names against DB and mark missing ones as removed.
 
-    Parses each discovered SKILL.md to extract the canonical skill name, then
-    queries the DB for existing (non-removed) skills under the same org+repo.
-    Any DB skills not found in the current discovery are marked source_repo_removed=true.
+    Receives the pre-parsed ``discovered_names`` set from the caller so
+    we don't re-open and re-parse every SKILL.md (the previous
+    implementation did a second parse-pass here).  Skills present in the
+    DB under the same org+repo but missing from the set are marked
+    ``source_repo_removed=true``.
+
+    ``skill_dirs`` is still accepted to retain the legacy safety guard:
+    if the caller passed in a non-empty list but every parse failed
+    upstream, ``discovered_names`` will be empty and subtracting from
+    ``db_names`` would wipe every skill row.  Bail out instead.
     """
     from decision_hub.infra.database import fetch_skill_names_by_source_repo, mark_skills_removed_by_name
 
-    discovered_names: set[str] = set()
-    for skill_dir in skill_dirs:
-        try:
-            manifest = parse_skill_md(skill_dir / "SKILL.md")
-            discovered_names.add(manifest.name)
-        except (ValueError, FileNotFoundError):
-            continue
-
-    # Guard: if skill_dirs were provided but every parse failed,
-    # discovered_names is empty and the subtraction would incorrectly
-    # mark all DB skills as removed.  Bail out instead.
     if skill_dirs and not discovered_names:
         logger.warning(
             "tracker_id={} repo={} all {} SKILL.md parses failed, skipping removal detection",

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1385,6 +1385,12 @@ def _refresh_skill_latest_version(conn: Connection, skill_id: UUID) -> None:
             versions_table.c.semver_major.desc(),
             versions_table.c.semver_minor.desc(),
             versions_table.c.semver_patch.desc(),
+            # Unique tiebreaker so LIMIT 1 is deterministic when two rows
+            # accidentally share a (major, minor, patch) triple.  The
+            # (skill_id, semver) uniqueness constraint *should* make this
+            # unnecessary, but belt-and-braces for robustness per
+            # CLAUDE.md (SQL query correctness).
+            versions_table.c.id.desc(),
         )
         .limit(1)
     )
@@ -2125,7 +2131,10 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        # Tiebreaker on skills.id keeps the top-N set deterministic when
+        # multiple candidates share an identical vec_dist (common for
+        # near-duplicate embeddings).
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id.asc())
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2425,6 +2434,10 @@ def has_recent_quarantine(
         return False
 
     cutoff = sa.func.now() - timedelta(hours=max_age_hours)
+    # Deterministic ORDER BY with a unique tiebreaker (id) keeps LIMIT 1
+    # behavior stable across replicas — without it, multiple F-grade
+    # entries sharing the same (org, skill, checksum) return an arbitrary
+    # row, so `exists`-style checks become non-reproducible.
     stmt = (
         sa.select(sa.literal(1))
         .select_from(eval_audit_logs_table)
@@ -2434,6 +2447,10 @@ def has_recent_quarantine(
             eval_audit_logs_table.c.checksum == checksum,
             eval_audit_logs_table.c.grade == "F",
             eval_audit_logs_table.c.created_at > cutoff,
+        )
+        .order_by(
+            eval_audit_logs_table.c.created_at.desc(),
+            eval_audit_logs_table.c.id.desc(),
         )
         .limit(1)
     )
@@ -2706,6 +2723,42 @@ def find_eval_run(conn: Connection, run_id: UUID) -> EvalRun | None:
     if row is None:
         return None
     return _row_to_eval_run(row)
+
+
+def mark_eval_run_failed_if_stale(
+    conn: Connection,
+    run_id: UUID,
+    *,
+    observed_heartbeat_at: datetime,
+    error_message: str,
+    completed_at: datetime,
+) -> bool:
+    """Atomically mark an eval run failed only if its heartbeat is still stale.
+
+    Prevents a read-check-update race where the caller observed a stale
+    heartbeat but a live worker emits a fresh heartbeat before we write
+    ``status='failed'``.  The UPDATE is gated by ``heartbeat_at`` still
+    equalling the value the caller saw; if the worker updated it in the
+    meantime, the UPDATE affects zero rows and we return ``False``.
+
+    Returns True when the row was marked failed, False otherwise.
+    """
+    stmt = (
+        sa.update(eval_runs_table)
+        .where(
+            eval_runs_table.c.id == run_id,
+            eval_runs_table.c.heartbeat_at == observed_heartbeat_at,
+            eval_runs_table.c.status.in_(("running", "judging", "provisioning")),
+        )
+        .values(
+            status="failed",
+            error_message=error_message,
+            completed_at=completed_at,
+            heartbeat_at=sa.func.now(),
+        )
+    )
+    result = conn.execute(stmt)
+    return bool(result.rowcount)
 
 
 def find_eval_runs_for_version(conn: Connection, version_id: UUID) -> list[EvalRun]:

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -82,19 +82,21 @@ class TestGetEvalRun:
 
         assert resp.status_code == 404
 
-    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.mark_eval_run_failed_if_stale")
     @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_zombie_detection_marks_stale_run_as_failed(
         self,
         mock_find_run: MagicMock,
-        mock_update_status: MagicMock,
+        mock_mark_stale: MagicMock,
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
-        """A running eval with a heartbeat >5 min stale is marked failed."""
+        """A running eval with a heartbeat >5 min stale is marked failed
+        via an atomic conditional UPDATE (gated on observed heartbeat)."""
         stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
 
+        mock_mark_stale.return_value = True  # conditional update succeeded
         # find_eval_run is called twice: once before zombie check, once after
         failed_run = _make_eval_run(
             id=run.id,
@@ -108,16 +110,51 @@ class TestGetEvalRun:
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "failed"
-        mock_update_status.assert_called_once()
-        call_kwargs = mock_update_status.call_args
-        assert call_kwargs.kwargs.get("status") == "failed"
+        mock_mark_stale.assert_called_once()
+        # The UPDATE must be gated on the heartbeat we observed.
+        assert mock_mark_stale.call_args.kwargs["observed_heartbeat_at"] == stale_heartbeat
 
-    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.mark_eval_run_failed_if_stale")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_zombie_detection_respects_concurrent_heartbeat(
+        self,
+        mock_find_run: MagicMock,
+        mock_mark_stale: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """If a live worker emitted a fresh heartbeat between our read
+        and the conditional UPDATE, ``mark_eval_run_failed_if_stale``
+        returns False and the zombie check must not report 'failed'."""
+        stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
+        run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
+
+        # Atomic UPDATE affected 0 rows because a concurrent transaction
+        # advanced heartbeat_at.
+        mock_mark_stale.return_value = False
+
+        # Second read reveals the run is actually still running (a live
+        # worker is writing heartbeats).
+        live_run = _make_eval_run(
+            id=run.id,
+            status="running",
+            heartbeat_at=datetime.now(UTC),
+        )
+        mock_find_run.side_effect = [run, live_run]
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        # Must NOT be 'failed' — the live worker won the race.
+        assert resp.json()["status"] == "running"
+        mock_mark_stale.assert_called_once()
+
+    @patch("decision_hub.api.registry_routes.mark_eval_run_failed_if_stale")
     @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_fresh_heartbeat_not_marked_zombie(
         self,
         mock_find_run: MagicMock,
-        mock_update_status: MagicMock,
+        mock_mark_stale: MagicMock,
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
@@ -132,7 +169,7 @@ class TestGetEvalRun:
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "running"
-        mock_update_status.assert_not_called()
+        mock_mark_stale.assert_not_called()
 
     @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_completed_run_not_checked_for_zombie(
@@ -382,14 +419,14 @@ class TestGetEvalRunLogs:
 
         assert resp.status_code == 404
 
-    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.mark_eval_run_failed_if_stale")
     @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
     @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_zombie_detected_during_log_fetch(
         self,
         mock_find_run: MagicMock,
         mock_list_chunks: MagicMock,
-        mock_update_status: MagicMock,
+        mock_mark_stale: MagicMock,
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
@@ -398,6 +435,7 @@ class TestGetEvalRunLogs:
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
         mock_find_run.return_value = run
         mock_list_chunks.return_value = []
+        mock_mark_stale.return_value = True
 
         resp = client.get(
             f"/v1/eval-runs/{run.id}/logs?cursor=0",
@@ -406,7 +444,7 @@ class TestGetEvalRunLogs:
 
         assert resp.status_code == 200
         assert resp.json()["run_status"] == "failed"
-        mock_update_status.assert_called_once()
+        mock_mark_stale.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -239,7 +239,7 @@ class TestProcessTrackerAllFailed:
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
     def test_all_failed_does_not_advance_sha(
@@ -254,7 +254,7 @@ class TestProcessTrackerAllFailed:
         """When every skill publish raises, SHA must not advance and last_error must be set."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
-        mock_discover.return_value = [Path("/tmp/fake/repo/skill-a")]
+        mock_discover.return_value = [("skill-a", Path("/tmp/fake/repo/skill-a"))]
         mock_publish.side_effect = RuntimeError("S3 outage")
 
         mock_conn = MagicMock()
@@ -279,10 +279,10 @@ class TestProcessTrackerAllFailed:
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
-    def test_partial_success_advances_sha(
+    def test_partial_success_advances_sha_and_records_errors(
         self,
         mock_publish,
         _mock_s3,
@@ -291,12 +291,14 @@ class TestProcessTrackerAllFailed:
         _mock_commits,
         _mock_token,
     ):
-        """When at least one skill succeeds, SHA advances and no error is recorded."""
+        """When at least one skill succeeds, SHA advances but per-skill
+        failures are still written to last_error so an operator can see
+        them on the tracker health dashboard."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
-            Path("/tmp/fake/repo/skill-a"),
-            Path("/tmp/fake/repo/skill-b"),
+            ("skill-a", Path("/tmp/fake/repo/skill-a")),
+            ("skill-b", Path("/tmp/fake/repo/skill-b")),
         ]
         # First actually publishes, second fails
         mock_publish.side_effect = [True, RuntimeError("gauntlet error")]
@@ -316,12 +318,14 @@ class TestProcessTrackerAllFailed:
             _, kwargs = mock_update.call_args
             # SHA should advance since at least one succeeded
             assert kwargs["last_commit_sha"] == "new_sha_xyz"
-            assert kwargs["last_error"] is None
+            # Partial-failure errors must still be surfaced.
+            assert kwargs["last_error"] is not None
+            assert "gauntlet error" in kwargs["last_error"]
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
     def test_all_rejected_does_not_set_published_at(
@@ -336,7 +340,7 @@ class TestProcessTrackerAllFailed:
         """When all skills are rejected/skipped (return False), last_published_at must not update."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
-        mock_discover.return_value = [Path("/tmp/fake/repo/skill-a")]
+        mock_discover.return_value = [("skill-a", Path("/tmp/fake/repo/skill-a"))]
         # Returns False = skipped (checksum dedup) or rejected (gauntlet)
         mock_publish.return_value = False
 
@@ -393,7 +397,7 @@ class TestProcessTrackerKnownSha:
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker", return_value=True)
     def test_known_sha_skips_rest_check(
@@ -420,7 +424,7 @@ class TestProcessTrackerKnownSha:
             created_at=datetime.now(UTC),
         )
         mock_clone.return_value = Path("/tmp/fake/repo")
-        mock_discover.return_value = [Path("/tmp/fake/repo/skill-a")]
+        mock_discover.return_value = [("skill-a", Path("/tmp/fake/repo/skill-a"))]
 
         mock_conn = MagicMock()
         mock_engine = MagicMock()
@@ -1327,7 +1331,7 @@ class TestProcessTrackerNoSkillsDisables:
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     def test_no_skills_found_disables_tracker(
         self,
         mock_discover,
@@ -1746,10 +1750,10 @@ class TestProcessTrackerMultiSkillPartialFailure:
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_multi"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
-    def test_three_of_five_succeed_advances_sha_clears_error(
+    def test_three_of_five_succeed_advances_sha_and_records_errors(
         self,
         mock_publish,
         _mock_s3,
@@ -1758,15 +1762,16 @@ class TestProcessTrackerMultiSkillPartialFailure:
         _mock_commits,
         _mock_token,
     ):
-        """When 3 out of 5 skills succeed and 2 fail, SHA advances and last_error is cleared."""
+        """When 3 out of 5 skills succeed and 2 fail, SHA advances and
+        per-skill failures are written to last_error (previously dropped)."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
-            Path("/tmp/fake/repo/skill-a"),
-            Path("/tmp/fake/repo/skill-b"),
-            Path("/tmp/fake/repo/skill-c"),
-            Path("/tmp/fake/repo/skill-d"),
-            Path("/tmp/fake/repo/skill-e"),
+            ("skill-a", Path("/tmp/fake/repo/skill-a")),
+            ("skill-b", Path("/tmp/fake/repo/skill-b")),
+            ("skill-c", Path("/tmp/fake/repo/skill-c")),
+            ("skill-d", Path("/tmp/fake/repo/skill-d")),
+            ("skill-e", Path("/tmp/fake/repo/skill-e")),
         ]
         # 3 succeed (return True), 2 fail with errors
         mock_publish.side_effect = [
@@ -1792,15 +1797,19 @@ class TestProcessTrackerMultiSkillPartialFailure:
             _, kwargs = mock_update.call_args
             # SHA advances because at least one skill succeeded
             assert kwargs["last_commit_sha"] == "new_sha_multi"
-            # last_error is None because not all failed
-            assert kwargs["last_error"] is None
+            # Previously: last_error was None because "all_failed" was False.
+            # Now: partial-failure errors are recorded so they surface in
+            # operator dashboards.
+            assert kwargs["last_error"] is not None
+            assert "gauntlet error on skill-b" in kwargs["last_error"]
+            assert "S3 timeout on skill-e" in kwargs["last_error"]
             # last_published_at should be set because 3 skills were published
             assert kwargs["last_published_at"] is not None
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_all_fail"))
     @patch("decision_hub.domain.tracker_service.clone_repo")
-    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.domain.tracker_service.discover_skills_with_names")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
     def test_all_five_fail_does_not_advance_sha_sets_error(
@@ -1816,11 +1825,11 @@ class TestProcessTrackerMultiSkillPartialFailure:
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
-            Path("/tmp/fake/repo/skill-a"),
-            Path("/tmp/fake/repo/skill-b"),
-            Path("/tmp/fake/repo/skill-c"),
-            Path("/tmp/fake/repo/skill-d"),
-            Path("/tmp/fake/repo/skill-e"),
+            ("skill-a", Path("/tmp/fake/repo/skill-a")),
+            ("skill-b", Path("/tmp/fake/repo/skill-b")),
+            ("skill-c", Path("/tmp/fake/repo/skill-c")),
+            ("skill-d", Path("/tmp/fake/repo/skill-d")),
+            ("skill-e", Path("/tmp/fake/repo/skill-e")),
         ]
         mock_publish.side_effect = [
             RuntimeError("fail-a"),
@@ -1872,25 +1881,19 @@ class TestDetectRemovedSkills:
             created_at=datetime.now(UTC),
         )
 
-    @patch("decision_hub.domain.tracker_service.parse_skill_md")
     @patch("decision_hub.infra.database.fetch_skill_names_by_source_repo")
     @patch("decision_hub.infra.database.mark_skills_removed_by_name")
     def test_missing_skills_are_marked_removed(
         self,
         mock_mark,
         mock_fetch,
-        mock_parse,
     ):
         """Skills in DB but not in discovered dirs should be marked as removed."""
         from decision_hub.domain.tracker_service import _detect_removed_skills
 
         tracker = self._make_tracker()
-
-        manifest_a = MagicMock()
-        manifest_a.name = "skill-a"
-        mock_parse.return_value = manifest_a
-
         skill_dirs = [Path("/tmp/fake/repo/skill-a")]
+        discovered_names = {"skill-a"}
 
         # DB has skill-a and skill-b
         mock_fetch.return_value = {"skill-a", "skill-b"}
@@ -1901,31 +1904,25 @@ class TestDetectRemovedSkills:
         mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        _detect_removed_skills(skill_dirs, tracker, mock_engine)
+        _detect_removed_skills(discovered_names, skill_dirs, tracker, mock_engine)
 
         mock_fetch.assert_called_once_with(mock_conn, "myorg", "https://github.com/myorg/myrepo")
         mock_mark.assert_called_once_with(mock_conn, "myorg", {"skill-b"})
         mock_conn.commit.assert_called_once()
 
-    @patch("decision_hub.domain.tracker_service.parse_skill_md")
     @patch("decision_hub.infra.database.fetch_skill_names_by_source_repo")
     @patch("decision_hub.infra.database.mark_skills_removed_by_name")
     def test_no_removal_when_all_present(
         self,
         mock_mark,
         mock_fetch,
-        mock_parse,
     ):
         """When all DB skills are still discovered, mark function should not be called."""
         from decision_hub.domain.tracker_service import _detect_removed_skills
 
         tracker = self._make_tracker()
-
-        manifest_a = MagicMock()
-        manifest_a.name = "skill-a"
-        mock_parse.return_value = manifest_a
-
         skill_dirs = [Path("/tmp/fake/repo/skill-a")]
+        discovered_names = {"skill-a"}
         mock_fetch.return_value = {"skill-a"}
 
         mock_conn = MagicMock()
@@ -1933,31 +1930,25 @@ class TestDetectRemovedSkills:
         mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        _detect_removed_skills(skill_dirs, tracker, mock_engine)
+        _detect_removed_skills(discovered_names, skill_dirs, tracker, mock_engine)
 
         mock_fetch.assert_called_once()
         mock_mark.assert_not_called()
         mock_conn.commit.assert_not_called()
 
-    @patch("decision_hub.domain.tracker_service.parse_skill_md")
     @patch("decision_hub.infra.database.fetch_skill_names_by_source_repo")
     @patch("decision_hub.infra.database.mark_skills_removed_by_name")
     def test_no_removal_when_no_db_skills(
         self,
         mock_mark,
         mock_fetch,
-        mock_parse,
     ):
         """Fresh repo with no prior DB skills should not trigger any removal."""
         from decision_hub.domain.tracker_service import _detect_removed_skills
 
         tracker = self._make_tracker()
-
-        manifest_a = MagicMock()
-        manifest_a.name = "skill-a"
-        mock_parse.return_value = manifest_a
-
         skill_dirs = [Path("/tmp/fake/repo/skill-a")]
+        discovered_names = {"skill-a"}
         mock_fetch.return_value = set()
 
         mock_conn = MagicMock()
@@ -1965,34 +1956,33 @@ class TestDetectRemovedSkills:
         mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        _detect_removed_skills(skill_dirs, tracker, mock_engine)
+        _detect_removed_skills(discovered_names, skill_dirs, tracker, mock_engine)
 
         mock_fetch.assert_called_once()
         mock_mark.assert_not_called()
         mock_conn.commit.assert_not_called()
 
-    @patch("decision_hub.domain.tracker_service.parse_skill_md")
     @patch("decision_hub.infra.database.fetch_skill_names_by_source_repo")
     @patch("decision_hub.infra.database.mark_skills_removed_by_name")
     def test_all_parses_failed_skips_removal(
         self,
         mock_mark,
         mock_fetch,
-        mock_parse,
     ):
-        """When all SKILL.md parses fail, should not mark anything as removed."""
+        """When every parse failed upstream (names empty but dirs present),
+        should bail out rather than wipe all DB skills."""
         from decision_hub.domain.tracker_service import _detect_removed_skills
 
         tracker = self._make_tracker()
-
-        # Every parse raises ValueError
-        mock_parse.side_effect = ValueError("bad manifest")
-
         skill_dirs = [Path("/tmp/fake/repo/skill-a"), Path("/tmp/fake/repo/skill-b")]
+        # Discovery found dirs but parse failed for all of them, so the
+        # caller passes an empty set.  The function must not treat this
+        # as "every DB skill is gone".
+        discovered_names: set[str] = set()
 
         mock_engine = MagicMock()
 
-        _detect_removed_skills(skill_dirs, tracker, mock_engine)
+        _detect_removed_skills(discovered_names, skill_dirs, tracker, mock_engine)
 
         # Should bail out before even opening a DB connection
         mock_engine.connect.assert_not_called()

--- a/server/tests/test_infra/test_limit_ordering.py
+++ b/server/tests/test_infra/test_limit_ordering.py
@@ -1,0 +1,63 @@
+"""Regression tests: every LIMIT-bounded query must have a deterministic ORDER BY.
+
+CLAUDE.md lists this as a project-wide invariant ("Every query with
+LIMIT must have an explicit ORDER BY with a unique tiebreaker").
+Non-deterministic top-N results cause flaky pagination, misleading
+similar-skill rankings, and version drift during publish races.
+
+These tests assert on compiled SQL shape to avoid needing a live DB.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from decision_hub.infra.database import (
+    _refresh_skill_latest_version,
+    fetch_similar_skills,
+)
+
+
+class TestFetchSimilarSkillsOrdering:
+    def test_orders_by_vec_dist_then_id_tiebreaker(self):
+        """Similar-skill vector search needs a tiebreaker on skills.id so
+        two candidates with identical cosine distance yield a
+        deterministic top-N across replicas."""
+        mock_conn = MagicMock()
+        # Pretend the queried skill has an embedding; return a dummy vector.
+        first_call_result = MagicMock()
+        first_call_result.embedding = [0.1] * 1536
+        mock_conn.execute.return_value.first.return_value = first_call_result
+        # Second call returns no rows (we only care about SQL shape).
+        mock_conn.execute.return_value.all.return_value = []
+
+        fetch_similar_skills(mock_conn, "myorg", "skill-a", limit=5)
+
+        # The second call is the vector-ordered query.
+        vec_call = mock_conn.execute.call_args_list[-1]
+        compiled = str(vec_call[0][0])
+        assert "ORDER BY" in compiled
+        assert "vec_dist ASC" in compiled
+        # Tiebreaker: skills.id ASC so ties are broken the same way everywhere.
+        assert "skills.id ASC" in compiled
+
+
+class TestRefreshSkillLatestVersionOrdering:
+    def test_orders_by_semver_parts_with_id_tiebreaker(self):
+        """Denormalized latest-version refresh orders by (major, minor,
+        patch) DESC but must also include an id DESC tiebreaker — two
+        rows accidentally sharing a triple would otherwise pick an
+        arbitrary winner, causing denormalized columns to flap."""
+        mock_conn = MagicMock()
+        # Return no rows — we only inspect the SELECT shape.
+        mock_conn.execute.return_value.first.return_value = None
+
+        _refresh_skill_latest_version(mock_conn, uuid4())
+
+        first_call = mock_conn.execute.call_args_list[0]
+        compiled = str(first_call[0][0])
+        assert "ORDER BY" in compiled
+        assert "semver_major DESC" in compiled
+        assert "semver_minor DESC" in compiled
+        assert "semver_patch DESC" in compiled
+        assert "versions.id DESC" in compiled
+        assert "LIMIT" in compiled

--- a/server/tests/test_infra/test_mark_eval_run_failed_if_stale.py
+++ b/server/tests/test_infra/test_mark_eval_run_failed_if_stale.py
@@ -1,0 +1,70 @@
+"""Unit tests for mark_eval_run_failed_if_stale atomic update.
+
+The helper exists specifically to avoid a read-check-update race where a
+worker emits a fresh heartbeat between the caller's observation of a
+stale heartbeat and the status flip.  These tests verify the SQL shape
+without needing a real database.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from decision_hub.infra.database import mark_eval_run_failed_if_stale
+
+
+class TestMarkEvalRunFailedIfStale:
+    def test_returns_true_when_row_updated(self):
+        """If the conditional UPDATE affects a row, the helper returns True."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.rowcount = 1
+
+        observed = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        result = mark_eval_run_failed_if_stale(
+            mock_conn,
+            uuid4(),
+            observed_heartbeat_at=observed,
+            error_message="Stale heartbeat",
+            completed_at=datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC),
+        )
+
+        assert result is True
+        mock_conn.execute.assert_called_once()
+
+    def test_returns_false_when_row_was_updated_concurrently(self):
+        """If another transaction updated heartbeat_at first, rowcount is 0."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.rowcount = 0
+
+        result = mark_eval_run_failed_if_stale(
+            mock_conn,
+            uuid4(),
+            observed_heartbeat_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+            error_message="Stale heartbeat",
+            completed_at=datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC),
+        )
+
+        assert result is False
+
+    def test_update_is_gated_on_observed_heartbeat(self):
+        """The UPDATE's WHERE must include heartbeat_at == observed so a
+        fresh heartbeat from a live worker doesn't get clobbered."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.rowcount = 1
+
+        observed = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mark_eval_run_failed_if_stale(
+            mock_conn,
+            uuid4(),
+            observed_heartbeat_at=observed,
+            error_message="Stale heartbeat",
+            completed_at=datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC),
+        )
+
+        stmt = mock_conn.execute.call_args[0][0]
+        compiled = str(stmt)
+        assert "UPDATE eval_runs" in compiled
+        # Guard clauses appear in the WHERE: the observed heartbeat and
+        # the active-worker status set must both be present.
+        assert "heartbeat_at" in compiled
+        assert "status IN" in compiled

--- a/server/tests/test_infra/test_quarantine_dedup.py
+++ b/server/tests/test_infra/test_quarantine_dedup.py
@@ -47,3 +47,27 @@ class TestHasRecentQuarantine:
         )
         assert result is False
         mock_conn.execute.assert_not_called()
+
+    def test_query_has_deterministic_order_by_with_tiebreaker(self):
+        """LIMIT 1 must be paired with ORDER BY including a unique
+        tiebreaker (id) so multiple F-grade rows with identical
+        created_at yield deterministic results across replicas."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.scalar_one_or_none.return_value = None
+
+        has_recent_quarantine(
+            mock_conn,
+            org_slug="myorg",
+            skill_name="my-skill",
+            checksum="abc123",
+            max_age_hours=24,
+        )
+
+        # Stringify using the default dialect (bind params render as
+        # :name); we only care about ORDER BY / LIMIT shape.
+        stmt = mock_conn.execute.call_args[0][0]
+        compiled = str(stmt)
+        assert "ORDER BY" in compiled
+        assert "created_at DESC" in compiled
+        assert "id DESC" in compiled
+        assert "LIMIT" in compiled

--- a/server/tests/test_scripts/test_github_crawler.py
+++ b/server/tests/test_scripts/test_github_crawler.py
@@ -940,6 +940,49 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         assert result == []
 
+    def test_discover_with_names_returns_name_and_path(self, tmp_path):
+        """discover_skills_with_names returns the parsed skill name alongside
+        the directory so callers don't have to re-parse SKILL.md."""
+        from decision_hub.domain.repo_utils import discover_skills_with_names
+
+        skill1 = tmp_path / "skills" / "skill-a"
+        skill1.mkdir(parents=True)
+        (skill1 / "SKILL.md").write_text("---\nname: skill-a\ndescription: test\n---\nBody")
+
+        with patch("decision_hub.domain.skill_manifest.parse_skill_md") as mock_parse:
+            m1 = MagicMock()
+            m1.name = "skill-a"
+            mock_parse.return_value = m1
+            result = discover_skills_with_names(tmp_path)
+
+        assert len(result) == 1
+        name, path = result[0]
+        assert name == "skill-a"
+        assert path == skill1
+
+    def test_discover_parses_each_manifest_exactly_once(self, tmp_path):
+        """Previous implementations parsed SKILL.md twice (once in
+        discover, once in the removal-detection pass).  Ensure a single
+        discovery pass results in a single parse per file."""
+        from decision_hub.domain.repo_utils import discover_skills_with_names
+
+        for name in ("skill-a", "skill-b", "skill-c"):
+            d = tmp_path / "skills" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: test\n---\nBody")
+
+        with patch("decision_hub.domain.skill_manifest.parse_skill_md") as mock_parse:
+            manifests = []
+            for name in ("skill-a", "skill-b", "skill-c"):
+                m = MagicMock()
+                m.name = name
+                manifests.append(m)
+            mock_parse.side_effect = manifests
+            result = discover_skills_with_names(tmp_path)
+
+        assert len(result) == 3
+        assert mock_parse.call_count == 3
+
 
 # ---------------------------------------------------------------------------
 # Clone repo tests


### PR DESCRIPTION
## Summary

Six surgical correctness fixes surfaced by a deep codebase review. No architectural refactors — every change stays inside existing module boundaries so the follow-up module splits (`database.py` 3.5k LoC, `registry_routes.py` 1.3k LoC, `client/cli/registry.py` 1.9k LoC) can land as their own focused PRs. The priority here is shipping **behavior-visible correctness wins** with focused regression tests.

### Findings addressed

| # | Fix | Why it matters |
|---|-----|-----------------|
| 1 | **Tracker partial-failure errors were silently dropped** (`tracker_service.py:804`) | When N-of-M skills failed, `last_error` was only written if *every* publish failed. Any partial failure vanished from the tracker health dashboard. `last_error` now records any failing skill; SHA-advance rule is unchanged. |
| 2 | **`has_recent_quarantine` used `LIMIT 1` without `ORDER BY`** (`database.py:2428`) | Violates the CLAUDE.md rule "every LIMIT must have an explicit ORDER BY with a unique tiebreaker." Multiple F-grade rows with matching checksum returned a non-deterministic row. Fixed: `ORDER BY created_at DESC, id DESC`. |
| 3 | **`fetch_similar_skills` top-N had no tiebreaker** (`database.py:2128`) | Near-duplicate embeddings with identical `vec_dist` produced a non-deterministic top-5, so the same user could see different "similar skills" on refresh. Fixed: tiebreaker on `skills.id ASC`. |
| 4 | **`_refresh_skill_latest_version` ordered only by semver triple** (`database.py:1384`) | The `(skill_id, semver)` unique constraint *should* make this unnecessary, but belt-and-braces: added `versions.id DESC` tiebreaker. |
| 5 | **Zombie-heartbeat race could clobber a live worker** (`registry_routes.py:1100`) | `_check_zombie` did a read-check-update sequence: read heartbeat, compare to wallclock, unconditionally `UPDATE status='failed'`. A worker sending a fresh heartbeat in that window would be overwritten. Introduced `mark_eval_run_failed_if_stale()` — an atomic conditional `UPDATE` gated on the observed `heartbeat_at` value. If a live worker updates `heartbeat_at` first, our `UPDATE` affects 0 rows and the run is left running. |
| 6 | **Duplicate SKILL.md parsing in tracker removal detection** (`tracker_service.py:857`) | `_detect_removed_skills` re-parsed every manifest that `discover_skills` had already parsed. Added `discover_skills_with_names()` → `list[tuple[str, Path]]`; the tracker threads the pre-parsed names through, halving the parse work per tracker tick. |

### Test coverage

New tests (all SQL-shape or behavior assertions, no DB required):
- `test_has_recent_quarantine` — deterministic `ORDER BY … LIMIT 1`
- `test_fetch_similar_skills` / `test__refresh_skill_latest_version` — SQL-shape tiebreaker assertions (new `test_limit_ordering.py`)
- `test_mark_eval_run_failed_if_stale` — returns `False` when `rowcount=0`, `UPDATE` gated on observed heartbeat + active-worker status set (new `test_mark_eval_run_failed_if_stale.py`)
- `test_zombie_detection_respects_concurrent_heartbeat` — end-to-end: if atomic update returns False, the endpoint does *not* report `failed`
- `test_partial_success_advances_sha_and_records_errors` — partial-failure errors appear in `last_error` (previously asserted `is None`)
- `test_three_of_five_succeed_advances_sha_and_records_errors` — multi-skill variant of the same guarantee
- `test_discover_with_names_returns_name_and_path` + `test_discover_parses_each_manifest_exactly_once`

Updated existing tests for the new tuple-return and patched-function names.

### Test plan

- [x] `uvx ruff check .` → clean
- [x] `uvx ruff format --check .` → clean
- [x] `uvx mypy client/src/ server/src/ shared/src/` → 0 issues
- [x] server: `pytest server/tests/ -m "not slow"` → 942 passed, 34 deselected
- [x] client: `pytest client/tests/` → 291 passed, 29 skipped
- [x] shared: `pytest shared/tests/` → 98 passed

### Deliberately out of scope (follow-up PRs)

Flagged during the review but not addressed here to keep the PR tight:
- Module splits: `database.py` (3.5k LoC) → per-domain submodules; `registry_routes.py` (1.3k LoC) → sub-routers; `client/cli/registry.py` (1.9k LoC) → command modules.
- Backfill scripts not resumable/checkpointed (CLAUDE.md §97 violation).
- Duplicate secret-redaction regex across `evals.py` and `anthropic_client.py`.
- `_log_ask_analytics` swallow-and-log has no metric/alert hook.

https://claude.ai/code/session_01JVy1BKgfcZSBH9cPBkNFYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVy1BKgfcZSBH9cPBkNFYz)_