### PR TITLE
fix: hardening fixes from codebase review (rate limits, tracker visibility, retries)

### DIFF
--- a/server/src/decision_hub/api/app.py
+++ b/server/src/decision_hub/api/app.py
@@ -5,13 +5,14 @@ from pathlib import Path
 from typing import ClassVar
 
 import sqlalchemy as sa
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi.responses import FileResponse
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from decision_hub.api.deps import get_current_user
+from decision_hub.domain.publish_pipeline import GauntletRejectionError, VersionConflictError
 from decision_hub.infra.database import create_engine
 from decision_hub.infra.storage import create_s3_client
 from decision_hub.logging import RequestLoggingMiddleware, setup_logging
@@ -158,6 +159,21 @@ def create_app() -> FastAPI:
     app.state.engine = engine
     app.state.settings = settings
     app.state.s3_client = s3_client
+
+    # Map domain exceptions to HTTP responses centrally so individual routes
+    # don't have to translate them. Routes still call `execute_publish()`
+    # straight; if a route doesn't catch these, we get a sensible response
+    # instead of a 500.
+    @app.exception_handler(VersionConflictError)
+    async def _handle_version_conflict(_request: Request, exc: VersionConflictError) -> JSONResponse:
+        return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(GauntletRejectionError)
+    async def _handle_gauntlet_rejection(_request: Request, exc: GauntletRejectionError) -> JSONResponse:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": f"Gauntlet checks failed: {exc.summary}"},
+        )
 
     # In-memory TTL cache for hot read paths (per-container, not shared
     # across Modal replicas).

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -167,6 +167,24 @@ def _enforce_publish_rate_limit(request: Request) -> None:
     state._publish_rate_limiter(request)
 
 
+def _enforce_skill_metadata_rate_limit(request: Request) -> None:
+    """Rate-limit per-skill metadata reads (summary, latest-version, eval-report).
+
+    These four public endpoints are unauthenticated and each hits the DB.
+    Without a limiter they are trivially scrapable and can hot-loop the
+    database — share one limiter across them so a single bad client
+    can't single-handedly amplify per-endpoint quotas.
+    """
+    state = request.app.state
+    if not hasattr(state, "_skill_metadata_rate_limiter"):
+        settings: Settings = state.settings
+        state._skill_metadata_rate_limiter = RateLimiter(
+            max_requests=settings.skill_metadata_rate_limit,
+            window_seconds=settings.skill_metadata_rate_window,
+        )
+    state._skill_metadata_rate_limiter(request)
+
+
 _VALID_VISIBILITIES = {"public", "org"}
 
 
@@ -642,6 +660,7 @@ def list_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/summary",
     response_model=SkillSummary,
+    dependencies=[Depends(_enforce_skill_metadata_rate_limit)],
 )
 def get_skill_summary(
     org_slug: str,
@@ -718,6 +737,7 @@ def get_similar_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/latest-version",
     response_model=LatestVersionResponse,
+    dependencies=[Depends(_enforce_skill_metadata_rate_limit)],
 )
 def get_latest_version(
     org_slug: str,
@@ -955,6 +975,7 @@ def get_scan_report(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_skill_metadata_rate_limit)],
 )
 def get_eval_report_by_skill(
     org_slug: str,
@@ -977,6 +998,7 @@ def get_eval_report_by_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_skill_metadata_rate_limit)],
 )
 def get_eval_report_by_version_path(
     org_slug: str,

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -3,6 +3,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from threading import Lock
 from typing import Literal
 from uuid import UUID, uuid4
 
@@ -27,6 +28,28 @@ from decision_hub.models import SkillIndexEntry, User
 from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
+
+# Process-wide thread pool used to parallelise the two pre-retrieval Gemini
+# calls (topicality guard + query embedding). The previous implementation
+# created a fresh ThreadPoolExecutor per request, which churns OS threads
+# under load — a single-digit RPS bump can balloon into hundreds of
+# short-lived threads. A bounded shared pool reuses workers and caps
+# concurrent Gemini side-calls to a sensible ceiling.
+_SHARED_PARALLEL_POOL: ThreadPoolExecutor | None = None
+_POOL_LOCK = Lock()
+
+
+def _get_parallel_pool() -> ThreadPoolExecutor:
+    """Return a process-wide ThreadPoolExecutor, creating it on first use."""
+    global _SHARED_PARALLEL_POOL
+    if _SHARED_PARALLEL_POOL is None:
+        with _POOL_LOCK:
+            if _SHARED_PARALLEL_POOL is None:
+                _SHARED_PARALLEL_POOL = ThreadPoolExecutor(
+                    max_workers=8,
+                    thread_name_prefix="ask-parallel",
+                )
+    return _SHARED_PARALLEL_POOL
 
 
 def _enforce_search_rate_limit(request: Request) -> None:
@@ -341,11 +364,11 @@ def _ask_skills_inner(
             logger.opt(exception=True).warning("Query embedding failed, falling back to FTS-only")
             return None, 0
 
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        guard_future = pool.submit(_do_guard)
-        embed_future = pool.submit(_do_embed)
-        guard_result = guard_future.result()
-        query_embedding, embed_ms = embed_future.result()
+    pool = _get_parallel_pool()
+    guard_future = pool.submit(_do_guard)
+    embed_future = pool.submit(_do_embed)
+    guard_result = guard_future.result()
+    query_embedding, embed_ms = embed_future.result()
 
     if not guard_result.is_skill_query:
         return AskResponse(query=q, answer=_OFF_TOPIC_ANSWER, skills=[])

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -802,16 +802,25 @@ def process_tracker(
                     )
 
             all_failed = published_count == 0 and len(errors) > 0
+            # Surface every error to the operator, even on partial success.
+            # Previously last_error was only recorded when *every* skill failed,
+            # which silently hid mixed-outcome runs (e.g. 2/3 published) and
+            # advanced the tracker SHA past the broken skills with no audit
+            # trail — so the failed ones never retried and nobody noticed.
+            last_error = "; ".join(errors)[:500] if errors else None
             with engine.connect() as conn:
                 update_skill_tracker(
                     conn,
                     tracker.id,
-                    # Don't advance SHA when all publishes failed so
-                    # the commit is retried on the next check cycle.
+                    # Don't advance SHA when *all* publishes failed so the
+                    # commit is retried on the next check cycle. On partial
+                    # success we still advance — the successful skills are
+                    # already pinned to this SHA in the DB, but the recorded
+                    # last_error tells operators what's broken.
                     last_commit_sha=current_sha if not all_failed else None,
                     last_checked_at=now,
                     last_published_at=now if published_count > 0 else None,
-                    last_error="; ".join(errors)[:500] if all_failed else None,
+                    last_error=last_error,
                 )
                 conn.commit()
 

--- a/server/src/decision_hub/infra/anthropic_client.py
+++ b/server/src/decision_hub/infra/anthropic_client.py
@@ -5,11 +5,17 @@ avoiding a heavy SDK dependency.
 """
 
 import json
+import random
+import time
 
 import httpx
 from loguru import logger
 
 _ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+
+# Transient HTTP statuses that should be retried with backoff.
+# 429 = rate limit, 500/502/503 = server error, 529 = Anthropic overloaded.
+_RETRIABLE_STATUS_CODES = {429, 500, 502, 503, 529}
 
 _JUDGE_SYSTEM_PROMPT = """You are an evaluation judge for AI agent skill tests.
 
@@ -61,20 +67,68 @@ def judge_eval_output(
     }
 
     logger.debug("Calling Anthropic judge API model={} case={}", model, eval_case_name)
-    response = httpx.post(
-        _ANTHROPIC_API_URL,
-        json=payload,
-        headers=headers,
-        timeout=60,
-    )
-    response.raise_for_status()
-
-    data = response.json()
+    data = _post_with_retry(payload, headers)
     raw_text = data["content"][0]["text"]
 
     result = _parse_judge_response(raw_text)
     logger.debug("Judge verdict for '{}': {}", eval_case_name, result["verdict"])
     return result
+
+
+def _post_with_retry(
+    payload: dict,
+    headers: dict,
+    *,
+    timeout: int = 60,
+    max_retries: int = 3,
+) -> dict:
+    """POST to the Anthropic Messages API with retry and exponential backoff.
+
+    Retries on transient HTTP errors (429 rate limit, 5xx server errors,
+    529 overloaded) and timeouts. Non-retriable errors propagate
+    immediately. Mirrors the Gemini retry pattern in infra/gemini.py so
+    eval runs do not fail on a single transient blip from Anthropic.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1 + max_retries):
+        try:
+            resp = httpx.post(_ANTHROPIC_API_URL, json=payload, headers=headers, timeout=timeout)
+        except httpx.TimeoutException as exc:
+            last_exc = exc
+            if attempt < max_retries:
+                delay = 2**attempt + random.uniform(0, 0.5)
+                logger.warning(
+                    "Anthropic timeout, retrying in {:.1f}s (attempt {}/{})",
+                    delay,
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(delay)
+            continue
+
+        if resp.status_code < 400:
+            return resp.json()
+
+        if resp.status_code not in _RETRIABLE_STATUS_CODES:
+            resp.raise_for_status()
+
+        last_exc = httpx.HTTPStatusError(
+            message=f"HTTP {resp.status_code}",
+            request=resp.request,
+            response=resp,
+        )
+        if attempt < max_retries:
+            delay = 2**attempt + random.uniform(0, 0.5)  # ~1s, ~2s, ~4s
+            logger.warning(
+                "Anthropic returned {}, retrying in {:.1f}s (attempt {}/{})",
+                resp.status_code,
+                delay,
+                attempt + 1,
+                max_retries,
+            )
+            time.sleep(delay)
+
+    raise last_exc  # type: ignore[misc]
 
 
 def _parse_judge_response(raw_text: str) -> dict:

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,12 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    # Per-skill metadata reads (summary, latest-version, eval-report).
+    # Public, unauthenticated, hits the DB on every call — protect from
+    # unbounded scraping. Sized to mirror similar_skills so a normal user
+    # browsing skills never trips it.
+    skill_metadata_rate_limit: int = 120  # max requests per window
+    skill_metadata_rate_window: int = 60  # window in seconds
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,8 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.skill_metadata_rate_limit = 30
+    settings.skill_metadata_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_seo_routes.py
+++ b/server/tests/test_api/test_seo_routes.py
@@ -1,0 +1,99 @@
+"""Tests for decision_hub.api.seo_routes -- robots.txt and sitemap.xml.
+
+These public, unauthenticated endpoints had no coverage. They're served
+to crawlers, so a regression (e.g. allowing indexing on a non-prod host
+or breaking the XML schema) is hard to detect without a CI test.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from xml.etree import ElementTree as ET
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from decision_hub.api.seo_routes import router as seo_router
+from decision_hub.infra.cache import TTLCache
+
+
+@pytest.fixture
+def seo_app() -> FastAPI:
+    """A minimal FastAPI app with only the SEO routes wired up."""
+    app = FastAPI()
+
+    settings = MagicMock()
+    settings.cache_ttl_sitemap = 0  # disable caching so each test gets fresh content
+
+    app.state.settings = settings
+    app.state.cache = TTLCache(default_ttl=60)
+
+    # The sitemap endpoint queries the DB; provide a stub engine that
+    # yields an empty result set (no skills, no orgs).
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value = []  # iter() over an empty list
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value = mock_ctx
+    app.state.engine = mock_engine
+
+    app.include_router(seo_router)
+    return app
+
+
+@pytest.fixture
+def seo_client(seo_app: FastAPI) -> TestClient:
+    return TestClient(seo_app)
+
+
+class TestRobotsTxt:
+    def test_non_prod_host_disallows_everything(self, seo_client: TestClient) -> None:
+        """On any host other than the production domains, deny all crawlers
+        so dev / preview environments aren't indexed."""
+        resp = seo_client.get("/robots.txt", headers={"host": "hub-dev.decision.ai"})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert "Disallow: /" in resp.text
+        assert "Allow: /" not in resp.text
+
+    def test_prod_host_allows_indexing(self, seo_client: TestClient) -> None:
+        """On the canonical prod hosts, indexing is allowed and the
+        sitemap location is advertised."""
+        resp = seo_client.get("/robots.txt", headers={"host": "hub.decision.ai"})
+        assert resp.status_code == 200
+        assert "Allow: /" in resp.text
+        assert "Sitemap: https://hub.decision.ai/sitemap.xml" in resp.text
+
+    def test_localhost_disallows(self, seo_client: TestClient) -> None:
+        """localhost is not in the prod allow-list."""
+        resp = seo_client.get("/robots.txt", headers={"host": "localhost"})
+        assert resp.status_code == 200
+        assert "Disallow: /" in resp.text
+
+
+class TestSitemapXml:
+    def test_returns_valid_xml(self, seo_client: TestClient) -> None:
+        """The sitemap is well-formed XML using the standard schema."""
+        resp = seo_client.get("/sitemap.xml")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/xml")
+
+        # Parses without error → well-formed XML.
+        root = ET.fromstring(resp.text)
+        ns = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+        assert root.tag == f"{ns}urlset"
+
+        # The static landing-page URLs are always present.
+        locs = {url.findtext(f"{ns}loc") for url in root.findall(f"{ns}url")}
+        assert "https://hub.decision.ai/" in locs
+        assert "https://hub.decision.ai/skills" in locs
+        assert "https://hub.decision.ai/orgs" in locs
+
+    def test_lastmod_uses_today(self, seo_client: TestClient) -> None:
+        """The static URLs are stamped with today's date."""
+        resp = seo_client.get("/sitemap.xml")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert today in resp.text

--- a/server/tests/test_api/test_skill_metadata_rate_limit.py
+++ b/server/tests/test_api/test_skill_metadata_rate_limit.py
@@ -1,0 +1,145 @@
+"""Regression tests for the skill metadata rate limiter.
+
+Locks in the fix for missing rate limiters on four public endpoints:
+ - GET /v1/skills/{org_slug}/{skill_name}/summary
+ - GET /v1/skills/{org_slug}/{skill_name}/latest-version
+ - GET /v1/skills/{org_slug}/{skill_name}/eval-report
+ - GET /v1/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report
+
+Without a limiter these are trivially scrapable. They share one limiter
+(``settings.skill_metadata_rate_limit``) so that a hostile client cannot
+multiply quotas across endpoints.
+"""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tests.factories import make_org, make_skill, make_version
+
+
+def _set_low_limit(app: FastAPI, limit: int = 2) -> None:
+    """Tighten the metadata limiter and discard any previously created instance."""
+    app.state.settings.skill_metadata_rate_limit = limit
+    app.state.settings.skill_metadata_rate_window = 60
+    if hasattr(app.state, "_skill_metadata_rate_limiter"):
+        delattr(app.state, "_skill_metadata_rate_limiter")
+
+
+class TestSkillMetadataRateLimit:
+    """All four metadata endpoints share a single per-IP sliding-window limiter."""
+
+    @patch("decision_hub.api.registry_routes.has_active_tracker_for_repo", return_value=False)
+    @patch("decision_hub.api.registry_routes.find_org_by_slug")
+    @patch("decision_hub.api.registry_routes.resolve_latest_version")
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_summary_is_rate_limited(
+        self,
+        mock_find_skill,
+        mock_resolve,
+        mock_find_org,
+        _mock_tracker,
+        test_app: FastAPI,
+    ) -> None:
+        org = make_org()
+        skill = make_skill(org)
+        mock_find_org.return_value = org
+        mock_find_skill.return_value = skill
+        mock_resolve.return_value = make_version(skill)
+        _set_low_limit(test_app, limit=2)
+        client = TestClient(test_app)
+
+        for _ in range(2):
+            resp = client.get("/v1/skills/test-org/my-skill/summary")
+            assert resp.status_code == 200
+
+        resp = client.get("/v1/skills/test-org/my-skill/summary")
+        assert resp.status_code == 429
+
+    @patch("decision_hub.api.registry_routes.resolve_latest_version")
+    def test_latest_version_is_rate_limited(
+        self,
+        mock_resolve,
+        test_app: FastAPI,
+    ) -> None:
+        org = make_org()
+        skill = make_skill(org)
+        mock_resolve.return_value = make_version(skill)
+        _set_low_limit(test_app, limit=2)
+        client = TestClient(test_app)
+
+        for _ in range(2):
+            resp = client.get("/v1/skills/test-org/my-skill/latest-version")
+            assert resp.status_code == 200
+
+        resp = client.get("/v1/skills/test-org/my-skill/latest-version")
+        assert resp.status_code == 429
+
+    @patch("decision_hub.api.registry_routes.find_eval_report_by_skill", return_value=None)
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_eval_report_query_is_rate_limited(
+        self,
+        mock_find_skill,
+        _mock_report,
+        test_app: FastAPI,
+    ) -> None:
+        org = make_org()
+        mock_find_skill.return_value = make_skill(org)
+        _set_low_limit(test_app, limit=2)
+        client = TestClient(test_app)
+
+        for _ in range(2):
+            resp = client.get("/v1/skills/test-org/my-skill/eval-report?semver=1.0.0")
+            assert resp.status_code == 200
+
+        resp = client.get("/v1/skills/test-org/my-skill/eval-report?semver=1.0.0")
+        assert resp.status_code == 429
+
+    @patch("decision_hub.api.registry_routes.find_eval_report_by_skill", return_value=None)
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_eval_report_path_is_rate_limited(
+        self,
+        mock_find_skill,
+        _mock_report,
+        test_app: FastAPI,
+    ) -> None:
+        org = make_org()
+        mock_find_skill.return_value = make_skill(org)
+        _set_low_limit(test_app, limit=2)
+        client = TestClient(test_app)
+
+        for _ in range(2):
+            resp = client.get("/v1/skills/test-org/my-skill/versions/1.0.0/eval-report")
+            assert resp.status_code == 200
+
+        resp = client.get("/v1/skills/test-org/my-skill/versions/1.0.0/eval-report")
+        assert resp.status_code == 429
+
+    @patch("decision_hub.api.registry_routes.find_eval_report_by_skill", return_value=None)
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    @patch("decision_hub.api.registry_routes.resolve_latest_version")
+    def test_limiter_is_shared_across_metadata_endpoints(
+        self,
+        mock_resolve,
+        mock_find_skill,
+        _mock_report,
+        test_app: FastAPI,
+    ) -> None:
+        """A single limiter covers all four endpoints — the budget cannot be
+        multiplied by alternating between them.
+        """
+        org = make_org()
+        skill = make_skill(org)
+        mock_find_skill.return_value = skill
+        mock_resolve.return_value = make_version(skill)
+        _set_low_limit(test_app, limit=2)
+        client = TestClient(test_app)
+
+        # First two requests across two different metadata endpoints fill the budget.
+        assert client.get("/v1/skills/test-org/my-skill/latest-version").status_code == 200
+        assert client.get("/v1/skills/test-org/my-skill/eval-report?semver=1.0.0").status_code == 200
+
+        # Third request — to a *third* metadata endpoint — must still be rejected.
+        resp = client.get("/v1/skills/test-org/my-skill/versions/1.0.0/eval-report")
+        assert resp.status_code == 429

--- a/server/tests/test_api/test_taxonomy_routes.py
+++ b/server/tests/test_api/test_taxonomy_routes.py
@@ -1,0 +1,39 @@
+"""Tests for decision_hub.api.taxonomy_routes -- the /v1/taxonomy endpoint.
+
+The taxonomy endpoint is tiny but completely public and was the only
+route under api/ with no test coverage at all. The test locks in the
+response shape and the cache header behaviour.
+"""
+
+from fastapi.testclient import TestClient
+
+
+class TestGetTaxonomy:
+    def test_returns_groups_dict(self, client: TestClient) -> None:
+        """Returns a `groups` mapping from taxonomy group name → subcategory list."""
+        resp = client.get("/v1/taxonomy")
+        assert resp.status_code == 200
+
+        body = resp.json()
+        assert "groups" in body
+        groups = body["groups"]
+        assert isinstance(groups, dict)
+        assert len(groups) > 0
+        # Every value should be a list of strings.
+        for key, value in groups.items():
+            assert isinstance(key, str)
+            assert isinstance(value, list)
+            assert all(isinstance(s, str) for s in value)
+
+    def test_sets_cache_control_header(self, client: TestClient) -> None:
+        """Static content — clients should be told to cache it."""
+        resp = client.get("/v1/taxonomy")
+        assert resp.status_code == 200
+        # Default test settings set cache_ttl_taxonomy=300.
+        assert "max-age=" in resp.headers.get("cache-control", "")
+
+    def test_returns_same_content_on_repeat_calls(self, client: TestClient) -> None:
+        """The taxonomy is static; repeated requests yield identical bodies."""
+        first = client.get("/v1/taxonomy").json()
+        second = client.get("/v1/taxonomy").json()
+        assert first == second

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -291,7 +291,13 @@ class TestProcessTrackerAllFailed:
         _mock_commits,
         _mock_token,
     ):
-        """When at least one skill succeeds, SHA advances and no error is recorded."""
+        """Mixed run: SHA advances (successful skills are now pinned to it),
+        but ``last_error`` records the failed skills so operators can see
+        what's broken — even though some skills published successfully.
+
+        Regression: previously ``last_error`` was only recorded when *every*
+        skill failed, which silently hid mixed-outcome runs.
+        """
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
@@ -314,9 +320,67 @@ class TestProcessTrackerAllFailed:
 
             mock_update.assert_called_once()
             _, kwargs = mock_update.call_args
-            # SHA should advance since at least one succeeded
+            # SHA should advance since at least one succeeded.
             assert kwargs["last_commit_sha"] == "new_sha_xyz"
-            assert kwargs["last_error"] is None
+            # last_published_at is set since a publish actually happened.
+            assert kwargs["last_published_at"] is not None
+            # Failure is now visible to the operator (was None before fix).
+            assert kwargs["last_error"] is not None
+            assert "skill-b" in kwargs["last_error"]
+            assert "gauntlet error" in kwargs["last_error"]
+
+    @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
+    @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
+    @patch("decision_hub.domain.tracker_service.clone_repo")
+    @patch("decision_hub.domain.tracker_service.discover_skills")
+    @patch("decision_hub.infra.storage.create_s3_client")
+    @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
+    def test_partial_failure_with_multiple_errors_aggregates_them(
+        self,
+        mock_publish,
+        _mock_s3,
+        mock_discover,
+        mock_clone,
+        _mock_commits,
+        _mock_token,
+    ):
+        """Multiple failed skills are concatenated into ``last_error``.
+
+        Locks in the partial-failure visibility fix: every error is named
+        with its skill so operators can act, capped at 500 chars to fit
+        the column.
+        """
+        tracker = self._make_tracker()
+        mock_clone.return_value = Path("/tmp/fake/repo")
+        mock_discover.return_value = [
+            Path("/tmp/fake/repo/skill-a"),
+            Path("/tmp/fake/repo/skill-b"),
+            Path("/tmp/fake/repo/skill-c"),
+        ]
+        mock_publish.side_effect = [
+            True,
+            RuntimeError("bad manifest"),
+            ValueError("zip too large"),
+        ]
+
+        mock_conn = MagicMock()
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_settings = MagicMock()
+        mock_settings.database_url = "postgresql://test"
+
+        with patch("decision_hub.infra.database.update_skill_tracker") as mock_update:
+            process_tracker(tracker, mock_settings, mock_engine)
+
+            mock_update.assert_called_once()
+            _, kwargs = mock_update.call_args
+            err = kwargs["last_error"]
+            assert err is not None
+            assert "skill-b" in err and "bad manifest" in err
+            assert "skill-c" in err and "zip too large" in err
+            assert len(err) <= 500
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
@@ -1749,7 +1813,7 @@ class TestProcessTrackerMultiSkillPartialFailure:
     @patch("decision_hub.domain.tracker_service.discover_skills")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
-    def test_three_of_five_succeed_advances_sha_clears_error(
+    def test_three_of_five_succeed_advances_sha_records_errors(
         self,
         mock_publish,
         _mock_s3,
@@ -1758,7 +1822,14 @@ class TestProcessTrackerMultiSkillPartialFailure:
         _mock_commits,
         _mock_token,
     ):
-        """When 3 out of 5 skills succeed and 2 fail, SHA advances and last_error is cleared."""
+        """3-of-5 succeed: SHA advances, ``last_published_at`` is set, and
+        ``last_error`` aggregates the two failed skills.
+
+        Regression: pre-fix, ``last_error`` was set to None on partial
+        success — operators couldn't tell mixed-outcome runs from clean
+        ones, and the failed skills never retried because the SHA had
+        moved on.
+        """
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
@@ -1790,12 +1861,15 @@ class TestProcessTrackerMultiSkillPartialFailure:
 
             mock_update.assert_called_once()
             _, kwargs = mock_update.call_args
-            # SHA advances because at least one skill succeeded
+            # SHA advances because at least one skill succeeded.
             assert kwargs["last_commit_sha"] == "new_sha_multi"
-            # last_error is None because not all failed
-            assert kwargs["last_error"] is None
-            # last_published_at should be set because 3 skills were published
+            # last_published_at is set because 3 skills were published.
             assert kwargs["last_published_at"] is not None
+            # last_error now reports both failures so operators can act.
+            err = kwargs["last_error"]
+            assert err is not None
+            assert "skill-b" in err
+            assert "skill-e" in err
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_all_fail"))

--- a/server/tests/test_infra/test_anthropic_client.py
+++ b/server/tests/test_infra/test_anthropic_client.py
@@ -98,9 +98,9 @@ class TestJudgeEvalOutput:
         assert len(user_content) < 15000
 
     @respx.mock
-    def test_api_error_propagates(self) -> None:
-        """httpx errors should propagate up."""
-        respx.post("https://api.anthropic.com/v1/messages").mock(return_value=httpx.Response(500, text="Server Error"))
+    def test_non_retriable_api_error_propagates(self) -> None:
+        """Non-retriable 4xx errors propagate immediately."""
+        respx.post("https://api.anthropic.com/v1/messages").mock(return_value=httpx.Response(400, text="Bad Request"))
 
         with pytest.raises(httpx.HTTPStatusError):
             judge_eval_output(
@@ -110,3 +110,73 @@ class TestJudgeEvalOutput:
                 eval_criteria="criteria",
                 agent_output="output",
             )
+
+    @respx.mock
+    def test_retries_on_transient_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A transient 503 is retried; the second attempt's success is returned."""
+        # Skip backoff sleeps so the test runs fast.
+        monkeypatch.setattr("decision_hub.infra.anthropic_client.time.sleep", lambda _: None)
+
+        success_body = {"content": [{"text": json.dumps({"verdict": "pass", "reasoning": "ok"})}]}
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            side_effect=[
+                httpx.Response(503, text="Service Unavailable"),
+                httpx.Response(200, json=success_body),
+            ]
+        )
+
+        result = judge_eval_output(
+            api_key="test-key",
+            model="test-model",
+            eval_case_name="test",
+            eval_criteria="criteria",
+            agent_output="output",
+        )
+
+        assert result["verdict"] == "pass"
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_retries_on_anthropic_overloaded_529(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """529 (Anthropic overloaded) is treated as retriable."""
+        monkeypatch.setattr("decision_hub.infra.anthropic_client.time.sleep", lambda _: None)
+
+        success_body = {"content": [{"text": json.dumps({"verdict": "fail", "reasoning": "no"})}]}
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            side_effect=[
+                httpx.Response(529, text="Overloaded"),
+                httpx.Response(529, text="Overloaded"),
+                httpx.Response(200, json=success_body),
+            ]
+        )
+
+        result = judge_eval_output(
+            api_key="test-key",
+            model="test-model",
+            eval_case_name="test",
+            eval_criteria="criteria",
+            agent_output="output",
+        )
+
+        assert result["verdict"] == "fail"
+        assert route.call_count == 3
+
+    @respx.mock
+    def test_gives_up_after_max_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After 1 initial + 3 retries on a retriable error, the last status is raised."""
+        monkeypatch.setattr("decision_hub.infra.anthropic_client.time.sleep", lambda _: None)
+
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(503, text="Service Unavailable"),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            judge_eval_output(
+                api_key="test-key",
+                model="test-model",
+                eval_case_name="test",
+                eval_criteria="criteria",
+                agent_output="output",
+            )
+
+        assert route.call_count == 4  # 1 initial + 3 retries


### PR DESCRIPTION
## Summary

Five focused, defensive fixes surfaced by a deep architecture / bug /
security / performance / testing review of the codebase. Each fix is
small, low-risk, and has a regression test that locks in the new
behaviour. The bigger refactor candidates from the review (splitting
`infra/database.py` and `domain/gauntlet.py`, centralising manifest
parsing, parallelising eval judging) are intentionally **not** in this
PR — they each warrant their own focused PR per `CLAUDE.md`.

## Fixes

### 1 · Rate-limit four unprotected public endpoints  *(security · high)*

`/v1/skills/{org}/{name}/summary`, `/latest-version`,
`/eval-report`, `/versions/{semver}/eval-report` were
unauthenticated DB-hitters with no rate limiter — a clear violation of
the limiter pattern enforced everywhere else in `api/`. Added a single
**shared** `skill_metadata` limiter (`settings.skill_metadata_rate_limit`,
default 120/min) so a hostile client cannot multiply quotas across the
four endpoints.

- `server/src/decision_hub/settings.py` — new settings.
- `server/src/decision_hub/api/registry_routes.py` — `_enforce_skill_metadata_rate_limit` + `dependencies=[…]` on the four endpoints.
- `server/tests/test_api/test_skill_metadata_rate_limit.py` (new) — 5 tests, including one that proves the limiter is **shared** across the four endpoints.

### 2 · Tracker partial-failure visibility  *(bugs · high)*

In `domain/tracker_service.py`, when a multi-skill repo had mixed
outcomes (e.g. 3 published, 2 failed), `last_error` was only set when
**every** skill failed. Partial failures silently disappeared:
`last_error` was None, the SHA advanced past the broken skills, and
the failed skills never retried. The fix: record `last_error` on
**any** failure; advance the SHA only when **all** skills failed
(unchanged for that case). The successful skills are already pinned to
the new SHA in the DB, but the operator now has visibility into what
broke.

- `server/src/decision_hub/domain/tracker_service.py:804–823`.
- `server/tests/test_domain/test_tracker_service.py` — updated existing
  partial-success test to assert errors are now recorded; added a new
  test that asserts multiple failures are aggregated and capped at 500
  chars.

### 3 · Anthropic judge retry + exponential backoff  *(reliability · high)*

`infra/anthropic_client.py` had a 60s timeout but **no retries**, while
the Gemini client correctly retries on transient 4xx/5xx with jittered
backoff. Transient 503 / 529 ("Anthropic overloaded") killed eval runs
with a misleading "judge error" report. Added a `_post_with_retry`
helper that mirrors the Gemini pattern (retries on 429/500/502/503/529
and timeouts; ~1s/2s/4s jittered backoff; 3 retries max).

- `server/src/decision_hub/infra/anthropic_client.py`.
- `server/tests/test_infra/test_anthropic_client.py` — adjusted existing
  500-error test to use a non-retriable 400, and added 3 new retry
  tests (transient 503 succeeds on retry; 529 succeeds after multiple
  retries; gives up after the configured maximum).

### 4 · Replace per-request `ThreadPoolExecutor` in `/v1/ask`  *(performance · medium)*

`api/search_routes.py:344` constructed a fresh
`ThreadPoolExecutor(max_workers=2)` **per request** to parallelise the
topicality-guard and embedding Gemini calls. Under any concurrency this
churns OS threads. Replaced with a process-wide bounded pool
(`max_workers=8`, lazily initialised) so workers are reused.

### 5 · Global domain → HTTP exception handler  *(code-health · medium)*

`api/app.py` now registers exception handlers for
`VersionConflictError` (-> 409) and `GauntletRejectionError` (-> 422)
so individual routes don't need to translate them. The existing
route-level `try/except` in `publish` is preserved as defense in
depth.

## Net-new test coverage

Two server modules previously had **zero** tests; both are public,
unauthenticated, and crawler-facing — exactly the surface area where a
silent regression hurts most.

- `server/tests/test_api/test_seo_routes.py` (new, 5 tests) — covers
  prod vs non-prod robots.txt behaviour and validates that
  `/sitemap.xml` returns well-formed XML using the standard schema.
- `server/tests/test_api/test_taxonomy_routes.py` (new, 3 tests) —
  covers `/v1/taxonomy` shape, cache header, and idempotency.

## Verification

- ✅ `uvx ruff check .` — all checks passed
- ✅ `uvx ruff format --check .` — 200 files already formatted
- ✅ `uvx mypy client/src/ server/src/ shared/src/` — no issues found in 88 source files
- ✅ `uv run --package decision-hub-server --extra dev pytest server/tests/ -m "not slow"` — **950 passed, 34 deselected** (29s)
- ✅ `uv run --package dhub-cli --extra dev pytest client/tests/` — 291 passed, 29 skipped
- ✅ `uv run --package dhub-core --extra dev pytest shared/tests/` — 98 passed
- Frontend untouched (no TypeScript / React files modified).

## Test plan

- [ ] Verify in dev that `/v1/skills/<org>/<name>/summary` and the three other endpoints return 429 after >120 hits/minute
- [ ] Confirm a tracker run with at least one publish failure now writes `last_error` (was previously NULL on partial success)
- [ ] Confirm Anthropic 503 incident no longer surfaces as a hard "judge error" — eval should retry transparently
- [ ] Re-run `/v1/ask` smoke test under concurrency and confirm thread count stays bounded

## Out of scope (deliberately deferred to follow-up PRs)

- Splitting `infra/database.py` (3,465 LOC, imported by 22 modules) into per-domain modules
- Splitting `domain/gauntlet.py` (1,355 LOC) into a per-check policy registry
- Centralising SKILL.md parsing in `shared/dhub_core/manifest.py`
- Parallelising per-case eval judging via `asyncio.gather`
- Resumability / checkpointing for the embedding & metadata backfill scripts

https://claude.ai/code/session_01HDSKYHUU3TRmxxXP4RAz2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDSKYHUU3TRmxxXP4RAz2P)_