### PR TITLE
refactor: dedupe rate-limit deps and skill-row → response builders

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -1,5 +1,6 @@
 """CLI configuration file management for ~/.dhub/config.{env}.json."""
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -82,7 +83,11 @@ def load_config() -> CliConfig:
 def save_config(config: CliConfig) -> None:
     """Save CLI config to ~/.dhub/config.{env}.json.
 
-    Creates the ~/.dhub directory if it does not already exist.
+    Creates the ~/.dhub directory if it does not already exist and
+    restricts the config file to mode ``0o600`` so the bearer token it
+    contains is not readable by other users on shared systems. ``chmod``
+    is best-effort: file systems that don't support POSIX permissions
+    (e.g. some Windows setups) silently leave the file as-is.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = config_file()
@@ -90,6 +95,11 @@ def save_config(config: CliConfig) -> None:
         json.dumps(asdict(config), indent=2) + "\n",
         encoding="utf-8",
     )
+    # File systems without POSIX semantics (e.g. some Windows mounts) don't
+    # honour chmod. Failing here would block login, which is worse than
+    # leaving the file world-readable on those systems.
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
 
 
 def get_api_url() -> str:

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -105,6 +105,34 @@ class TestSaveConfig:
         assert loaded.default_org is None
         assert loaded.token == "old-tok"
 
+    def test_saved_file_is_user_only_readable(self, tmp_path, monkeypatch):
+        """Bearer token must not be world- or group-readable on POSIX systems.
+
+        Regression test: previously the file was written with the process
+        umask, which on most multi-user systems left the file mode 0o644.
+        """
+        import os
+        import stat
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("POSIX permissions not applicable on Windows")
+
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+        # Ensure umask wouldn't otherwise produce 0o600 by accident.
+        old_umask = os.umask(0o022)
+        try:
+            save_config(CliConfig(api_url="https://example.com", token="secret"))
+        finally:
+            os.umask(old_umask)
+
+        mode = (tmp_path / "config.dev.json").stat().st_mode & 0o777
+        # Owner read+write only -- no group or world bits set.
+        assert mode == 0o600, oct(mode)
+        assert not (mode & stat.S_IRGRP)
+        assert not (mode & stat.S_IROTH)
+
 
 class TestGetToken:
     """get_token should check DHUB_TOKEN env var first."""

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,11 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limiter_dep(
+    state_attr="_auth_rate_limiter",
+    limit_attr="auth_rate_limit",
+    window_attr="auth_rate_window",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -2,9 +2,18 @@
 
 import threading
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+from decision_hub.settings import Settings
+
+# How often to scan the in-memory request map for stale per-IP entries.
+# A counter increments per call and triggers a sweep every N requests so
+# memory stays bounded even when individual IPs go quiet. Counter-based
+# (not modulo on the live total) so the sweep is independent of state size.
+_PURGE_EVERY_N_REQUESTS = 100
 
 
 class RateLimiter:
@@ -29,8 +38,15 @@ class RateLimiter:
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        self._requests: dict[str, list[float]] = defaultdict(list)
+        # ``deque`` (vs list) lets us pop expired timestamps from the left
+        # in amortised O(1) instead of rebuilding the list on every call.
+        self._requests: dict[str, deque[float]] = defaultdict(deque)
         self._lock = threading.Lock()
+        # Counts every call; drives the periodic stale-IP sweep below.
+        # Decoupling from ``len(self._requests)`` avoids a quirk where a
+        # post-purge total of 0 satisfied ``total % 100 == 0`` and triggered
+        # a sweep on every subsequent request.
+        self._calls_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -38,11 +54,12 @@ class RateLimiter:
         cutoff = now - self.window_seconds
 
         with self._lock:
-            # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            # popleft is O(1); deque is sorted by insertion (monotonic time).
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(timestamps) >= self.max_requests:
                 raise HTTPException(
                     status_code=429,
                     detail=(
@@ -50,16 +67,54 @@ class RateLimiter:
                     ),
                 )
 
-            self._requests[key].append(now)
+            timestamps.append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._calls_since_purge += 1
+            if self._calls_since_purge >= _PURGE_EVERY_N_REQUESTS:
                 self._purge_stale(cutoff)
+                self._calls_since_purge = 0
 
     def _purge_stale(self, cutoff: float) -> None:
         """Remove IPs with no recent activity. Caller must hold self._lock."""
-        stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
+        stale = [k for k, v in self._requests.items() if not v or v[-1] <= cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limiter_dep(
+    state_attr: str,
+    limit_attr: str,
+    window_attr: str,
+) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that lazily wires up a per-route ``RateLimiter``.
+
+    The same one-shot lazy-init pattern was previously copy-pasted nine times
+    across the route modules; this factory replaces all of them.
+
+    Args:
+        state_attr: Name of the attribute on ``app.state`` used to cache the
+            ``RateLimiter`` instance for this dependency. Each route must use
+            a unique attribute so independent routes get independent buckets.
+        limit_attr: ``Settings`` attribute holding the max-requests value.
+        window_attr: ``Settings`` attribute holding the window-seconds value.
+
+    Returns:
+        A callable suitable for ``Depends(...)``.
+    """
+
+    def _enforce(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, state_attr, None)
+        if limiter is None:
+            settings: Settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    # Helpful on tracebacks; FastAPI also keys schema by callable identity.
+    _enforce.__name__ = f"enforce_{state_attr}"
+    _enforce.__qualname__ = _enforce.__name__
+    return _enforce

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,49 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
+# Rate-limit dependencies. Each route gets an independent in-memory bucket
+# keyed by ``state_attr``; the limit and window come from Settings.
+_enforce_list_skills_rate_limit = make_rate_limiter_dep(
+    state_attr="_list_skills_rate_limiter",
+    limit_attr="list_skills_rate_limit",
+    window_attr="list_skills_rate_window",
+)
 
+_enforce_resolve_rate_limit = make_rate_limiter_dep(
+    state_attr="_resolve_rate_limiter",
+    limit_attr="resolve_rate_limit",
+    window_attr="resolve_rate_window",
+)
 
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
+_enforce_similar_skills_rate_limit = make_rate_limiter_dep(
+    state_attr="_similar_skills_rate_limiter",
+    limit_attr="similar_skills_rate_limit",
+    window_attr="similar_skills_rate_window",
+)
 
+_enforce_download_rate_limit = make_rate_limiter_dep(
+    state_attr="_download_rate_limiter",
+    limit_attr="download_rate_limit",
+    window_attr="download_rate_window",
+)
 
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
+_enforce_audit_log_rate_limit = make_rate_limiter_dep(
+    state_attr="_audit_log_rate_limiter",
+    limit_attr="audit_log_rate_limit",
+    window_attr="audit_log_rate_window",
+)
 
+_enforce_scan_report_rate_limit = make_rate_limiter_dep(
+    state_attr="_scan_report_rate_limiter",
+    limit_attr="scan_report_rate_limit",
+    window_attr="scan_report_rate_window",
+)
 
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_publish_rate_limit = make_rate_limiter_dep(
+    state_attr="_publish_rate_limiter",
+    limit_attr="publish_rate_limit",
+    window_attr="publish_rate_window",
+)
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -442,6 +403,44 @@ class AccessGrantListEntry(BaseModel):
 _STALE_HEARTBEAT_SECONDS = 300
 
 
+def _format_summary_dt(value: datetime | None) -> str:
+    """Format a datetime for the ``SkillSummary.updated_at`` field."""
+    return value.strftime("%Y-%m-%d %H:%M:%S") if value else ""
+
+
+def _skill_summary_from_row(row: dict, *, is_auto_synced: bool) -> SkillSummary:
+    """Build a :class:`SkillSummary` from a row dict.
+
+    Both the paginated list endpoint and the per-skill summary endpoint go
+    through this helper so the response shape stays in sync. ``is_auto_synced``
+    is taken as a parameter rather than read from the row because the list
+    endpoint joins the trackers table while the detail endpoint computes it
+    on the fly via :func:`has_active_tracker_for_repo`.
+    """
+    return SkillSummary(
+        org_slug=row["org_slug"],
+        skill_name=row["skill_name"],
+        description=row.get("description", "") or "",
+        latest_version=row["latest_version"],
+        updated_at=_format_summary_dt(row.get("created_at")),
+        safety_rating=format_trust_score(row.get("eval_status", "")),
+        author=resolve_author_display(row.get("published_by", "")),
+        download_count=row.get("download_count", 0),
+        is_personal_org=row.get("is_personal_org", False),
+        category=row.get("category", "") or "",
+        visibility=row.get("visibility", "public"),
+        source_repo_url=row.get("source_repo_url"),
+        manifest_path=row.get("manifest_path"),
+        source_repo_removed=row.get("source_repo_removed", False),
+        github_stars=row.get("github_stars"),
+        github_forks=row.get("github_forks"),
+        github_watchers=row.get("github_watchers"),
+        github_is_archived=row.get("github_is_archived"),
+        github_license=row.get("github_license"),
+        is_auto_synced=is_auto_synced,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -605,31 +604,7 @@ def list_skills(
         sort_dir=sort_dir,
     )
     total_pages = math.ceil(total / page_size) if total > 0 else 1
-    items = [
-        SkillSummary(
-            org_slug=row["org_slug"],
-            skill_name=row["skill_name"],
-            description=row.get("description", ""),
-            latest_version=row["latest_version"],
-            updated_at=row["created_at"].strftime("%Y-%m-%d %H:%M:%S") if row.get("created_at") else "",
-            safety_rating=format_trust_score(row["eval_status"]),
-            author=resolve_author_display(row.get("published_by", "")),
-            download_count=row.get("download_count", 0),
-            is_personal_org=row.get("is_personal_org", False),
-            category=row.get("category", ""),
-            visibility=row.get("visibility", "public"),
-            source_repo_url=row.get("source_repo_url"),
-            manifest_path=row.get("manifest_path"),
-            source_repo_removed=row.get("source_repo_removed", False),
-            github_stars=row.get("github_stars"),
-            github_forks=row.get("github_forks"),
-            github_watchers=row.get("github_watchers"),
-            github_is_archived=row.get("github_is_archived"),
-            github_license=row.get("github_license"),
-            is_auto_synced=row.get("has_tracker", False),
-        )
-        for row in rows
-    ]
+    items = [_skill_summary_from_row(row, is_auto_synced=row.get("has_tracker", False)) for row in rows]
     return PaginatedSkillsResponse(
         items=items,
         total=total,
@@ -659,28 +634,31 @@ def get_skill_summary(
         raise HTTPException(status_code=404, detail=f"No versions found for {org_slug}/{skill_name}")
 
     org = find_org_by_slug(conn, org_slug)
-    return SkillSummary(
-        org_slug=org_slug,
-        skill_name=skill_name,
-        description=skill.description,
-        latest_version=version.semver,
-        updated_at=version.created_at.strftime("%Y-%m-%d %H:%M:%S") if version.created_at else "",
-        safety_rating=format_trust_score(version.eval_status),
-        author=resolve_author_display(version.published_by),
-        download_count=skill.download_count,
-        is_personal_org=org.is_personal if org else False,
-        category=skill.category,
-        visibility=skill.visibility,
-        source_repo_url=skill.source_repo_url,
-        manifest_path=skill.manifest_path,
-        source_repo_removed=skill.source_repo_removed,
-        github_stars=skill.github_stars,
-        github_forks=skill.github_forks,
-        github_watchers=skill.github_watchers,
-        github_is_archived=skill.github_is_archived,
-        github_license=skill.github_license,
-        is_auto_synced=bool(skill.source_repo_url and has_active_tracker_for_repo(conn, skill.source_repo_url)),
-    )
+    # Reshape models into the row-dict shape produced by
+    # ``fetch_all_skills_for_index`` so both endpoints share the same builder.
+    row = {
+        "org_slug": org_slug,
+        "skill_name": skill_name,
+        "description": skill.description,
+        "latest_version": version.semver,
+        "created_at": version.created_at,
+        "eval_status": version.eval_status,
+        "published_by": version.published_by,
+        "download_count": skill.download_count,
+        "is_personal_org": org.is_personal if org else False,
+        "category": skill.category,
+        "visibility": skill.visibility,
+        "source_repo_url": skill.source_repo_url,
+        "manifest_path": skill.manifest_path,
+        "source_repo_removed": skill.source_repo_removed,
+        "github_stars": skill.github_stars,
+        "github_forks": skill.github_forks,
+        "github_watchers": skill.github_watchers,
+        "github_is_archived": skill.github_is_archived,
+        "github_license": skill.github_license,
+    }
+    is_auto_synced = bool(skill.source_repo_url and has_active_tracker_for_repo(conn, skill.source_repo_url))
+    return _skill_summary_from_row(row, is_auto_synced=is_auto_synced)
 
 
 @public_router.get(

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,11 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limiter_dep(
+    state_attr="_search_rate_limiter",
+    limit_attr="search_rate_limit",
+    window_attr="search_rate_window",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -210,6 +205,32 @@ class AskResponse(BaseModel):
     answer: str
     skills: list[AskSkillRef]
     category: str | None = None
+
+
+def _ask_skill_ref_from_row(row: dict, *, reason: str) -> AskSkillRef:
+    """Build an ``AskSkillRef`` from a candidate row dict.
+
+    Single source of truth for the field mapping. Both the LLM-success path
+    and the LLM-failure fallback go through this helper so adding a new
+    column to ``_SKILL_SUMMARY_COLUMNS`` only requires updating this one
+    function (plus ``AskSkillRef`` itself), avoiding the dual-write footgun
+    flagged in CLAUDE.md.
+    """
+    return AskSkillRef(
+        org_slug=row["org_slug"],
+        skill_name=row["skill_name"],
+        description=row.get("description", ""),
+        safety_rating=format_trust_score(row.get("eval_status", "")),
+        reason=reason,
+        author=resolve_author_display(row.get("published_by", "")),
+        category=row.get("category", ""),
+        download_count=row.get("download_count", 0),
+        latest_version=row.get("latest_version", ""),
+        source_repo_url=row.get("source_repo_url"),
+        gauntlet_summary=row.get("gauntlet_summary"),
+        github_stars=row.get("github_stars"),
+        github_license=row.get("github_license"),
+    )
 
 
 class AskMessage(BaseModel):
@@ -387,25 +408,11 @@ def _ask_skills_inner(
     except Exception:
         logger.opt(exception=True).warning("Conversational ask failed, using fallback")
         fallback_latency_ms = int((time.monotonic() - start_time) * 1000)
+        # Iterate the raw candidate rows so the fallback uses the same
+        # column source as the main path (was previously a hybrid of
+        # ``SkillIndexEntry`` + a row lookup just for ``eval_status``).
         skill_refs = [
-            AskSkillRef(
-                org_slug=e.org_slug,
-                skill_name=e.skill_name,
-                description=e.description,
-                safety_rating=format_trust_score(
-                    candidate_map.get((e.org_slug, e.skill_name), {}).get("eval_status", "")
-                ),
-                reason="Matched your search query.",
-                author=e.author,
-                category=e.category,
-                download_count=e.download_count,
-                latest_version=e.latest_version,
-                source_repo_url=e.source_repo_url,
-                gauntlet_summary=e.gauntlet_summary,
-                github_stars=e.github_stars,
-                github_license=e.github_license,
-            )
-            for e in result.entries[:5]
+            _ask_skill_ref_from_row(row, reason="Matched your search query.") for row in result.candidates[:5]
         ]
         background_tasks.add_task(
             _log_ask_analytics,
@@ -459,26 +466,9 @@ def _ask_skills_inner(
     # Enrich LLM skill references with metadata from DB candidates
     skill_refs = []
     for ref in llm_result.get("referenced_skills", []):
-        key = (ref["org_slug"], ref["skill_name"])
-        row = candidate_map.get(key)
+        row = candidate_map.get((ref["org_slug"], ref["skill_name"]))
         if row:
-            skill_refs.append(
-                AskSkillRef(
-                    org_slug=ref["org_slug"],
-                    skill_name=ref["skill_name"],
-                    description=row.get("description", ""),
-                    safety_rating=format_trust_score(row.get("eval_status", "")),
-                    reason=ref.get("reason", ""),
-                    author=resolve_author_display(row.get("published_by", "")),
-                    category=row.get("category", ""),
-                    download_count=row.get("download_count", 0),
-                    latest_version=row.get("latest_version", ""),
-                    source_repo_url=row.get("source_repo_url"),
-                    gauntlet_summary=row.get("gauntlet_summary"),
-                    github_stars=row.get("github_stars"),
-                    github_license=row.get("github_license"),
-                )
-            )
+            skill_refs.append(_ask_skill_ref_from_row(row, reason=ref.get("reason", "")))
 
     return AskResponse(
         query=q,

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limiter_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,94 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_purge_stale_runs_on_counter_not_total(self) -> None:
+        """Stale-IP purge fires every N calls regardless of map size.
+
+        Regression test: the previous implementation triggered the sweep when
+        ``total % 100 == 0``, which is true for ``total == 0`` -- so once
+        every IP was purged the sweep ran on every subsequent request.
+        """
+        limiter = RateLimiter(max_requests=1000, window_seconds=60)
+        request = _make_request()
+        # No exceptions; deque-based pruning + counter-based sweep should
+        # not regress on bursts of small calls.
+        for _ in range(250):
+            limiter(request)
+        # Internal counter resets after each sweep, so it stays bounded.
+        assert limiter._calls_since_purge < 100
+
+    def test_uses_deque_not_list(self) -> None:
+        """Per-IP timestamps are stored in a deque so popleft is O(1)."""
+        from collections import deque
+
+        limiter = RateLimiter(max_requests=10, window_seconds=60)
+        limiter(_make_request())
+        assert isinstance(limiter._requests["127.0.0.1"], deque)
+
+
+class TestMakeRateLimiterDep:
+    """Unit tests for the make_rate_limiter_dep factory."""
+
+    def _make_app_state(self, *, limit: int = 5, window: int = 60) -> SimpleNamespace:
+        """Build a minimal request whose ``app.state`` carries settings."""
+        settings = SimpleNamespace(my_limit=limit, my_window=window, other_limit=99, other_window=10)
+        return SimpleNamespace(settings=settings)
+
+    def _make_request_with_state(self, state: SimpleNamespace, host: str = "127.0.0.1") -> MagicMock:
+        request = MagicMock()
+        request.client.host = host
+        request.app.state = state
+        return request
+
+    def test_lazy_init_creates_limiter_once(self) -> None:
+        """The first call constructs the limiter; later calls reuse it."""
+        dep = make_rate_limiter_dep("_test_lim", "my_limit", "my_window")
+        state = self._make_app_state()
+        request = self._make_request_with_state(state)
+
+        dep(request)
+        first = state._test_lim
+        dep(request)
+        assert state._test_lim is first
+
+    def test_independent_attrs_get_independent_buckets(self) -> None:
+        """Two factories with different state_attrs must not share counters."""
+        dep_a = make_rate_limiter_dep("_lim_a", "my_limit", "my_window")
+        dep_b = make_rate_limiter_dep("_lim_b", "my_limit", "my_window")
+        state = self._make_app_state(limit=2, window=60)
+        request = self._make_request_with_state(state)
+
+        # Fill bucket A.
+        dep_a(request)
+        dep_a(request)
+        # Bucket B should be untouched.
+        dep_b(request)
+        dep_b(request)
+        # Both should now reject on the next call.
+        with pytest.raises(HTTPException):
+            dep_a(request)
+        with pytest.raises(HTTPException):
+            dep_b(request)
+
+    def test_reads_settings_at_init_time_only(self) -> None:
+        """Limit/window are captured on first call -- mutating settings later is a no-op.
+
+        This documents existing behaviour so callers don't expect runtime
+        changes to settings to take effect without restarting the app.
+        """
+        dep = make_rate_limiter_dep("_lim_freeze", "my_limit", "my_window")
+        state = self._make_app_state(limit=2, window=60)
+        request = self._make_request_with_state(state)
+
+        dep(request)
+        # Bumping the setting after init has no effect on the cached limiter.
+        state.settings.my_limit = 1000
+        dep(request)
+        with pytest.raises(HTTPException):
+            dep(request)
+
+    def test_dependency_has_a_useful_name(self) -> None:
+        """FastAPI uses callable identity/name for traceback clarity."""
+        dep = make_rate_limiter_dep("_lim_named", "my_limit", "my_window")
+        assert "lim_named" in dep.__name__

--- a/server/tests/test_api/test_row_builders.py
+++ b/server/tests/test_api/test_row_builders.py
@@ -1,0 +1,168 @@
+"""Tests for the row-to-response helpers shared across registry & search routes.
+
+These helpers are the single source of truth for translating a DB row dict
+(produced by ``_row_to_skill_summary`` / ``_SKILL_SUMMARY_COLUMNS``) into the
+public API response shape. They exist to prevent the dual-write footgun
+documented in CLAUDE.md, where adding a new column required updating
+multiple call sites in lock-step.
+"""
+
+from datetime import UTC, datetime
+
+from decision_hub.api.registry_routes import _format_summary_dt, _skill_summary_from_row
+from decision_hub.api.search_routes import _ask_skill_ref_from_row
+
+# ---------------------------------------------------------------------------
+# _skill_summary_from_row
+# ---------------------------------------------------------------------------
+
+
+class TestSkillSummaryFromRow:
+    """Tests for the row -> SkillSummary builder used by /v1/skills."""
+
+    def _full_row(self) -> dict:
+        return {
+            "org_slug": "acme",
+            "skill_name": "weather",
+            "description": "Forecasting skill",
+            "latest_version": "1.2.3",
+            "created_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
+            "eval_status": "passed",
+            "published_by": "alice",
+            "download_count": 42,
+            "is_personal_org": False,
+            "category": "Data Science",
+            "visibility": "public",
+            "source_repo_url": "https://github.com/acme/weather-skill",
+            "manifest_path": "skills/weather/SKILL.md",
+            "source_repo_removed": False,
+            "github_stars": 12,
+            "github_forks": 3,
+            "github_watchers": 1,
+            "github_is_archived": False,
+            "github_license": "MIT",
+        }
+
+    def test_full_row_maps_every_field(self) -> None:
+        row = self._full_row()
+        summary = _skill_summary_from_row(row, is_auto_synced=True)
+
+        assert summary.org_slug == "acme"
+        assert summary.skill_name == "weather"
+        assert summary.description == "Forecasting skill"
+        assert summary.latest_version == "1.2.3"
+        assert summary.updated_at == "2026-01-02 03:04:05"
+        # passed -> A in the trust-score formatter
+        assert summary.safety_rating == "A"
+        assert summary.author == "alice"
+        assert summary.download_count == 42
+        assert summary.category == "Data Science"
+        assert summary.visibility == "public"
+        assert summary.source_repo_url == "https://github.com/acme/weather-skill"
+        assert summary.manifest_path == "skills/weather/SKILL.md"
+        assert summary.github_stars == 12
+        assert summary.github_license == "MIT"
+        assert summary.is_auto_synced is True
+
+    def test_minimal_row_falls_back_to_defaults(self) -> None:
+        """Missing optional columns must not raise -- defaults are used."""
+        row = {
+            "org_slug": "acme",
+            "skill_name": "weather",
+            "latest_version": "0.1.0",
+        }
+        summary = _skill_summary_from_row(row, is_auto_synced=False)
+
+        assert summary.description == ""
+        assert summary.updated_at == ""
+        assert summary.author == ""
+        assert summary.download_count == 0
+        assert summary.category == ""
+        assert summary.visibility == "public"
+        assert summary.source_repo_url is None
+        assert summary.github_stars is None
+        assert summary.is_auto_synced is False
+
+    def test_is_auto_synced_overrides_row(self) -> None:
+        """The list endpoint passes the joined ``has_tracker`` value via this kwarg."""
+        row = self._full_row()
+        summary = _skill_summary_from_row(row, is_auto_synced=False)
+        assert summary.is_auto_synced is False
+
+    def test_format_summary_dt_handles_none(self) -> None:
+        assert _format_summary_dt(None) == ""
+
+    def test_null_text_columns_are_coerced(self) -> None:
+        """Postgres can return NULL for text columns; coerce to empty string."""
+        row = {
+            "org_slug": "acme",
+            "skill_name": "weather",
+            "latest_version": "0.1.0",
+            "description": None,
+            "category": None,
+        }
+        summary = _skill_summary_from_row(row, is_auto_synced=False)
+        assert summary.description == ""
+        assert summary.category == ""
+
+
+# ---------------------------------------------------------------------------
+# _ask_skill_ref_from_row
+# ---------------------------------------------------------------------------
+
+
+class TestAskSkillRefFromRow:
+    """Tests for the row -> AskSkillRef builder used by /v1/ask."""
+
+    def _row(self) -> dict:
+        return {
+            "org_slug": "acme",
+            "skill_name": "weather",
+            "description": "Forecasting skill",
+            "eval_status": "passed",
+            "published_by": "alice",
+            "category": "Data Science",
+            "download_count": 7,
+            "latest_version": "1.0.0",
+            "source_repo_url": "https://github.com/acme/weather-skill",
+            "gauntlet_summary": "All checks passed",
+            "github_stars": 12,
+            "github_license": "MIT",
+        }
+
+    def test_full_row_with_explicit_reason(self) -> None:
+        ref = _ask_skill_ref_from_row(self._row(), reason="LLM-cited match")
+
+        assert ref.org_slug == "acme"
+        assert ref.skill_name == "weather"
+        assert ref.description == "Forecasting skill"
+        assert ref.safety_rating == "A"
+        assert ref.author == "alice"
+        assert ref.category == "Data Science"
+        assert ref.download_count == 7
+        assert ref.latest_version == "1.0.0"
+        assert ref.source_repo_url == "https://github.com/acme/weather-skill"
+        assert ref.gauntlet_summary == "All checks passed"
+        assert ref.github_stars == 12
+        assert ref.github_license == "MIT"
+        assert ref.reason == "LLM-cited match"
+
+    def test_minimal_row_uses_safe_defaults(self) -> None:
+        row = {"org_slug": "acme", "skill_name": "weather"}
+        ref = _ask_skill_ref_from_row(row, reason="Matched your search query.")
+        assert ref.description == ""
+        assert ref.author == ""
+        assert ref.category == ""
+        assert ref.download_count == 0
+        assert ref.latest_version == ""
+        assert ref.source_repo_url is None
+        assert ref.gauntlet_summary is None
+        assert ref.reason == "Matched your search query."
+
+    def test_reason_is_required_kwarg(self) -> None:
+        """The reason differs between paths (LLM-cited vs. fallback) and must be explicit."""
+        import pytest
+
+        with pytest.raises(TypeError):
+            # type: ignore[call-arg] -- intentionally wrong signature
+            _ask_skill_ref_from_row({"org_slug": "x", "skill_name": "y"})


### PR DESCRIPTION
## Summary

A focused, behaviour-preserving refactor that targets the highest-leverage duplication patterns surfaced by a deep code review of the server + CLI. Net **−199 / +515** lines (most of the additions are new test coverage).

The bigger structural splits flagged by the review (`infra/database.py` at 3,465 LOC; `client/cli/registry.py` at 1,912 LOC; the test conftest re-implementing the production `CLIVersionMiddleware` as `BaseHTTPMiddleware`) are deferred to follow-up PRs because they are higher-risk and want their own focused review.

## What's in the box

### 1. Single rate-limiter dependency factory  *(server)*

`api/rate_limit.py` gains `make_rate_limiter_dep(state_attr, limit_attr, window_attr)`. This collapses **nine** copy-pasted `_enforce_*_rate_limit` functions across `auth_routes.py`, `search_routes.py`, and `registry_routes.py` into one factory call per route. Each call site shrinks from ~10 lines to 5.

### 2. Single `SkillSummary` builder  *(server)*

`_skill_summary_from_row(row, *, is_auto_synced)` in `registry_routes.py` is now the single source of truth for both `GET /v1/skills` and `GET /v1/skills/{org}/{name}/summary`. Adding a new column to `_SKILL_SUMMARY_COLUMNS` no longer requires touching two endpoints.

### 3. Single `AskSkillRef` builder  *(server)*

`_ask_skill_ref_from_row(row, *, reason)` in `search_routes.py` unifies the LLM-success and LLM-fallback paths in `/v1/ask`. This closes the dual-write footgun explicitly flagged in CLAUDE.md:

> to surface a new column to the ask LLM and API consumers, you must also update: ... AskSkillRef in search_routes.py + both enrichment paths (main + fallback)

The fallback path also fixes a subtle inconsistency: it used to be a hybrid of `SkillIndexEntry` (for most fields) + a row lookup just for `eval_status`. It now iterates `result.candidates[:5]` so both paths read from the same source.

### 4. `RateLimiter` correctness + perf  *(server)*

- **Bug fix:** the stale-IP sweep was triggered by `total % 100 == 0`. Once a sweep emptied the dict, `total == 0` satisfied the check and a sweep ran on every subsequent request. Replaced with a per-instance call counter that resets after each sweep.
- **Perf:** per-IP timestamp lists are now `deque`s. Expired entries are `popleft`'d in amortised O(1) instead of rebuilding the list on every call.

### 5. CLI config-file permissions  *(client)*

`save_config()` now `chmod`s `~/.dhub/config.{env}.json` to mode `0o600`, so the bearer JWT it contains is no longer readable by other users on shared/multi-user systems. `OSError` is suppressed so file systems without POSIX semantics (e.g. some Windows mounts) still let `dhub login` succeed.

## Test plan

- [x] `make test-server` — 947 passed, 34 deselected (slow)
- [x] `make test-client` — 292 passed, 29 skipped
- [x] `make test-shared` — 98 passed
- [x] `uvx ruff check . && uvx ruff format --check .` — clean
- [x] `uvx mypy` on every touched source file — clean
- [x] New tests:
  - `test_row_builders.py` (8 tests) — both helpers with full + minimal-row inputs, NULL coercion, kwarg signature
  - `test_rate_limit.py` (6 new tests) — `make_rate_limiter_dep` lazy init / isolation / settings-frozen-at-init / named callable; counter-based sweep regression; `deque` storage check
  - `test_config.py` (1 new test) — POSIX permissions regression; sets umask `0o022` then asserts `0o600`

## Behaviour change

Effectively zero, except the new `chmod 0o600` on the CLI config file (intentional security hardening; old files keep their existing mode until next `dhub login` rewrites them).

## Out of scope (review notes)

Filed mentally for follow-up PRs:
- Split `infra/database.py` (3,465 LOC, 103 functions) per aggregate
- Split `client/cli/registry.py` (1,912 LOC) per command
- Mount `search_router` and `tracker_router` in the test conftest and replace the `BaseHTTPMiddleware` shim with the production `CLIVersionMiddleware`
- Frontend `ErrorBoundary` and harden `useLocalStorage`
- Type CLI HTTP responses with `TypedDict`s to surface server schema drift
- Replace silent `except Exception: pass` blocks in CLI tracker / version-check paths with logged warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHZS18etK2esc8VT4BnAgd)_