### PR TITLE
fix: use Docker Hub base image and uv run for Modal deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,7 +51,7 @@ DHUB_ENV="$DHUB_ENV" uv run --package decision-hub-server python ../scripts/run_
 echo ""
 echo ">>> Deploying Modal app (env=$DHUB_ENV)..."
 
-DHUB_ENV="$DHUB_ENV" modal deploy modal_app.py
+DHUB_ENV="$DHUB_ENV" uv run --package decision-hub-server modal deploy modal_app.py
 
 echo ""
 echo "=== Deploy complete ==="

--- a/server/modal_app.py
+++ b/server/modal_app.py
@@ -14,7 +14,7 @@ app = modal.App(app_name)
 _frontend_dist = Path("../frontend/dist")
 
 image = (
-    modal.Image.debian_slim(python_version="3.11")
+    modal.Image.from_registry("python:3.11-slim-bookworm")
     .add_local_dir("../shared", remote_path="/tmp/dhub-core", copy=True)
     .run_commands("pip install /tmp/dhub-core")
     .pip_install_from_pyproject("pyproject.toml")


### PR DESCRIPTION
## Summary
- Switch Modal base image from `debian_slim(python_version="3.11")` to `from_registry("python:3.11-slim-bookworm")` — Docker Hub images are refreshed weekly, fixing the stale `libssl3` 404 that blocks all deploys
- Fix `scripts/deploy.sh` to invoke `modal` through `uv run` so it's found on PATH

Closes #359

## Test plan
- [ ] CI passes (no runtime code changes, just image source and deploy script)
- [ ] `make deploy-dev` succeeds (image builds, `apt_install("git")` works)
- [ ] After dev deploy confirms working, `make deploy-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)