### PR TITLE
refactor: shared rate-limit factory, JWT parser, and four correctness fixes

### DIFF
--- a/frontend/src/components/AskModal.test.tsx
+++ b/frontend/src/components/AskModal.test.tsx
@@ -347,4 +347,74 @@ describe("AskModal", () => {
       expect(onClose).toHaveBeenCalled();
     });
   });
+
+  describe("state reset on close", () => {
+    it("clears the previous conversation when reopened", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <MemoryRouter>
+          <AskModal isOpen={true} onClose={onClose} />
+        </MemoryRouter>,
+      );
+
+      // Send a question and wait for the answer to render.
+      const input = screen.getByPlaceholderText("Ask about skills...");
+      await user.type(input, "analyze data");
+      await user.click(screen.getByRole("button", { name: "Send" }));
+      await waitFor(() =>
+        expect(screen.getByText(/great skills/)).toBeInTheDocument(),
+      );
+
+      // Close the modal — component returns null but state lives on…
+      rerender(
+        <MemoryRouter>
+          <AskModal isOpen={false} onClose={onClose} />
+        </MemoryRouter>,
+      );
+
+      // …reopening should NOT show the stale conversation.
+      rerender(
+        <MemoryRouter>
+          <AskModal isOpen={true} onClose={onClose} />
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByText("analyze data")).not.toBeInTheDocument();
+      expect(screen.queryByText(/great skills/)).not.toBeInTheDocument();
+      expect(screen.getByText("What are you looking for?")).toBeInTheDocument();
+    });
+
+    it("clears a stale error when reopened", async () => {
+      server.use(
+        http.post("/v1/ask", () =>
+          new HttpResponse("Internal Server Error", { status: 500 }),
+        ),
+      );
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <MemoryRouter>
+          <AskModal isOpen={true} onClose={onClose} />
+        </MemoryRouter>,
+      );
+
+      await user.type(screen.getByPlaceholderText("Ask about skills..."), "broken");
+      await user.click(screen.getByRole("button", { name: "Send" }));
+      await waitFor(() => expect(screen.getByText(/API 500/)).toBeInTheDocument());
+
+      rerender(
+        <MemoryRouter>
+          <AskModal isOpen={false} onClose={onClose} />
+        </MemoryRouter>,
+      );
+      rerender(
+        <MemoryRouter>
+          <AskModal isOpen={true} onClose={onClose} />
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByText(/API 500/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/AskModal.tsx
+++ b/frontend/src/components/AskModal.tsx
@@ -41,6 +41,17 @@ export default function AskModal({ isOpen, onClose }: AskModalProps) {
     }
   }, [isOpen]);
 
+  // Reset transient state when the modal closes so reopening starts fresh —
+  // otherwise a stale conversation or error message would still be displayed.
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery("");
+      setMessages([]);
+      setError(null);
+      setLoading(false);
+    }
+  }, [isOpen]);
+
   // Re-read recently viewed from localStorage each time the modal opens
   useEffect(() => {
     if (isOpen) refreshRecentlyViewed();

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import lazy_rate_limiter
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -25,17 +25,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = lazy_rate_limiter("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/deps.py
+++ b/server/src/decision_hub/api/deps.py
@@ -50,6 +50,44 @@ def get_connection(
         yield conn
 
 
+class _JWTReason:
+    """Why a JWT failed to resolve to a user. Used by the shared parser."""
+
+    MISSING = "missing"
+    INVALID = "invalid"
+    OUTDATED = "outdated"
+
+
+def _user_from_jwt(request: Request, settings: Settings) -> tuple[User | None, str | None]:
+    """Decode a Bearer JWT into a ``User``.
+
+    Returns ``(user, None)`` on success, or ``(None, reason)`` for any of:
+    missing/malformed Authorization header, invalid signature/expired token,
+    or token predating the ``github_orgs`` claim. Callers decide whether
+    to raise 401 (auth-required routes) or fall back to anonymous access.
+    """
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None, _JWTReason.MISSING
+
+    token = auth_header.removeprefix("Bearer ")
+    try:
+        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
+    except JWTError:
+        return None, _JWTReason.INVALID
+
+    if "github_orgs" not in payload:
+        return None, _JWTReason.OUTDATED
+
+    user = User(
+        id=UUID(payload["sub"]),
+        github_id="",
+        username=payload["username"],
+        github_orgs=tuple(payload["github_orgs"]),
+    )
+    return user, None
+
+
 def get_current_user(
     request: Request,
     settings: Settings = Depends(get_settings),
@@ -63,37 +101,21 @@ def get_current_user(
         HTTPException 401: When the header is missing, malformed, or the
             token is invalid / expired.
     """
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        raise HTTPException(
-            status_code=401,
-            detail="Missing or invalid authorization header",
-        )
+    user, reason = _user_from_jwt(request, settings)
+    if user is not None:
+        return user
 
-    token = auth_header.removeprefix("Bearer ")
-
-    try:
-        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
-    except JWTError:
+    if reason == _JWTReason.MISSING:
+        raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
+    if reason == _JWTReason.INVALID:
         logger.warning("Invalid JWT from {}", request.client.host if request.client else "unknown")
-        raise HTTPException(status_code=401, detail="Invalid token") from None
-
-    # Tokens issued before the org refactor lack the github_orgs claim.
-    # Prompt the user to re-authenticate so they get a fresh token.
-    if "github_orgs" not in payload:
-        logger.warning("Outdated token for user={} (missing github_orgs claim)", payload.get("username"))
-        raise HTTPException(
-            status_code=401,
-            detail="Your session is outdated. Run 'dhub login' to refresh.",
-        )
-
-    # The JWT 'sub' claim holds the user id and 'username' holds the login.
-    # We trust the signed token and avoid a DB lookup on every request.
-    return User(
-        id=UUID(payload["sub"]),
-        github_id="",
-        username=payload["username"],
-        github_orgs=tuple(payload["github_orgs"]),
+        raise HTTPException(status_code=401, detail="Invalid token")
+    # Outdated: pre-org-refactor token. Prompt re-auth so the client picks
+    # up a token that includes the github_orgs claim.
+    logger.warning("Outdated JWT — missing github_orgs claim")
+    raise HTTPException(
+        status_code=401,
+        detail="Your session is outdated. Run 'dhub login' to refresh.",
     )
 
 
@@ -106,28 +128,8 @@ def get_current_user_optional(
     Unlike get_current_user(), this does not raise HTTP 401 for unauthenticated
     requests. Use this for endpoints that support both authenticated and
     anonymous access.
-
-    Returns:
-        User object if valid token present, None otherwise.
     """
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        return None
-
-    token = auth_header.removeprefix("Bearer ")
-
-    try:
-        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
-    except JWTError:
+    user, reason = _user_from_jwt(request, settings)
+    if reason == _JWTReason.INVALID:
         logger.debug("Invalid JWT in optional auth context")
-        return None
-
-    if "github_orgs" not in payload:
-        return None
-
-    return User(
-        id=UUID(payload["sub"]),
-        github_id="",
-        username=payload["username"],
-        github_orgs=tuple(payload["github_orgs"]),
-    )
+    return user

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,6 +3,7 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -63,3 +64,35 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def lazy_rate_limiter(name: str) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that rate-limits a route by ``<name>``.
+
+    The limiter is constructed on first call from settings fields
+    ``<name>_rate_limit`` (max requests) and ``<name>_rate_window`` (seconds)
+    and cached on ``request.app.state`` under ``_<name>_rate_limiter`` so all
+    requests in the same Modal container share counters.
+
+    Replaces a family of near-identical ``_enforce_*_rate_limit`` helpers:
+    each route now writes ``dependencies=[Depends(lazy_rate_limiter("publish"))]``
+    instead of declaring its own factory function.
+    """
+    state_attr = f"_{name}_rate_limiter"
+    limit_attr = f"{name}_rate_limit"
+    window_attr = f"{name}_rate_window"
+
+    def _dependency(request: Request) -> None:
+        state = request.app.state
+        limiter: RateLimiter | None = getattr(state, state_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    _dependency.__name__ = f"_enforce_{name}_rate_limit"
+    return _dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import lazy_rate_limiter
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -82,89 +82,16 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
-
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_list_skills_rate_limit = lazy_rate_limiter("list_skills")
+_enforce_resolve_rate_limit = lazy_rate_limiter("resolve")
+_enforce_similar_skills_rate_limit = lazy_rate_limiter("similar_skills")
+_enforce_download_rate_limit = lazy_rate_limiter("download")
+_enforce_audit_log_rate_limit = lazy_rate_limiter("audit_log")
+_enforce_scan_report_rate_limit = lazy_rate_limiter("scan_report")
+_enforce_publish_rate_limit = lazy_rate_limiter("publish")
+_enforce_stats_rate_limit = lazy_rate_limiter("stats")
+_enforce_skill_summary_rate_limit = lazy_rate_limiter("skill_summary")
+_enforce_eval_report_rate_limit = lazy_rate_limiter("eval_report")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -556,6 +483,7 @@ def publish_skill(
 
 @public_router.get(
     "/stats",
+    dependencies=[Depends(_enforce_stats_rate_limit)],
 )
 def get_registry_stats(
     response: Response,
@@ -642,6 +570,7 @@ def list_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/summary",
     response_model=SkillSummary,
+    dependencies=[Depends(_enforce_skill_summary_rate_limit)],
 )
 def get_skill_summary(
     org_slug: str,
@@ -718,6 +647,7 @@ def get_similar_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/latest-version",
     response_model=LatestVersionResponse,
+    dependencies=[Depends(_enforce_resolve_rate_limit)],
 )
 def get_latest_version(
     org_slug: str,
@@ -955,6 +885,7 @@ def get_scan_report(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_eval_report_rate_limit)],
 )
 def get_eval_report_by_skill(
     org_slug: str,
@@ -977,6 +908,7 @@ def get_eval_report_by_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_eval_report_rate_limit)],
 )
 def get_eval_report_by_version_path(
     org_slug: str,

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import lazy_rate_limiter
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -28,17 +28,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
 
-
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = lazy_rate_limiter("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/taxonomy_routes.py
+++ b/server/src/decision_hub/api/taxonomy_routes.py
@@ -4,10 +4,13 @@ from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
 
 from decision_hub.api.deps import get_settings
+from decision_hub.api.rate_limit import lazy_rate_limiter
 from decision_hub.settings import Settings
 from dhub_core.taxonomy import CATEGORY_TAXONOMY
 
 public_router = APIRouter(prefix="/v1", tags=["taxonomy"])
+
+_enforce_taxonomy_rate_limit = lazy_rate_limiter("taxonomy")
 
 
 class TaxonomyResponse(BaseModel):
@@ -16,7 +19,11 @@ class TaxonomyResponse(BaseModel):
     groups: dict[str, list[str]]
 
 
-@public_router.get("/taxonomy", response_model=TaxonomyResponse)
+@public_router.get(
+    "/taxonomy",
+    response_model=TaxonomyResponse,
+    dependencies=[Depends(_enforce_taxonomy_rate_limit)],
+)
 def get_taxonomy(
     response: Response,
     settings: Settings = Depends(get_settings),

--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -785,13 +785,15 @@ def execute_publish(
             settings=settings,
             user_id=user_id,
         )
-    except Exception as exc:
-        logger.warning(
-            "Eval trigger failed for {}/{} v{} (publish succeeded): {}",
+    except Exception:
+        # Publish has already committed; eval trigger is best-effort.
+        # Use opt(exception=True) so the traceback survives — the rest of
+        # this file already follows that pattern.
+        logger.opt(exception=True).warning(
+            "Eval trigger failed for {}/{} v{} (publish succeeded)",
             org_slug,
             skill_name,
             version,
-            exc,
         )
 
     logger.info(

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2040,7 +2040,13 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # ts_rank ties are common when query terms appear in identical
+        # positions; without a unique tiebreaker pagination is non-deterministic.
+        fts_stmt = fts_stmt.order_by(
+            sa.text("fts_rank DESC"),
+            organizations_table.c.slug,
+            skills_table.c.name,
+        ).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2058,13 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        # Cosine distance ties are rare but possible (identical embeddings);
+        # tiebreak on (org_slug, skill_name) for deterministic top-N selection.
+        vec_stmt = vec_stmt.order_by(
+            sa.text("vec_dist ASC"),
+            organizations_table.c.slug,
+            skills_table.c.name,
+        ).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -93,6 +93,17 @@ class Settings(BaseSettings):
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
 
+    # Light-weight read endpoints — generous defaults; the limit exists to
+    # block abusive bots, not to throttle the frontend.
+    stats_rate_limit: int = 120
+    stats_rate_window: int = 60
+    skill_summary_rate_limit: int = 120
+    skill_summary_rate_window: int = 60
+    eval_report_rate_limit: int = 60
+    eval_report_rate_window: int = 60
+    taxonomy_rate_limit: int = 120
+    taxonomy_rate_window: int = 60
+
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096
     sandbox_timeout_seconds: int = 900

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,16 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.scan_report_rate_limit = 30
+    settings.scan_report_rate_window = 60
+    settings.stats_rate_limit = 120
+    settings.stats_rate_window = 60
+    settings.skill_summary_rate_limit = 120
+    settings.skill_summary_rate_window = 60
+    settings.eval_report_rate_limit = 60
+    settings.eval_report_rate_window = 60
+    settings.taxonomy_rate_limit = 120
+    settings.taxonomy_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_deps.py
+++ b/server/tests/test_api/test_deps.py
@@ -1,8 +1,94 @@
-"""Tests for stale token detection in get_current_user."""
+"""Tests for the auth dependencies in ``decision_hub.api.deps``.
+
+Covers both end-to-end behaviour through the test client and the shared
+``_user_from_jwt`` parser used by both ``get_current_user`` (raises 401)
+and ``get_current_user_optional`` (returns None).
+"""
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from jose import jwt
+
+from decision_hub.api.deps import _JWTReason, _user_from_jwt
+
+
+def _request_with_header(value: str | None) -> MagicMock:
+    request = MagicMock()
+    request.headers = {"Authorization": value} if value is not None else {}
+    request.client.host = "127.0.0.1"
+    return request
+
+
+def _settings(secret: str = "shared-secret") -> SimpleNamespace:
+    return SimpleNamespace(jwt_secret=secret, jwt_algorithm="HS256")
+
+
+class TestUserFromJwt:
+    """Unit tests for the shared ``_user_from_jwt`` helper."""
+
+    def test_missing_header_returns_missing(self) -> None:
+        request = _request_with_header(None)
+        user, reason = _user_from_jwt(request, _settings())
+        assert user is None
+        assert reason == _JWTReason.MISSING
+
+    def test_non_bearer_header_returns_missing(self) -> None:
+        request = _request_with_header("Basic abc123")
+        user, reason = _user_from_jwt(request, _settings())
+        assert user is None
+        assert reason == _JWTReason.MISSING
+
+    def test_invalid_signature_returns_invalid(self) -> None:
+        # Token signed with a different secret than _settings().
+        token = jwt.encode(
+            {
+                "sub": "12345678-1234-5678-1234-567812345678",
+                "username": "x",
+                "github_orgs": [],
+                "exp": datetime.now(UTC) + timedelta(hours=1),
+            },
+            "wrong-secret",
+            algorithm="HS256",
+        )
+        request = _request_with_header(f"Bearer {token}")
+        user, reason = _user_from_jwt(request, _settings())
+        assert user is None
+        assert reason == _JWTReason.INVALID
+
+    def test_missing_github_orgs_claim_returns_outdated(self) -> None:
+        token = jwt.encode(
+            {
+                "sub": "12345678-1234-5678-1234-567812345678",
+                "username": "olduser",
+                "exp": datetime.now(UTC) + timedelta(hours=1),
+            },
+            "shared-secret",
+            algorithm="HS256",
+        )
+        request = _request_with_header(f"Bearer {token}")
+        user, reason = _user_from_jwt(request, _settings())
+        assert user is None
+        assert reason == _JWTReason.OUTDATED
+
+    def test_valid_token_returns_user_and_no_reason(self) -> None:
+        token = jwt.encode(
+            {
+                "sub": "12345678-1234-5678-1234-567812345678",
+                "username": "alice",
+                "github_orgs": ["acme", "widgets"],
+                "exp": datetime.now(UTC) + timedelta(hours=1),
+            },
+            "shared-secret",
+            algorithm="HS256",
+        )
+        request = _request_with_header(f"Bearer {token}")
+        user, reason = _user_from_jwt(request, _settings())
+        assert reason is None
+        assert user is not None
+        assert user.username == "alice"
+        assert user.github_orgs == ("acme", "widgets")
 
 
 class TestStaleTokenDetection:

--- a/server/tests/test_api/test_public_endpoint_rate_limits.py
+++ b/server/tests/test_api/test_public_endpoint_rate_limits.py
@@ -1,0 +1,77 @@
+"""Regression tests: every public read endpoint enforces a rate limit.
+
+CLAUDE.md mandates that public endpoints always carry a per-IP limiter.
+These tests guard against the next public endpoint being shipped without one
+by exercising each route past its configured limit and asserting HTTP 429.
+
+We override the rate-limit settings to tiny windows so the tests stay fast.
+The shared limiter cache lives on ``app.state``, so each test gets its own
+``client`` (and thus its own app + state) via the conftest fixtures.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def tight_settings(test_settings):
+    """Override read-endpoint limits to 1 request per 60s."""
+    test_settings.stats_rate_limit = 1
+    test_settings.skill_summary_rate_limit = 1
+    test_settings.resolve_rate_limit = 1
+    test_settings.eval_report_rate_limit = 1
+    test_settings.taxonomy_rate_limit = 1
+    return test_settings
+
+
+def test_taxonomy_rate_limited(tight_settings, client: TestClient) -> None:
+    assert client.get("/v1/taxonomy").status_code == 200
+    assert client.get("/v1/taxonomy").status_code == 429
+
+
+def test_stats_rate_limited(tight_settings, client: TestClient) -> None:
+    with patch("decision_hub.api.registry_routes.fetch_registry_stats") as fetch:
+        fetch.return_value = {"total_skills": 0, "total_orgs": 0, "total_downloads": 0}
+        assert client.get("/v1/stats").status_code == 200
+        assert client.get("/v1/stats").status_code == 429
+
+
+def test_skill_summary_rate_limited(tight_settings, client: TestClient) -> None:
+    with patch("decision_hub.api.registry_routes.find_skill_by_slug") as find:
+        # 404 path is fine; we only care that the limiter ran.
+        find.return_value = None
+        assert client.get("/v1/skills/acme/widget/summary").status_code == 404
+        assert client.get("/v1/skills/acme/widget/summary").status_code == 429
+
+
+def test_latest_version_rate_limited(tight_settings, client: TestClient) -> None:
+    with patch("decision_hub.api.registry_routes.resolve_latest_version") as resolve:
+        resolve.return_value = None
+        assert client.get("/v1/skills/acme/widget/latest-version").status_code == 404
+        assert client.get("/v1/skills/acme/widget/latest-version").status_code == 429
+
+
+def test_eval_report_query_form_rate_limited(tight_settings, client: TestClient) -> None:
+    with patch("decision_hub.api.registry_routes.find_skill_by_slug") as find:
+        find.return_value = MagicMock(visibility="public")
+        with patch(
+            "decision_hub.api.registry_routes.find_eval_report_by_skill",
+            return_value=None,
+        ):
+            url = "/v1/skills/acme/widget/eval-report?semver=1.0.0"
+            assert client.get(url).status_code == 200
+            assert client.get(url).status_code == 429
+
+
+def test_eval_report_path_form_rate_limited(tight_settings, client: TestClient) -> None:
+    with patch("decision_hub.api.registry_routes.find_skill_by_slug") as find:
+        find.return_value = MagicMock(visibility="public")
+        with patch(
+            "decision_hub.api.registry_routes.find_eval_report_by_skill",
+            return_value=None,
+        ):
+            url = "/v1/skills/acme/widget/versions/1.0.0/eval-report"
+            assert client.get(url).status_code == 200
+            assert client.get(url).status_code == 429

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, lazy_rate_limiter
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,69 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestLazyRateLimiter:
+    """Tests for the ``lazy_rate_limiter`` factory used by route dependencies."""
+
+    @staticmethod
+    def _make_request(host: str = "1.2.3.4") -> MagicMock:
+        request = MagicMock()
+        request.client.host = host
+        # SimpleNamespace lets the dependency mutate state via setattr().
+        request.app.state = SimpleNamespace(
+            settings=SimpleNamespace(foo_rate_limit=2, foo_rate_window=60),
+        )
+        return request
+
+    def test_initialises_limiter_lazily_from_settings(self) -> None:
+        """First call constructs the limiter from <name>_rate_limit/window settings."""
+        dep = lazy_rate_limiter("foo")
+        request = self._make_request()
+
+        # Before any call, no limiter is cached on app state.
+        assert not hasattr(request.app.state, "_foo_rate_limiter")
+
+        dep(request)
+
+        cached = request.app.state._foo_rate_limiter
+        assert isinstance(cached, RateLimiter)
+        assert cached.max_requests == 2
+        assert cached.window_seconds == 60
+
+    def test_reuses_cached_limiter_across_calls(self) -> None:
+        """Subsequent calls reuse the cached limiter so counters accumulate per IP."""
+        dep = lazy_rate_limiter("foo")
+        request = self._make_request()
+
+        dep(request)
+        first = request.app.state._foo_rate_limiter
+        dep(request)
+        second = request.app.state._foo_rate_limiter
+        assert first is second
+
+        # Third call exceeds max_requests=2 → 429.
+        with pytest.raises(HTTPException) as exc_info:
+            dep(request)
+        assert exc_info.value.status_code == 429
+
+    def test_two_names_get_independent_limiters(self) -> None:
+        """Limiters for different ``name`` keys are isolated on app state."""
+        foo = lazy_rate_limiter("foo")
+        bar = lazy_rate_limiter("bar")
+        request = MagicMock()
+        request.client.host = "9.9.9.9"
+        request.app.state = SimpleNamespace(
+            settings=SimpleNamespace(
+                foo_rate_limit=1,
+                foo_rate_window=60,
+                bar_rate_limit=10,
+                bar_rate_window=60,
+            ),
+        )
+
+        foo(request)
+        # foo is now at its 1-request limit; bar is unaffected.
+        with pytest.raises(HTTPException):
+            foo(request)
+        bar(request)  # should not raise


### PR DESCRIPTION
## Summary

Findings from a deep code review of the monorepo. This PR cuts boilerplate, closes a few small but real correctness gaps, and adds regression tests for each fix. **No behaviour changes for existing endpoints** — every previously rate-limited route still uses the same `<name>_rate_limit` / `<name>_rate_window` settings, just plumbed through one shared factory.

The full review (system map, top-15 changes, test recommendations, detailed findings, non-obvious insights) is too long for a PR description, but this PR ships the highest-leverage "S"-effort items from it. Larger items — splitting `database.py`/`gauntlet.py`, repository pattern, OpenTelemetry — are out of scope and will land in follow-ups.

## What changed

### Code-health: collapse rate-limiter & JWT-parser duplication
- **`api/rate_limit.py`** now exports `lazy_rate_limiter("name")`, a factory that returns a FastAPI dependency. It pulls `<name>_rate_limit` and `<name>_rate_window` from settings on first hit and caches the `RateLimiter` on `app.state._<name>_rate_limiter` so all requests in the same Modal container share counters. Replaces 9 near-identical `_enforce_*_rate_limit` helpers across `auth_routes.py`, `search_routes.py`, and `registry_routes.py` (~140 LoC of boilerplate gone).
- **`api/deps.py`**: extracted `_user_from_jwt(request, settings) -> (User | None, reason)`. Both `get_current_user` (raises 401) and `get_current_user_optional` (returns `None`) now use it. Removes ~50 LoC of duplication and makes the three failure modes — missing header, invalid signature, outdated `github_orgs` claim — explicit and testable in isolation.

### Security: missing rate limits on public endpoints
CLAUDE.md mandates that every public endpoint carries a per-IP limiter. Six did not. All now do:
- `GET /v1/taxonomy`
- `GET /v1/stats`
- `GET /v1/skills/{org}/{name}/summary`
- `GET /v1/skills/{org}/{name}/latest-version`
- `GET /v1/skills/{org}/{name}/eval-report`
- `GET /v1/skills/{org}/{name}/versions/{semver}/eval-report`

New settings (`stats_rate_limit/window`, `skill_summary_rate_limit/window`, `eval_report_rate_limit/window`, `taxonomy_rate_limit/window`) ship with generous defaults — the limit exists to block abusive bots, not to throttle the frontend.

### Correctness: search tiebreaker
`infra.database.search_skills_hybrid` ordered by `fts_rank DESC` and `vec_dist ASC` with no tiebreaker. Float ties → non-deterministic pagination, which violates the CLAUDE.md SQL rule. Both `LIMIT` queries now order by `(rank, organizations.slug, skills.name)` for deterministic top-N selection.

### Correctness: lost traceback on eval-trigger failure
`domain.publish_pipeline.execute_publish` swallowed the traceback on the eval-trigger error path:
```python
# before
except Exception as exc:
    logger.warning("Eval trigger failed for {}/{} v{}: {}", org_slug, skill_name, version, exc)
# after
except Exception:
    logger.opt(exception=True).warning("Eval trigger failed for {}/{} v{} (publish succeeded)", ...)
```
Now matches every other `opt(exception=True)` site in the file.

### Frontend: AskModal stale state
Per the CLAUDE.md React rule "reset state on context changes", the modal now clears `messages`, `query`, `error`, and `loading` whenever `isOpen` flips false. Previously a closed modal kept the old conversation and any error message in memory; reopening showed stale content.

## Tests

| File | Coverage added |
|--|--|
| `test_rate_limit.py` | `TestLazyRateLimiter`: lazy init, limiter reuse across calls, per-name isolation, 429 path |
| `test_deps.py` | `TestUserFromJwt`: missing header, non-Bearer, invalid signature, outdated claim, valid token |
| `test_public_endpoint_rate_limits.py` (new) | Each newly-protected public endpoint returns 429 once its limit is hit |
| `AskModal.test.tsx` | Conversation cleared after close+reopen; stale error cleared after close+reopen |

## Test plan

- [x] `make lint` — ruff clean (198 files)
- [x] `make typecheck` — mypy clean (88 files)
- [x] `make test-server` — **947 passed**, 34 deselected (slow)
- [x] `make test-client` — **291 passed**, 29 skipped (pre-existing)
- [x] `make test-shared` — **98 passed**
- [x] `make test-frontend` — **84 passed**
- [x] `make lint-frontend` — `tsc -b` clean; one pre-existing `react-hooks/exhaustive-deps` warning in `SkillDetailPage.tsx` that this PR does not touch
- [ ] Smoke-test `/v1/taxonomy` and `/v1/stats` against dev after deploy

## Out of scope (deferred to follow-ups)

These came up in the review but are too large for a focused PR; happy to open issues if any are wanted:
1. Split `infra/database.py` (3,465 LoC) by entity.
2. Split `domain/gauntlet.py` (1,355 LoC) by check type.
3. Split `client/cli/registry.py` (1,912 LoC) into `cli/commands/*.py`.
4. Add a transaction-scoped Postgres pytest fixture so `test_database.py` can exercise real SQL instead of mocks.
5. OpenTelemetry instrumentation (FastAPI / SQLAlchemy / httpx).
6. Frontend error boundary + Sentry.
7. Repository pattern for domain → infra coupling.
8. Delete `api/registry_service.py` once external scripts migrate to `domain.publish_pipeline` directly (currently a re-export shim with a duplicate `# noqa: F401` comment on the same line).

---
_Generated by [Claude Code](https://claude.ai/code/session_0166ZXerMpfdhtRwQ36Qnbqp)_