### PR TITLE
refactor(rate-limit): collapse 9 dependency wrappers into one factory

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limit_dep("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -1,8 +1,21 @@
-"""In-memory sliding-window rate limiter for FastAPI dependencies."""
+"""In-memory sliding-window rate limiter for FastAPI dependencies.
+
+The module exposes two layers:
+
+* ``RateLimiter`` — the per-IP sliding-window primitive.
+* ``make_rate_limit_dep(name)`` — a factory that returns a FastAPI
+  dependency callable. The factory lazily reads
+  ``settings.{name}_rate_limit`` / ``settings.{name}_rate_window`` from
+  ``app.state`` on first invocation and caches one ``RateLimiter`` per
+  name on ``app.state._rate_limiters``. This replaces what used to be
+  nine near-identical ``_enforce_*_rate_limit`` functions duplicated
+  across the route files.
+"""
 
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -26,11 +39,20 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # How often to scan the full dict for stale IPs. The previous
+    # implementation called ``sum(len(v) for v in self._requests.values())``
+    # on every request, which is O(N) in the number of tracked IPs and
+    # ran on the hottest pre-handler path. We now maintain an explicit
+    # request counter and trigger a purge every _PURGE_INTERVAL requests
+    # — same intent, O(1) per call.
+    _PURGE_INTERVAL = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._call_count = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -53,9 +75,9 @@ class RateLimiter:
             self._requests[key].append(now)
 
             # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._call_count += 1
+            if self._call_count >= self._PURGE_INTERVAL:
+                self._call_count = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:
@@ -63,3 +85,41 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limit_dep(name: str) -> Callable[[Request], None]:
+    """Return a FastAPI dependency that enforces a named rate limit.
+
+    The limiter is built lazily on first request from
+    ``settings.{name}_rate_limit`` and ``settings.{name}_rate_window``
+    and cached on ``app.state._rate_limiters[name]``. All endpoints
+    sharing the same ``name`` share the same per-IP counters.
+
+    Args:
+        name: Settings prefix. The factory looks up
+            ``{name}_rate_limit`` and ``{name}_rate_window`` on the
+            ``Settings`` object stored in ``app.state.settings``.
+
+    Returns:
+        A callable suitable for ``Depends(...)`` in a FastAPI route.
+    """
+
+    def dep(request: Request) -> None:
+        state = request.app.state
+        limiters: dict[str, RateLimiter] | None = getattr(state, "_rate_limiters", None)
+        if limiters is None:
+            limiters = {}
+            state._rate_limiters = limiters
+        limiter = limiters.get(name)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, f"{name}_rate_limit"),
+                window_seconds=getattr(settings, f"{name}_rate_window"),
+            )
+            limiters[name] = limiter
+        limiter(request)
+
+    dep.__name__ = f"rate_limit_{name}"
+    dep.__doc__ = f"Per-IP rate limit for the '{name}' endpoint group."
+    return dep

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,15 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate-limit dependencies for this router. Each name maps to
+# ``settings.{name}_rate_limit`` / ``settings.{name}_rate_window``.
+_enforce_list_skills_rate_limit = make_rate_limit_dep("list_skills")
+_enforce_resolve_rate_limit = make_rate_limit_dep("resolve")
+_enforce_similar_skills_rate_limit = make_rate_limit_dep("similar_skills")
+_enforce_download_rate_limit = make_rate_limit_dep("download")
+_enforce_audit_log_rate_limit = make_rate_limit_dep("audit_log")
+_enforce_scan_report_rate_limit = make_rate_limit_dep("scan_report")
+_enforce_publish_rate_limit = make_rate_limit_dep("publish")
 
 
 _VALID_VISIBILITIES = {"public", "org"}

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limit_dep("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limit_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,93 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_purge_stale_runs_every_interval(self) -> None:
+        """Stale-IP purge should run every _PURGE_INTERVAL calls, not on every call.
+
+        The previous implementation summed every value list to drive the
+        check; this guards the new O(1) counter approach against regressing.
+        """
+        limiter = RateLimiter(max_requests=1000, window_seconds=60)
+        with patch.object(RateLimiter, "_purge_stale") as mock_purge:
+            for _ in range(RateLimiter._PURGE_INTERVAL - 1):
+                limiter(_make_request())
+            assert mock_purge.call_count == 0
+            limiter(_make_request())
+            assert mock_purge.call_count == 1
+            for _ in range(RateLimiter._PURGE_INTERVAL):
+                limiter(_make_request())
+            assert mock_purge.call_count == 2
+
+
+def _make_app_request(settings: object, *, host: str = "127.0.0.1") -> MagicMock:
+    """Build a mock Request whose app.state mirrors the production layout."""
+    request = MagicMock()
+    request.client.host = host
+    # ``hasattr(state, ...)`` is used by the limiter cache, so use a
+    # SimpleNamespace as the state container rather than MagicMock which
+    # would auto-create any attribute.
+    state = SimpleNamespace()
+    state.settings = settings
+    request.app.state = state
+    return request
+
+
+class TestMakeRateLimitDep:
+    """Unit tests for the make_rate_limit_dep factory."""
+
+    def test_builds_limiter_from_settings(self) -> None:
+        """The factory reads {name}_rate_limit and {name}_rate_window from settings."""
+        settings = SimpleNamespace(foo_rate_limit=2, foo_rate_window=60)
+        dep = make_rate_limit_dep("foo")
+        request = _make_app_request(settings)
+
+        dep(request)
+        dep(request)
+        with pytest.raises(HTTPException) as exc_info:
+            dep(request)
+        assert exc_info.value.status_code == 429
+
+    def test_caches_limiter_per_name_on_app_state(self) -> None:
+        """Repeated calls reuse the same limiter; separate names get separate counters."""
+        settings = SimpleNamespace(
+            a_rate_limit=1,
+            a_rate_window=60,
+            b_rate_limit=1,
+            b_rate_window=60,
+        )
+        dep_a = make_rate_limit_dep("a")
+        dep_b = make_rate_limit_dep("b")
+        request = _make_app_request(settings)
+
+        dep_a(request)
+        # 'a' should now be exhausted but 'b' is independent.
+        with pytest.raises(HTTPException):
+            dep_a(request)
+        dep_b(request)
+        with pytest.raises(HTTPException):
+            dep_b(request)
+
+        # The shared state holds exactly one limiter per name.
+        limiters = request.app.state._rate_limiters
+        assert set(limiters.keys()) == {"a", "b"}
+        assert limiters["a"] is not limiters["b"]
+
+    def test_missing_setting_raises_attribute_error(self) -> None:
+        """A typo in the dependency name surfaces as AttributeError on first call.
+
+        This is a sanity guard: silent fallback to "no limit" would be a
+        worse failure mode than a clear AttributeError at startup.
+        """
+        settings = SimpleNamespace()  # no matching attrs
+        dep = make_rate_limit_dep("ghost")
+        request = _make_app_request(settings)
+        with pytest.raises(AttributeError):
+            dep(request)
+
+    def test_dependency_name_is_set_for_debuggability(self) -> None:
+        """The returned dep callable carries a useful __name__ and docstring."""
+        dep = make_rate_limit_dep("search")
+        assert dep.__name__ == "rate_limit_search"
+        assert dep.__doc__ is not None
+        assert "search" in dep.__doc__


### PR DESCRIPTION
## Summary

Comes out of a deep architectural review of the codebase. Two related cleanups, both in `api/rate_limit.py`:

1. **DRY the rate-limit dependency boilerplate.** Three route files (`registry_routes.py`, `search_routes.py`, `auth_routes.py`) each defined a near-identical `_enforce_*_rate_limit` function — 9 copies, ~12 LOC apiece — that all did the same three things: read `settings.{name}_rate_limit` / `settings.{name}_rate_window`, build a `RateLimiter`, cache it on `app.state._{name}_rate_limiter`. They are now one-liners pointing at a single `make_rate_limit_dep(name)` factory.

2. **Bonus: O(N) → O(1) on the hot path.** `RateLimiter.__call__` was calling `sum(len(v) for v in self._requests.values())` on every request to decide whether to run `_purge_stale`. Replaced with an explicit call counter (`_PURGE_INTERVAL = 100`). Same intent, no per-call dict scan.

Net effect: **–113 / +173** with new tests, **–~90 lines** of production code.

## What changed

- **`api/rate_limit.py`** — new `make_rate_limit_dep(name)` factory. Lazily reads settings on first call, caches limiters in a single `app.state._rate_limiters` dict keyed by name. Sets `__name__` on the returned callable so it's recognisable in stack traces. Also: O(1) purge counter.
- **`api/registry_routes.py`** — 7 wrappers collapsed to 7 one-liners (`_enforce_list_skills_rate_limit = make_rate_limit_dep("list_skills")`, etc.); unused `Request` import dropped.
- **`api/search_routes.py`** — 1 wrapper collapsed; unused `Request` import dropped.
- **`api/auth_routes.py`** — 1 wrapper collapsed; unused `Request` import dropped.
- **`tests/test_api/test_rate_limit.py`** — 4 new factory tests + 1 new purge-counter test (10 total, all green).

## Behaviour preservation

- Same per-IP sliding window semantics
- Same `{name}_rate_limit` / `{name}_rate_window` settings keys
- Same lazy initialisation (no work until first request hits a rate-limited route)
- Same 429 response shape and message
- Limiters are still per-container (intentional; documented in `RateLimiter` docstring)
- Existing route tests still pass without modification

## Why a factory instead of a class

`Depends(...)` resolves by identity. Two routes that share a limiter need to share the same callable object — a class instance works, but a closure captured by `make_rate_limit_dep("publish")` is simpler, has no `__init__` overhead, and lets `__name__` reflect the limiter group for debugging.

## Test plan

- [x] `pytest server/tests/test_api/test_rate_limit.py` — 10/10 pass
- [x] `pytest server/tests/test_api/ -q --no-cov` — 231/231 pass
- [x] `pytest server/tests/ -q --no-cov -m "not slow"` — 938/938 pass
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy` on the four changed source files — clean

## Out of scope (surfaced in review, deferred to follow-ups)

The review surfaced a longer list of higher-leverage but riskier items kept out of this PR to keep the diff focused:

- Split `database.py` (3.5k LOC) into per-domain query modules
- Replace per-call `create_engine(settings.database_url)` (18 sites, NullPool) with a process-cached engine
- Unify `logging._extract_username_from_jwt` with `decode_jwt` (reduce hand-rolled base64 path)
- Extract the cache-TTL pattern duplicated across `org_routes`, `seo_routes`
- Reduce `@patch(...)` walls in route tests by injecting a pipeline protocol
- Strengthen `_redact_sensitive` to cover provider key prefixes (`sk-ant-`, `AKIA`, `gh[ps]_`, …) in addition to `key=…` URL params
- Re-evaluate exposing raw `quarantine_s3_key` on the public audit-log endpoint

Happy to take any of those as separate PRs if useful.


---
_Generated by [Claude Code](https://claude.ai/code/session_013pczYD6Zwnphx1c5MMMiZV)_