### PR TITLE
fix: update stale lfiaschi API URLs to pymc-labs

### DIFF
--- a/.claude/commands/test-upload-evals-skill.md
+++ b/.claude/commands/test-upload-evals-skill.md
@@ -134,7 +134,7 @@ If you get a **500 error**, check:
 The eval pipeline takes **3–6 minutes** (sandbox spin-up + `uv sync` for PyMC + MCMC sampling + LLM judge). Poll the eval-report endpoint:
 
 ```bash
-curl -s "https://lfiaschi--api-dev.modal.run/v1/skills/lfiaschi/bayesian-ab-test/eval-report?semver=<version>" | python3 -m json.tool
+curl -s "https://pymc-labs--api-dev.modal.run/v1/skills/lfiaschi/bayesian-ab-test/eval-report?semver=<version>" | python3 -m json.tool
 ```
 
 - Returns `null` while evals are still running.

--- a/bootstrap-skills/dhub-cli/SKILL.md
+++ b/bootstrap-skills/dhub-cli/SKILL.md
@@ -47,8 +47,8 @@ dhub supports two independent stacks controlled by `DHUB_ENV`:
 
 | Env | API URL | Config File |
 |-----|---------|-------------|
-| `prod` (default) | `https://lfiaschi--api.modal.run` | `~/.dhub/config.prod.json` |
-| `dev` | `https://lfiaschi--api-dev.modal.run` | `~/.dhub/config.dev.json` |
+| `prod` (default) | `https://pymc-labs--api.modal.run` | `~/.dhub/config.prod.json` |
+| `dev` | `https://pymc-labs--api-dev.modal.run` | `~/.dhub/config.dev.json` |
 
 Always prefix commands with `DHUB_ENV=dev` when working against the dev stack:
 

--- a/bootstrap-skills/dhub-cli/references/command_reference.md
+++ b/bootstrap-skills/dhub-cli/references/command_reference.md
@@ -23,7 +23,7 @@ dhub login [--api-url URL]
 
 **Config after login:**
 ```json
-{"api_url": "https://lfiaschi--api.modal.run", "token": "<oauth_token>"}
+{"api_url": "https://pymc-labs--api.modal.run", "token": "<oauth_token>"}
 ```
 
 ---

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
 # Decision Hub Frontend Configuration
 # API URL defaults to dev if not set
-VITE_API_URL=https://lfiaschi--api-dev.modal.run
+VITE_API_URL=https://pymc-labs--api-dev.modal.run


### PR DESCRIPTION
## Summary

- Replaces all remaining `lfiaschi--api.modal.run` URLs with `pymc-labs--api.modal.run` across four files missed during the Feb 2026 migration (f318ab6)
- The old URLs still resolve but serve the frontend HTML instead of the API, causing silent breakage

Closes #356

## Test plan

- [ ] Verify no `lfiaschi--api` references remain: `grep -rn "lfiaschi--api" .`
- [ ] Republish the `pymc-labs/dhub-cli` skill so AI assistants pick up the corrected URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)