### PR TITLE
fix: cap network and memory blast radius on shared infra

### DIFF
--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -26,11 +26,23 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # Run the stale-IP purge every N admitted requests. Cheap counter
+    # avoids the O(n) `sum(len(v) for ...)` that the previous
+    # implementation ran on every call.
+    _PURGE_EVERY = 100
+
+    # Hard ceiling on tracked IPs. A botnet of rotating source IPs would
+    # otherwise force unbounded growth between purges. When breached we
+    # purge eagerly; if that doesn't free space we drop the request with
+    # 429 instead of growing without bound.
+    _MAX_TRACKED_KEYS = 10_000
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._calls_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -51,12 +63,25 @@ class RateLimiter:
                 )
 
             self._requests[key].append(now)
+            self._calls_since_purge += 1
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            # Periodic background purge keeps the dict from growing slowly
+            # under steady traffic.
+            if self._calls_since_purge >= self._PURGE_EVERY:
                 self._purge_stale(cutoff)
+                self._calls_since_purge = 0
+
+            # Hard ceiling: under a flood of unique IPs the periodic purge
+            # is too lazy. Force a purge once we cross the cap and, if the
+            # caller is itself a brand-new IP that pushed us over, reject.
+            if len(self._requests) > self._MAX_TRACKED_KEYS:
+                self._purge_stale(cutoff)
+                self._calls_since_purge = 0
+                if len(self._requests) > self._MAX_TRACKED_KEYS:
+                    raise HTTPException(
+                        status_code=429,
+                        detail="Rate limiter saturated. Try again shortly.",
+                    )
 
     def _purge_stale(self, cutoff: float) -> None:
         """Remove IPs with no recent activity. Caller must hold self._lock."""

--- a/server/src/decision_hub/infra/github.py
+++ b/server/src/decision_hub/infra/github.py
@@ -22,6 +22,12 @@ GITHUB_USER_ORGS_URL = "https://api.github.com/user/orgs"
 
 _ACCEPT_JSON = "application/json"
 
+# Hard timeout for every outbound GitHub call. Without this, a slow or
+# unresponsive github.com pins the FastAPI event loop for httpx's default
+# ~5-minute connect timeout, starving other async traffic on the same
+# Modal container.
+_DEFAULT_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
+
 
 class AuthorizationPending(Exception):
     """Raised when the user has not yet completed GitHub authorization."""
@@ -44,7 +50,7 @@ async def request_device_code(client_id: str) -> DeviceCodeResponse:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.post(
             GITHUB_DEVICE_CODE_URL,
             data={"client_id": client_id, "scope": "read:org"},
@@ -79,7 +85,7 @@ async def poll_for_access_token(client_id: str, device_code: str, interval: int 
         RuntimeError: If the user denies access or the device code expires.
         httpx.HTTPStatusError: If the GitHub API returns an unexpected error.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.post(
             GITHUB_ACCESS_TOKEN_URL,
             data={
@@ -123,7 +129,7 @@ async def get_github_user(access_token: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.get(
             GITHUB_USER_URL,
             headers={
@@ -168,7 +174,7 @@ async def list_user_orgs(access_token: str) -> list[dict]:
     orgs: list[dict] = []
     url: str | None = f"{GITHUB_USER_ORGS_URL}?per_page=100"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         while url is not None:
             response = await client.get(
                 url,
@@ -201,7 +207,7 @@ async def check_org_membership(access_token: str, org: str, username: str) -> bo
     Returns:
         True if the user is a member of the organization.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org}/members/{username}",
             headers={
@@ -235,7 +241,7 @@ async def fetch_org_metadata(access_token: str, org_login: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org_login}",
             headers={
@@ -270,7 +276,7 @@ async def fetch_user_metadata(access_token: str, username: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/users/{username}",
             headers={

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -84,3 +84,71 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestRateLimiterPurge:
+    """Stale-IP purge keeps memory bounded."""
+
+    def test_periodic_purge_drops_stale_keys(self) -> None:
+        """After enough requests, IPs with only-expired timestamps disappear."""
+        limiter = RateLimiter(max_requests=5, window_seconds=10)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            # Seed many distinct IPs at t=0.
+            mock_time.monotonic.return_value = 0.0
+            for i in range(50):
+                limiter(_make_request(f"10.0.0.{i}"))
+            assert len(limiter._requests) == 50
+
+            # Jump past the window so all those entries are now stale.
+            mock_time.monotonic.return_value = 1000.0
+
+            # Drive enough fresh traffic from one IP to trigger _PURGE_EVERY.
+            fresh = _make_request("192.168.1.1")
+            for _ in range(RateLimiter._PURGE_EVERY):
+                # Reset the per-key list so a single IP can drive many calls
+                # without exhausting its own quota.
+                limiter._requests["192.168.1.1"] = []
+                limiter(fresh)
+
+        # After the periodic purge fires, only the fresh IP should remain.
+        assert "192.168.1.1" in limiter._requests
+        assert all(k.startswith("192.168.1.") for k in limiter._requests)
+
+    def test_saturation_rejects_new_ip_with_429(self, monkeypatch) -> None:
+        """When the tracked-IP cap is hit and nothing is purgeable, reject."""
+        # Shrink the cap so the test is fast and obvious.
+        monkeypatch.setattr(RateLimiter, "_MAX_TRACKED_KEYS", 10)
+
+        limiter = RateLimiter(max_requests=5, window_seconds=60)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            # Fill at the cap with fresh entries the purge can't reclaim.
+            for i in range(10):
+                limiter._requests[f"ip-{i}"] = [100.0]
+
+            # The next brand-new IP pushes us over and should be rejected.
+            with pytest.raises(HTTPException) as exc_info:
+                limiter(_make_request("brand-new-ip"))
+            assert exc_info.value.status_code == 429
+
+    def test_saturation_admits_when_purge_frees_space(self, monkeypatch) -> None:
+        """If the cap is hit but stale entries exist, purge them and admit."""
+        monkeypatch.setattr(RateLimiter, "_MAX_TRACKED_KEYS", 10)
+
+        limiter = RateLimiter(max_requests=5, window_seconds=10)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            # Fill at the cap with stale entries.
+            mock_time.monotonic.return_value = 0.0
+            for i in range(10):
+                limiter._requests[f"ip-{i}"] = [0.0]
+
+            # Jump past the window — all 10 are now purgeable.
+            mock_time.monotonic.return_value = 1000.0
+
+            # New IP is admitted; purge reclaims space.
+            limiter(_make_request("brand-new-ip"))  # should not raise
+            assert "brand-new-ip" in limiter._requests
+            assert len(limiter._requests) <= 10

--- a/server/tests/test_infra/test_cache.py
+++ b/server/tests/test_infra/test_cache.py
@@ -1,8 +1,29 @@
 """Tests for decision_hub.infra.cache -- in-memory TTL cache."""
 
-import time
+from unittest.mock import patch
+
+import pytest
 
 from decision_hub.infra.cache import TTLCache
+
+
+@pytest.fixture
+def fake_clock():
+    """Drive cache expiration deterministically.
+
+    Patches ``time.monotonic`` inside the cache module so tests don't have
+    to call ``time.sleep`` and risk flaking on slow CI runners.
+    """
+    state = {"now": 1000.0}
+
+    def fake_monotonic() -> float:
+        return state["now"]
+
+    def advance(seconds: float) -> None:
+        state["now"] += seconds
+
+    with patch("decision_hub.infra.cache.time.monotonic", side_effect=fake_monotonic):
+        yield advance
 
 
 class TestTTLCacheBasics:
@@ -39,24 +60,24 @@ class TestTTLCacheBasics:
 class TestTTLCacheExpiration:
     """TTL-based expiration behaviour."""
 
-    def test_expired_entry_returns_none(self) -> None:
+    def test_expired_entry_returns_none(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=10)
-        cache.set("key", "value", ttl=0.01)
-        time.sleep(0.02)
+        cache.set("key", "value", ttl=5)
+        fake_clock(6)
         assert cache.get("key") is None
 
-    def test_per_entry_ttl_override(self) -> None:
-        cache = TTLCache(default_ttl=0.01)
-        cache.set("short", "fast", ttl=0.01)
-        cache.set("long", "slow", ttl=10)
-        time.sleep(0.02)
+    def test_per_entry_ttl_override(self, fake_clock) -> None:
+        cache = TTLCache(default_ttl=1)
+        cache.set("short", "fast", ttl=1)
+        cache.set("long", "slow", ttl=100)
+        fake_clock(2)
         assert cache.get("short") is None
         assert cache.get("long") == "slow"
 
-    def test_expired_entry_is_cleaned_on_get(self) -> None:
-        cache = TTLCache(default_ttl=0.01)
+    def test_expired_entry_is_cleaned_on_get(self, fake_clock) -> None:
+        cache = TTLCache(default_ttl=1)
         cache.set("key", "value")
-        time.sleep(0.02)
+        fake_clock(2)
         # First get should clean up the expired entry
         assert cache.get("key") is None
         # Internal store should be empty
@@ -76,11 +97,11 @@ class TestTTLCacheEviction:
         # The newest entry should still be present
         assert cache.get("c") == 3
 
-    def test_prefers_evicting_expired_entries(self) -> None:
+    def test_prefers_evicting_expired_entries(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=60, max_size=2)
-        cache.set("expired", "old", ttl=0.01)
+        cache.set("expired", "old", ttl=1)
         cache.set("fresh", "new", ttl=60)
-        time.sleep(0.02)
+        fake_clock(2)
         # Adding a third entry should evict the expired one
         cache.set("newest", "latest")
         assert cache.get("fresh") == "new"
@@ -94,16 +115,23 @@ class TestTTLCacheEviction:
         assert cache.get("a") == 10
         assert cache.get("b") == 2
 
+    def test_set_under_concurrent_full_state_respects_max_size(self) -> None:
+        # Filling beyond max_size from a single thread should never let
+        # the store exceed max_size, even if multiple inserts contend.
+        cache = TTLCache(default_ttl=60, max_size=3)
+        for i in range(20):
+            cache.set(f"k-{i}", i)
+        assert len(cache._store) <= 3
+
 
 class TestTTLCacheDisabledTTL:
     """Verify zero-TTL means caching is effectively disabled."""
 
-    def test_zero_ttl_entry_expires_immediately(self) -> None:
+    def test_zero_ttl_entry_expires_immediately(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=60)
         cache.set("key", "value", ttl=0)
-        # Entry should already be expired (monotonic clock precision)
-        # Give a tiny sleep to ensure monotonic moves forward
-        time.sleep(0.001)
+        # Any forward motion of the clock invalidates a 0-TTL entry.
+        fake_clock(0.001)
         assert cache.get("key") is None
 
 

--- a/server/tests/test_infra/test_github.py
+++ b/server/tests/test_infra/test_github.py
@@ -4,12 +4,39 @@ import httpx
 import pytest
 import respx
 
+from decision_hub.infra import github as github_module
 from decision_hub.infra.github import (
+    _DEFAULT_TIMEOUT,
     _parse_next_link,
     fetch_org_metadata,
     fetch_user_metadata,
     list_user_orgs,
 )
+
+
+class TestDefaultTimeout:
+    """Every outbound GitHub call must carry a finite timeout.
+
+    Without one a slow github.com pins the FastAPI event loop on
+    httpx's ~5 minute default connect timeout. Regression guard.
+    """
+
+    def test_default_timeout_is_finite_and_short(self) -> None:
+        assert isinstance(_DEFAULT_TIMEOUT, httpx.Timeout)
+        # Read timeout must be set and well under a minute.
+        assert _DEFAULT_TIMEOUT.read is not None
+        assert _DEFAULT_TIMEOUT.read <= 30
+        assert _DEFAULT_TIMEOUT.connect is not None
+        assert _DEFAULT_TIMEOUT.connect <= 30
+
+    def test_no_unbounded_async_clients_in_module(self) -> None:
+        # Belt and braces: scan the source for `httpx.AsyncClient()` with
+        # no keyword args, which is the buggy form that has no timeout.
+        import inspect
+
+        source = inspect.getsource(github_module)
+        # The literal "httpx.AsyncClient()" (empty parens) is the broken form.
+        assert "httpx.AsyncClient()" not in source
 
 
 class TestParseNextLink:


### PR DESCRIPTION
## Summary

Three small reliability/security fixes surfaced during a principal-engineer review of the server. Each fix is independently verifiable.

- **`infra/github.py`** — every outbound GitHub call now has a finite timeout (15 s read / 5 s connect). Previously every helper used a bare `httpx.AsyncClient()`, which falls back to httpx's ~5-minute default. A slow `github.com` would pin the FastAPI event loop and starve other async traffic on the same Modal container.
- **`api/rate_limit.py`** — replaced an O(n) `sum(len(v) for ...)` purge trigger with a per-instance counter and added a hard `_MAX_TRACKED_KEYS` cap so a rotating-IP flood can no longer grow the dict without bound. Limiter rejects with 429 once saturated and nothing is purgeable.
- **`tests/test_infra/test_cache.py`** — replaced `time.sleep` with a fake-monotonic-clock fixture so the suite is deterministic and ~100 ms faster per run.

All 939 server tests pass. Lint, format, mypy clean on the touched files.

---

## Review notes (for context)

This PR is one slice of a wider review. The full assessment (system map, top-15 leverage list, test plan, etc.) is below. Only the highest-confidence, smallest-blast-radius fixes are in this PR — bigger items are flagged for follow-up.

### High-level summary

The codebase is a uv workspace monorepo with four components: a Typer-based CLI (`client/`), a FastAPI server on Modal (`server/`), a shared domain model package (`shared/`), and a React 19 + Vite frontend. The split is principled and the shared package keeps duplication low. The biggest risks are concentrated in a few large files (`server/src/decision_hub/infra/database.py` ~3.5k lines, `client/src/dhub/cli/registry.py` ~1.9k lines, `server/src/decision_hub/api/registry_routes.py` ~1.3k lines) and in implicit assumptions about external services — most notably the GitHub timeouts fixed here. Test coverage is broad but skewed toward route-level mocked tests; integration coverage of `publish_pipeline` and `repo_utils` is thin.

### Top high-leverage changes (10 items, ranked)

| # | Change | Category | Impact | Effort | Status |
|---|--------|----------|--------|--------|--------|
| 1 | Add timeouts to all `httpx.AsyncClient()` calls in `infra/github.py` | security/reliability | H | S | **Done in this PR** |
| 2 | Bound rate-limiter memory and replace O(n) purge trigger | security/perf | H | S | **Done in this PR** |
| 3 | De-flake cache tests by mocking `time.monotonic` | testing | M | S | **Done in this PR** |
| 4 | Split `client/src/dhub/cli/registry.py` (1912 LOC) into per-command submodules; share a single `httpx.Client` factory with retry/backoff for 429/5xx | architecture | H | M | follow-up |
| 5 | Add an integration test for `domain/publish_pipeline.execute_publish()` covering the happy path and rollback on upload failure | testing | H | M | follow-up |
| 6 | Audit `api/registry_routes.py` for IDOR / enumeration via differing 403 vs 404 responses on org-scoped paths (`delete_skill_version`, audit-log, eval-run lookups) | security | H | M | follow-up |
| 7 | Make publish race-safe: replace the `find_version`-then-`insert_version` pattern with `INSERT ... ON CONFLICT` or `SELECT ... FOR UPDATE` | correctness | M | M | follow-up |
| 8 | Add an `AbortController` to `frontend/src/api/client.ts` so stale fetches don't update unmounted components | frontend | M | S | follow-up |
| 9 | Move `from loguru import logger` out of domain functions (e.g. `gauntlet.py:1346`); domain layer should return values, not log | code-health | M | S | follow-up |
| 10 | Add `pytest-timeout` and per-test 10 s budget to bound CI hang risk | testing/CI | M | S | follow-up |

### Why only items 1–3 here

Items 4–10 are higher effort or have broader review surface (UX changes, schema/transaction shifts, route-level error-shape changes). They deserve their own PRs with focused reviewers. Items 1–3 share a tight theme — bound the blast radius of network calls, memory growth, and test wall-clock — and are mechanical enough to land safely together.

### Skipped findings (rejected after verification)

A few findings from the initial review were rejected on closer reading:

- **Cache TOCTOU in `set()`** — the `len >= max_size` check is already inside the lock at `cache.py:60–62`. Not a real race.
- **`SkillDetailPage.tsx:699` array index as key** — the surrounding `expandedIndex` state is itself an index, so the index-as-key is intentional. Switching to `check_name` would actually break expand/collapse if names duplicate.
- **DRY refactor of `_find_credential_hits` / `_find_suspicious_lines` / `_find_prompt_injection_hits` in `gauntlet.py`** — the three functions return dicts with different schemas (`{source,label,line}` vs `{file,label,line}` vs `{pattern,label,context}`); collapsing them would force an artificial uniform shape and obscure intent.

### Open questions / assumptions

- 15 s read timeout on GitHub calls assumes typical org-list pagination completes in well under that. If real users with very large org lists hit this we'll see it as 504s in logs and can raise the cap.
- `_MAX_TRACKED_KEYS = 10_000` is sized for a single Modal container; revisit if container concurrency changes materially.

## Test plan

- [x] `make test-server` (excludes slow LLM tests) — 939 passed, 34 deselected
- [x] `uvx ruff check` and `uvx ruff format --check` on the five changed files — clean
- [x] `uvx mypy server/src/decision_hub/infra/github.py server/src/decision_hub/api/rate_limit.py` — no issues
- [x] New tests cover periodic purge, saturation 429, deterministic cache TTL, and a regression scan that fails if any future `httpx.AsyncClient()` (no kwargs) creeps back into `infra/github.py`

https://claude.ai/code/session_012LMuzsUtWEUAfEBXW5yDyL

---
_Generated by [Claude Code](https://claude.ai/code/session_012LMuzsUtWEUAfEBXW5yDyL)_