### PR TITLE
refactor: harden rate limiter, S3 paging, manifest path, config perms

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -1,5 +1,6 @@
 """CLI configuration file management for ~/.dhub/config.{env}.json."""
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -82,7 +83,12 @@ def load_config() -> CliConfig:
 def save_config(config: CliConfig) -> None:
     """Save CLI config to ~/.dhub/config.{env}.json.
 
-    Creates the ~/.dhub directory if it does not already exist.
+    Creates the ~/.dhub directory if it does not already exist and locks
+    the resulting file to owner-only read/write (``0o600``). The file
+    contains a long-lived JWT bearer token; without explicit perms it
+    inherits umask 0o022, making the token world-readable on any shared
+    host. ``chmod`` is a no-op on Windows, where ACLs already restrict
+    files in the user's home to that user.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = config_file()
@@ -90,6 +96,10 @@ def save_config(config: CliConfig) -> None:
         json.dumps(asdict(config), indent=2) + "\n",
         encoding="utf-8",
     )
+    # Filesystem may not support chmod (e.g. some FUSE mounts); don't fail
+    # the login flow over that.
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)
 
 
 def get_api_url() -> str:

--- a/client/src/dhub/cli/init.py
+++ b/client/src/dhub/cli/init.py
@@ -3,9 +3,28 @@
 from pathlib import Path
 
 import typer
+import yaml
 from rich.console import Console
 
 console = Console()
+
+
+def _prompt_nonempty(message: str, *, max_length: int) -> str:
+    """Prompt repeatedly until the user enters a non-empty value of the right length.
+
+    The bare ``typer.prompt`` accepts an empty Enter, which then propagates
+    through to manifest validation as a confusing failure at publish time.
+    Catching it here keeps the round-trip tight.
+    """
+    while True:
+        value = typer.prompt(message).strip()
+        if not value:
+            console.print("[yellow]Value cannot be empty — please try again.[/]")
+            continue
+        if len(value) > max_length:
+            console.print(f"[yellow]Value must be at most {max_length} characters.[/]")
+            continue
+        return value
 
 
 def init_command(
@@ -15,17 +34,19 @@ def init_command(
     if path is None:
         path = Path(".")
 
-    # Interactive prompts
-    name = typer.prompt("Skill name (lowercase, hyphens ok)")
-    description = typer.prompt("Short description")
+    # Interactive prompts.
+    name = _prompt_nonempty("Skill name (lowercase, hyphens ok)", max_length=64)
+    description = _prompt_nonempty("Short description", max_length=1024)
 
     from dhub.core.validation import validate_skill_name
 
-    validate_skill_name(name)
-
-    if len(description) > 1024:
-        console.print("[red]Error: Description must be 1-1024 characters.[/]")
-        raise typer.Exit(1)
+    try:
+        validate_skill_name(name)
+    except ValueError as exc:
+        # validate_skill_name raises with a useful message; render it as
+        # a friendly error instead of letting the traceback through.
+        console.print(f"[red]Error: {exc}[/]")
+        raise typer.Exit(1) from exc
 
     # Create directory structure
     skill_dir = path / name if path != Path(".") else Path(".")
@@ -38,10 +59,21 @@ def init_command(
         console.print(f"[red]Error: {skill_md} already exists.[/]")
         raise typer.Exit(1)
 
+    # Hand the description to PyYAML so quote/colon characters get escaped
+    # consistently. The previous f-string interpolation produced invalid
+    # YAML for inputs containing a double quote, which then failed parsing
+    # on publish with a non-obvious error.
+    description_yaml = yaml.safe_dump(
+        description,
+        default_style='"',
+        allow_unicode=True,
+        width=2**20,  # don't wrap
+    ).rstrip()
+
     skill_md.write_text(
         f"---\n"
         f"name: {name}\n"
-        f'description: "{description}"\n'
+        f"description: {description_yaml}\n"
         f"---\n"
         f"\n"
         f"# {name}\n"

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -106,6 +106,41 @@ class TestSaveConfig:
         assert loaded.token == "old-tok"
 
 
+class TestSaveConfigPermissions:
+    """The config file stores a bearer token; only the owner may read it."""
+
+    def test_saved_file_is_owner_only(self, tmp_path, monkeypatch):
+        import os
+        import stat as _stat
+
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://example.com", token="s3cret"))
+
+        path = tmp_path / "config.dev.json"
+        mode = _stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600, f"expected 0o600 perms, got {oct(mode)}"
+
+    def test_overwrite_resets_permissions(self, tmp_path, monkeypatch):
+        """Re-saving with relaxed perms should re-lock the file."""
+        import os
+        import stat as _stat
+
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        # First save, then deliberately loosen perms (simulating a user
+        # who chmod'd it or an old client that didn't lock the file).
+        save_config(CliConfig(api_url="https://example.com", token="t"))
+        path = tmp_path / "config.dev.json"
+        os.chmod(path, 0o644)
+
+        save_config(CliConfig(api_url="https://example.com", token="t2"))
+        mode = _stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600
+
+
 class TestGetToken:
     """get_token should check DHUB_TOKEN env var first."""
 

--- a/client/tests/test_cli/test_init_cli.py
+++ b/client/tests/test_cli/test_init_cli.py
@@ -88,3 +88,54 @@ class TestInitCommand:
         assert result.exit_code == 0
         content = (tmp_path / "cool-tool" / "SKILL.md").read_text()
         assert "# cool-tool" in content
+
+    def test_init_reprompts_on_empty_description(self, tmp_path: Path) -> None:
+        """Pressing Enter at the description prompt re-asks instead of writing junk.
+
+        Before this guard, an empty description produced a SKILL.md that
+        only failed when the user later ran ``dhub publish`` — a confusing
+        round-trip. The init command now loops until a real value is given.
+        """
+        # First blank, then real text. The CLI should accept the second.
+        result = runner.invoke(
+            app,
+            ["init", str(tmp_path)],
+            input="my-skill\n\nA real description\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        assert "A real description" in content
+
+    def test_init_escapes_special_chars_in_description(self, tmp_path: Path) -> None:
+        """Descriptions containing quotes/colons round-trip through YAML safely.
+
+        The previous template did ``description: "{description}"`` and broke
+        whenever the user typed a literal double quote.
+        """
+        import yaml
+
+        tricky = 'A "quoted" thing: with colon'
+        result = runner.invoke(
+            app,
+            ["init", str(tmp_path)],
+            input=f"my-skill\n{tricky}\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        # Pull out just the frontmatter and verify YAML round-trips it.
+        _, frontmatter, _ = content.split("---", 2)
+        loaded = yaml.safe_load(frontmatter)
+        assert loaded["description"] == tricky
+
+    def test_init_invalid_name_shows_friendly_error(self, tmp_path: Path) -> None:
+        """An invalid name produces a message, not a Python traceback."""
+        result = runner.invoke(
+            app,
+            ["init", str(tmp_path)],
+            input="INVALID NAME!\nA description\n",
+        )
+        assert result.exit_code != 0
+        # The friendly error path doesn't bubble up a Python traceback.
+        assert "Traceback" not in result.output

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -236,14 +236,39 @@ describe("downloadSkillZip", () => {
 });
 
 describe("error handling", () => {
-  it("throws with status and body on non-OK response", async () => {
+  it("throws an ApiError with sanitised user-facing message on 5xx", async () => {
     server.use(
       http.get("/v1/skills", () =>
-        new HttpResponse("Internal Server Error", { status: 500 }),
+        new HttpResponse("Internal Server Error: database host db.prod.internal unreachable", { status: 500 }),
       ),
     );
 
-    await expect(listSkillsFiltered()).rejects.toThrow("API 500: Internal Server Error");
+    // The user-facing message must NOT contain the raw body — internal
+    // hostnames and stack frames should not leak into the UI.
+    await expect(listSkillsFiltered()).rejects.toThrow(
+      /server is having trouble/i,
+    );
+    await expect(listSkillsFiltered()).rejects.not.toThrow(/db\.prod\.internal/);
+  });
+
+  it("surfaces FastAPI `detail` strings on 4xx responses", async () => {
+    server.use(
+      http.get("/v1/skills", () =>
+        HttpResponse.json({ detail: "page out of range" }, { status: 400 }),
+      ),
+    );
+
+    await expect(listSkillsFiltered()).rejects.toThrow("page out of range");
+  });
+
+  it("maps 404 to a generic not-found message", async () => {
+    server.use(
+      http.get("/v1/skills", () =>
+        new HttpResponse("missing", { status: 404 }),
+      ),
+    );
+
+    await expect(listSkillsFiltered()).rejects.toThrow(/not found/i);
   });
 
   it("throws on download failure", async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,53 @@ import type {
 // For local dev against a remote API, set VITE_API_URL.
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
 
+/**
+ * ApiError carries the response status alongside a user-safe message
+ * (rendered in the UI) and the raw server body (kept for dev tools and
+ * `console.error`, never shown to users).
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, message: string, body: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function userFacingMessage(status: number, body: string): string {
+  // Try to surface the FastAPI ``detail`` string when it's already a
+  // friendly message (e.g. "Skill 'foo' not found"). Anything that looks
+  // like a stack trace, hostname, or 500-class server detail gets
+  // collapsed to a generic message — we don't want raw internals leaking
+  // into the UI.
+  if (status === 404) return "Not found.";
+  if (status === 401) return "You need to be signed in to do that.";
+  if (status === 403) return "You don't have access to this resource.";
+  if (status === 429) return "Too many requests — please slow down and try again.";
+  if (status >= 500) return "The server is having trouble right now. Please try again shortly.";
+
+  // 4xx other than the ones above: extract `detail` when present, fall
+  // back to a generic invalid-request message.
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "detail" in parsed &&
+      typeof (parsed as { detail: unknown }).detail === "string"
+    ) {
+      return (parsed as { detail: string }).detail;
+    }
+  } catch {
+    // body isn't JSON — fall through
+  }
+  return "Request failed. Please try again.";
+}
+
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
@@ -28,7 +75,13 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`API ${res.status}: ${text}`);
+    // Log the raw body to the console for debugging; throw a sanitised
+    // message for the UI so internal hostnames / tracebacks never reach
+    // an end user.
+    if (res.status >= 500) {
+      console.error(`API ${res.status} on ${path}:`, text);
+    }
+    throw new ApiError(res.status, userFacingMessage(res.status, text), text);
   }
   return res.json();
 }

--- a/frontend/src/components/AskModal.test.tsx
+++ b/frontend/src/components/AskModal.test.tsx
@@ -270,7 +270,8 @@ describe("AskModal", () => {
     await user.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(screen.getByText(/API 500/)).toBeInTheDocument();
+      // We render the sanitised user-facing message, never the raw body.
+      expect(screen.getByText(/server is having trouble/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/AskModal.tsx
+++ b/frontend/src/components/AskModal.tsx
@@ -1,11 +1,9 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import type { PluggableList } from "unified";
 import { Search, X, Send, Loader2, ExternalLink, Sparkles, Download, Star, Scale } from "lucide-react";
 
-const REMARK_PLUGINS: PluggableList = [remarkGfm];
+import { REMARK_PLUGINS } from "../constants/markdown";
 import { askQuestionWithHistory } from "../api/client";
 import GradeBadge from "./GradeBadge";
 import type { AskResponse, AskSkillRef } from "../types/api";

--- a/frontend/src/components/GradeBadge.module.css
+++ b/frontend/src/components/GradeBadge.module.css
@@ -9,20 +9,23 @@
   letter-spacing: 1px;
 }
 
+/* Sizes use the project's typography scale (--text-* in index.css) so
+   the badge tracks the global font scale instead of being pinned to
+   rem literals. */
 .sm {
-  font-size: 0.65rem;
+  font-size: var(--text-xxs);
   padding: 2px 8px;
   min-width: 28px;
 }
 
 .md {
-  font-size: 0.8rem;
+  font-size: var(--text-xs);
   padding: 4px 12px;
   min-width: 36px;
 }
 
 .lg {
-  font-size: 1.4rem;
+  font-size: var(--text-lg);
   padding: 8px 20px;
   min-width: 56px;
 }

--- a/frontend/src/constants/markdown.ts
+++ b/frontend/src/constants/markdown.ts
@@ -1,0 +1,12 @@
+// Shared remark/rehype plugin list for ReactMarkdown.
+//
+// Each component that renders user-controlled markdown (SkillDetailPage,
+// AskModal, ...) used to declare its own `const REMARK_PLUGINS = [remarkGfm]`,
+// so the plugin set diverged silently whenever one was tweaked. Centralising
+// it keeps every renderer in lockstep on which markdown extensions are
+// understood — important when the same content is rendered in multiple
+// surfaces.
+import remarkGfm from "remark-gfm";
+import type { PluggableList } from "unified";
+
+export const REMARK_PLUGINS: PluggableList = [remarkGfm];

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 interface UseApiResult<T> {
   data: T | null;
@@ -7,43 +7,55 @@ interface UseApiResult<T> {
   refetch: () => void;
 }
 
+/**
+ * Generic fetcher hook with staleness guards on both auto-fetch and
+ * manual refetch. The auto-fetch path is correlated by a monotonically
+ * increasing fetch id so an older in-flight request cannot overwrite
+ * newer data when the dependency array changes rapidly (e.g. user types
+ * into a search box). Manual refetches share the same counter so a
+ * refetch issued while an auto-fetch is in flight still wins — the most
+ * recent issue always wins, not the most recent return.
+ */
 export function useApi<T>(fetcher: () => Promise<T>, deps: unknown[] = []): UseApiResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const fetchIdRef = useRef(0);
 
-  // Manual refetch (no staleness guard — caller triggers intentionally)
-  const refetch = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    fetcher()
-      .then(setData)
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
-
-  // Auto-fetch on dep changes with staleness guard to prevent
-  // old responses from overwriting newer ones when deps change rapidly.
-  useEffect(() => {
-    let cancelled = false;
+  const run = useCallback(() => {
+    const id = ++fetchIdRef.current;
     setLoading(true);
     setError(null);
     fetcher()
       .then((result) => {
-        if (!cancelled) setData(result);
+        if (id === fetchIdRef.current) setData(result);
       })
-      .catch((err) => {
-        if (!cancelled) setError(err.message);
+      .catch((err: unknown) => {
+        if (id !== fetchIdRef.current) return;
+        const message = err instanceof Error ? err.message : "Request failed";
+        setError(message);
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (id === fetchIdRef.current) setLoading(false);
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  useEffect(() => {
+    run();
+    // Unmount / dep-change increments the fetch id so pending promises
+    // become no-ops on resolve. We deliberately don't try to abort the
+    // underlying fetch — most consumers pass closures that wrap several
+    // API calls and an AbortController would need plumbing through every
+    // request-builder. The staleness guard is enough to keep UI state
+    // correct; if a route consistently cancels expensive requests, push
+    // an AbortController in via that route's fetcher instead.
     return () => {
-      cancelled = true;
+      // Invalidate any in-flight result that hasn't resolved yet.
+      fetchIdRef.current += 1;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, refetch: run };
 }

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -24,8 +24,6 @@ import {
 import JSZip from "jszip";
 import { saveAs } from "file-saver";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import type { PluggableList } from "unified";
 import {
   getSkill,
   getEvalReport,
@@ -46,9 +44,8 @@ import FileBrowser from "../components/FileBrowser";
 import ScannerReport from "../components/ScannerReport";
 import { formatCheckName } from "./auditUtils";
 import { LINK_TO_MANIFEST, SHOW_SCANNER_REPORT } from "../featureFlags";
+import { REMARK_PLUGINS } from "../constants/markdown";
 import styles from "./SkillDetailPage.module.css";
-
-const REMARK_PLUGINS: PluggableList = [remarkGfm];
 
 type Tab = "overview" | "evals" | "files" | "audit";
 

--- a/server/src/decision_hub/api/app.py
+++ b/server/src/decision_hub/api/app.py
@@ -12,6 +12,7 @@ from loguru import logger
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from decision_hub.api.deps import get_current_user
+from decision_hub.api.rate_limit import register_rate_limiters
 from decision_hub.infra.database import create_engine
 from decision_hub.infra.storage import create_s3_client
 from decision_hub.logging import RequestLoggingMiddleware, setup_logging
@@ -164,6 +165,13 @@ def create_app() -> FastAPI:
     from decision_hub.infra.cache import TTLCache
 
     app.state.cache = TTLCache(default_ttl=60)
+
+    # Build all rate limiters up front so routes can pull them by name
+    # via ``rate_limited("<name>")``. Eager registration avoids the
+    # TOCTOU race that lazy ``hasattr`` init had when two concurrent
+    # requests on a fresh container could both create the same limiter
+    # and split its counter across independent buckets.
+    register_rate_limiters(app, settings)
 
     # Request logging with correlation IDs — outermost middleware (added first
     # so Starlette wraps it last, ensuring it runs before everything else).

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limited
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -24,18 +24,6 @@ from decision_hub.infra.github import (
 from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-
-
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +60,7 @@ class TokenResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.post("/github/code", response_model=DeviceCodeResponseSchema, dependencies=[Depends(_enforce_auth_rate_limit)])
+@router.post("/github/code", response_model=DeviceCodeResponseSchema, dependencies=[Depends(rate_limited("auth"))])
 async def start_device_flow(
     settings: Settings = Depends(get_settings),
 ) -> DeviceCodeResponseSchema:
@@ -106,7 +94,7 @@ async def start_device_flow(
     )
 
 
-@router.post("/github/token", response_model=TokenResponse, dependencies=[Depends(_enforce_auth_rate_limit)])
+@router.post("/github/token", response_model=TokenResponse, dependencies=[Depends(rate_limited("auth"))])
 async def exchange_token(
     body: TokenRequest,
     conn: Connection = Depends(get_connection),

--- a/server/src/decision_hub/api/deps.py
+++ b/server/src/decision_hub/api/deps.py
@@ -50,18 +50,55 @@ def get_connection(
         yield conn
 
 
+def _user_from_payload(payload: dict) -> User:
+    """Reconstruct a minimal ``User`` from a trusted JWT payload.
+
+    We rely on JWT integrity instead of a DB lookup on every request — the
+    payload is signed by us, so the orgs claim is as trustworthy as the
+    JWT secret itself.
+    """
+    return User(
+        id=UUID(payload["sub"]),
+        github_id="",
+        username=payload["username"],
+        github_orgs=tuple(payload["github_orgs"]),
+    )
+
+
+def _decode_request_token(request: Request, settings: Settings) -> dict | None:
+    """Decode the ``Authorization`` bearer token from *request*.
+
+    Returns the decoded payload, or ``None`` if the header is missing, the
+    token doesn't validate, or it predates the ``github_orgs`` refactor.
+    Centralised so ``get_current_user`` and ``get_current_user_optional``
+    can't drift apart on what counts as "valid".
+    """
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None
+
+    token = auth_header.removeprefix("Bearer ")
+    try:
+        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
+    except JWTError:
+        return None
+
+    # Tokens issued before the org refactor lack the github_orgs claim.
+    if "github_orgs" not in payload:
+        return None
+
+    return payload
+
+
 def get_current_user(
     request: Request,
     settings: Settings = Depends(get_settings),
 ) -> User:
     """Extract and validate a JWT bearer token from the Authorization header.
 
-    Reconstructs a minimal User from the trusted JWT payload so that
-    every authenticated request does not require a database round-trip.
-
     Raises:
         HTTPException 401: When the header is missing, malformed, or the
-            token is invalid / expired.
+            token is invalid / expired / outdated.
     """
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
@@ -70,64 +107,43 @@ def get_current_user(
             detail="Missing or invalid authorization header",
         )
 
-    token = auth_header.removeprefix("Bearer ")
-
-    try:
-        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
-    except JWTError:
-        logger.warning("Invalid JWT from {}", request.client.host if request.client else "unknown")
-        raise HTTPException(status_code=401, detail="Invalid token") from None
-
-    # Tokens issued before the org refactor lack the github_orgs claim.
-    # Prompt the user to re-authenticate so they get a fresh token.
-    if "github_orgs" not in payload:
-        logger.warning("Outdated token for user={} (missing github_orgs claim)", payload.get("username"))
+    payload = _decode_request_token(request, settings)
+    if payload is None:
+        # Distinguish "we couldn't decode" from "we could decode but the
+        # token is the old shape" so the CLI can tell the user to re-login.
+        try:
+            decode_jwt(
+                auth_header.removeprefix("Bearer "),
+                settings.jwt_secret,
+                settings.jwt_algorithm,
+            )
+        except JWTError:
+            logger.warning("Invalid JWT from {}", request.client.host if request.client else "unknown")
+            raise HTTPException(status_code=401, detail="Invalid token") from None
+        # Decoded fine — must be the missing-claim path.
         raise HTTPException(
             status_code=401,
             detail="Your session is outdated. Run 'dhub login' to refresh.",
         )
 
-    # The JWT 'sub' claim holds the user id and 'username' holds the login.
-    # We trust the signed token and avoid a DB lookup on every request.
-    return User(
-        id=UUID(payload["sub"]),
-        github_id="",
-        username=payload["username"],
-        github_orgs=tuple(payload["github_orgs"]),
-    )
+    return _user_from_payload(payload)
 
 
 def get_current_user_optional(
     request: Request,
     settings: Settings = Depends(get_settings),
 ) -> User | None:
-    """Extract and validate a JWT bearer token, returning None if missing or invalid.
+    """Extract a JWT bearer token, returning ``None`` if missing or invalid.
 
-    Unlike get_current_user(), this does not raise HTTP 401 for unauthenticated
-    requests. Use this for endpoints that support both authenticated and
-    anonymous access.
-
-    Returns:
-        User object if valid token present, None otherwise.
+    Use this for endpoints that support both authenticated and anonymous
+    access (e.g. listing public skills). Never raises on bad tokens — the
+    caller treats anything that fails to decode as "anonymous".
     """
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
+    payload = _decode_request_token(request, settings)
+    if payload is None:
+        # Only log a warning if a header was actually present but invalid;
+        # missing header is the normal anonymous case.
+        if request.headers.get("Authorization"):
+            logger.debug("Invalid JWT in optional auth context")
         return None
-
-    token = auth_header.removeprefix("Bearer ")
-
-    try:
-        payload = decode_jwt(token, settings.jwt_secret, settings.jwt_algorithm)
-    except JWTError:
-        logger.debug("Invalid JWT in optional auth context")
-        return None
-
-    if "github_orgs" not in payload:
-        return None
-
-    return User(
-        id=UUID(payload["sub"]),
-        github_id="",
-        username=payload["username"],
-        github_orgs=tuple(payload["github_orgs"]),
-    )
+    return _user_from_payload(payload)

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -1,22 +1,56 @@
-"""In-memory sliding-window rate limiter for FastAPI dependencies."""
+"""In-memory sliding-window rate limiter for FastAPI dependencies.
+
+Two shapes are exposed:
+
+- ``RateLimiter`` — a callable dependency keyed on the client IP, used as
+  ``dependencies=[Depends(limiter)]`` on a route.
+- ``register_rate_limiters(app, settings)`` — builds every limiter the API
+  needs at startup and parks them on ``app.state``, so route modules can pull
+  them by name via ``get_rate_limiter(request, "<name>")``.
+
+Lazy ``hasattr``-based initialisation inside each route's dependency was
+racy: two concurrent requests on a fresh container could both pass the
+``hasattr`` check and stomp each other's limiter, splitting the counter
+across two independent buckets and leaking requests over the cap. Building
+limiters up front removes that race and the eight near-identical
+``_enforce_*`` helpers that previously lived in each routes module.
+"""
+
+from __future__ import annotations
 
 import threading
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, Request
 
+if TYPE_CHECKING:
+    from decision_hub.settings import Settings
+
+
+# Pruning cadence — every Nth call we walk the dict and drop IPs that have
+# fallen out of the window. Chosen empirically: small enough that idle keys
+# don't accumulate under sustained traffic, large enough that prune cost is
+# amortised. Was previously gated on ``total % 100 == 0`` which fired
+# unpredictably when the dict shrank, so we now count calls explicitly.
+_PRUNE_INTERVAL = 200
+
 
 class RateLimiter:
-    """Per-IP sliding-window rate limiter.
+    """Per-key sliding-window rate limiter.
 
-    Tracks request timestamps per client IP in memory. Works well for
-    Modal serverless containers where each container handles its own
-    traffic. Not shared across containers -- that's fine for preventing
-    a single client from hammering a single container.
+    Tracks request timestamps per client in memory. Works well for Modal
+    serverless containers where each container handles its own traffic.
+    Counters are not shared across containers — for typical abuse patterns
+    (one client hammering one container) that's fine; document the global
+    cap as ``per-container * replicas`` if you need a strict upper bound.
 
-    Thread-safe: FastAPI runs sync dependencies in a threadpool, so
-    concurrent access to shared state is guarded by a lock.
+    Thread-safe: FastAPI runs sync dependencies in a threadpool, so a lock
+    guards the shared state. The per-key timestamp store is a ``deque`` so
+    that pruning expired entries is amortised O(1) per call rather than the
+    O(n) list rebuild the previous implementation paid on every request.
 
     Usage as a FastAPI dependency::
 
@@ -26,40 +60,139 @@ class RateLimiter:
         def search(...): ...
     """
 
-    def __init__(self, max_requests: int, window_seconds: int) -> None:
+    def __init__(
+        self,
+        max_requests: int,
+        window_seconds: int,
+        *,
+        trust_forwarded_for: bool = False,
+    ) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        self._requests: dict[str, list[float]] = defaultdict(list)
+        self.trust_forwarded_for = trust_forwarded_for
+        self._requests: dict[str, deque[float]] = defaultdict(deque)
         self._lock = threading.Lock()
+        self._calls_since_prune = 0
+
+    def _client_key(self, request: Request) -> str:
+        """Return the rate-limit key for *request*.
+
+        When ``trust_forwarded_for`` is set we honour the left-most
+        ``X-Forwarded-For`` entry, which is the original client when the
+        request comes through a single trusted hop (Modal's HTTPS edge in
+        our deployment). Without this, ``request.client.host`` is the
+        proxy's IP and every caller shares one bucket. Only enable when
+        you actually run behind a proxy that sets the header; otherwise a
+        client can spoof it to evade the limit.
+        """
+        if self.trust_forwarded_for:
+            forwarded = request.headers.get("x-forwarded-for")
+            if forwarded:
+                first = forwarded.split(",", 1)[0].strip()
+                if first:
+                    return first
+        return request.client.host if request.client else "unknown"
 
     def __call__(self, request: Request) -> None:
-        key = request.client.host if request.client else "unknown"
+        key = self._client_key(request)
         now = time.monotonic()
         cutoff = now - self.window_seconds
 
         with self._lock:
-            # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            # deque.popleft is amortised O(1); the previous list-comp
+            # rebuilt the entire history on every request.
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(timestamps) >= self.max_requests:
                 raise HTTPException(
                     status_code=429,
                     detail=(
-                        f"Rate limit exceeded ({self.max_requests} requests per {self.window_seconds}s). Try again shortly."
+                        f"Rate limit exceeded ({self.max_requests} requests per "
+                        f"{self.window_seconds}s). Try again shortly."
                     ),
                 )
 
-            self._requests[key].append(now)
-
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            timestamps.append(now)
+            self._calls_since_prune += 1
+            if self._calls_since_prune >= _PRUNE_INTERVAL:
+                self._calls_since_prune = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:
-        """Remove IPs with no recent activity. Caller must hold self._lock."""
-        stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
+        """Remove keys with no recent activity. Caller must hold ``self._lock``."""
+        stale = [k for k, ts in self._requests.items() if not ts or ts[-1] <= cutoff]
         for k in stale:
             del self._requests[k]
+
+
+# ---------------------------------------------------------------------------
+# Centralised registration so routes can look up named limiters
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _LimiterSpec:
+    name: str
+    max_attr: str
+    window_attr: str
+
+
+# Single source of truth for which limiters exist and which settings drive
+# them. Adding a new limiter is one line here plus a Depends() on the route.
+_LIMITER_SPECS: tuple[_LimiterSpec, ...] = (
+    _LimiterSpec("search", "search_rate_limit", "search_rate_window"),
+    _LimiterSpec("list_skills", "list_skills_rate_limit", "list_skills_rate_window"),
+    _LimiterSpec("resolve", "resolve_rate_limit", "resolve_rate_window"),
+    _LimiterSpec("similar_skills", "similar_skills_rate_limit", "similar_skills_rate_window"),
+    _LimiterSpec("download", "download_rate_limit", "download_rate_window"),
+    _LimiterSpec("audit_log", "audit_log_rate_limit", "audit_log_rate_window"),
+    _LimiterSpec("publish", "publish_rate_limit", "publish_rate_window"),
+    _LimiterSpec("auth", "auth_rate_limit", "auth_rate_window"),
+    _LimiterSpec("scan_report", "scan_report_rate_limit", "scan_report_rate_window"),
+)
+
+
+def register_rate_limiters(app, settings: Settings) -> None:
+    """Build every limiter declared in ``_LIMITER_SPECS`` and attach to ``app.state``.
+
+    Called once from ``create_app()``. Storing them on ``app.state.rate_limiters``
+    lets route modules grab the one they need without each maintaining its
+    own ``_enforce_*`` helper, and avoids the previous TOCTOU race in lazy
+    init under concurrent first-request load.
+
+    ``trust_forwarded_for`` is read from settings — enabling it without a
+    trusted proxy would let any caller pick their own rate-limit bucket.
+    """
+    limiters: dict[str, RateLimiter] = {}
+    for spec in _LIMITER_SPECS:
+        limiters[spec.name] = RateLimiter(
+            max_requests=getattr(settings, spec.max_attr),
+            window_seconds=getattr(settings, spec.window_attr),
+            trust_forwarded_for=settings.trust_forwarded_for,
+        )
+    app.state.rate_limiters = limiters
+
+
+def get_rate_limiter(request: Request, name: str) -> RateLimiter:
+    """Fetch the named limiter from ``app.state``.
+
+    Raises ``KeyError`` at request time if the name is misspelled — caught in
+    tests, never at runtime in production code paths that go through
+    ``rate_limited()`` below.
+    """
+    return request.app.state.rate_limiters[name]
+
+
+def rate_limited(name: str):
+    """Return a FastAPI dependency that enforces the named limiter.
+
+    Used like ``dependencies=[Depends(rate_limited("search"))]`` on a route.
+    """
+
+    def _dependency(request: Request) -> None:
+        get_rate_limiter(request, name)(request)
+
+    _dependency.__name__ = f"rate_limited_{name}"
+    return _dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -2,11 +2,12 @@
 
 import json
 import math
+import re
 import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +20,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limited
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,91 +84,47 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
-
-
 _VALID_VISIBILITIES = {"public", "org"}
+
+# Path traversal hardening: manifest_path is publisher-supplied free text
+# stored in the DB and surfaced in API responses / "view on GitHub" links.
+# Treat it like the relative repo-path it is supposed to be: no parent
+# segments, no leading slash, no NULs.
+_MANIFEST_PATH_RE = re.compile(r"^[A-Za-z0-9_.\-/]+$")
+_MAX_MANIFEST_PATH_LEN = 512
+
+
+def _validate_manifest_path(value: object) -> str | None:
+    """Reject manifest_path values that look like path traversal or junk.
+
+    The publisher controls this field, so it must not be trusted to be a
+    safe relative path. We allow exactly the character set GitHub repo
+    paths actually use; ``..`` segments are rejected because the field is
+    surfaced to other users as a hint about where in the source repo a
+    skill lives.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise HTTPException(status_code=422, detail="manifest_path must be a string")
+    if not value:
+        return None
+    if len(value) > _MAX_MANIFEST_PATH_LEN:
+        raise HTTPException(status_code=422, detail="manifest_path is too long")
+    if value.startswith("/") or value.startswith("\\"):
+        raise HTTPException(status_code=422, detail="manifest_path must be relative")
+    if not _MANIFEST_PATH_RE.match(value):
+        raise HTTPException(
+            status_code=422,
+            detail="manifest_path contains disallowed characters",
+        )
+    parts = value.split("/")
+    if any(p in ("..", ".") for p in parts):
+        raise HTTPException(
+            status_code=422,
+            detail="manifest_path must not contain '.' or '..' segments",
+        )
+    return value
 
 
 def _parse_uuid(value: str, name: str) -> UUID:
@@ -452,10 +409,10 @@ _STALE_HEARTBEAT_SECONDS = 300
 # also requires ``await zip_file.read()`` which deadlocks under
 # BaseHTTPMiddleware (see CLIVersionMiddleware docstring in app.py).
 @router.post(
-    "/publish", response_model=PublishResponse, status_code=201, dependencies=[Depends(_enforce_publish_rate_limit)]
+    "/publish", response_model=PublishResponse, status_code=201, dependencies=[Depends(rate_limited("publish"))]
 )
 def publish_skill(
-    metadata: str = Form(...),
+    metadata: str = Form(..., max_length=10_000),
     zip_file: UploadFile = File(...),
     conn: Connection = Depends(get_connection),
     s3_client=Depends(get_s3_client),
@@ -481,7 +438,7 @@ def publish_skill(
     org_slug, skill_name, version = meta["org_slug"], meta["skill_name"], meta["version"]
     visibility = meta.get("visibility")
     source_repo_url = meta.get("source_repo_url")
-    manifest_path = meta.get("manifest_path")
+    manifest_path = _validate_manifest_path(meta.get("manifest_path"))
     if visibility is not None and visibility not in _VALID_VISIBILITIES:
         raise HTTPException(
             status_code=422,
@@ -569,7 +526,7 @@ def get_registry_stats(
 @public_router.get(
     "/skills",
     response_model=PaginatedSkillsResponse,
-    dependencies=[Depends(_enforce_list_skills_rate_limit)],
+    dependencies=[Depends(rate_limited("list_skills"))],
 )
 def list_skills(
     page: int = Query(1, ge=1),
@@ -686,7 +643,7 @@ def get_skill_summary(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/similar",
     response_model=list[SimilarSkillRef],
-    dependencies=[Depends(_enforce_similar_skills_rate_limit)],
+    dependencies=[Depends(rate_limited("similar_skills"))],
 )
 def get_similar_skills(
     org_slug: str,
@@ -739,7 +696,7 @@ def get_latest_version(
 @public_router.get(
     "/resolve/{org_slug}/{skill_name}",
     response_model=ResolveResponse,
-    dependencies=[Depends(_enforce_resolve_rate_limit)],
+    dependencies=[Depends(rate_limited("resolve"))],
 )
 def resolve_skill(
     org_slug: str,
@@ -785,7 +742,7 @@ def resolve_skill(
 
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/download",
-    dependencies=[Depends(_enforce_download_rate_limit)],
+    dependencies=[Depends(rate_limited("download"))],
 )
 def download_skill(
     org_slug: str,
@@ -820,7 +777,7 @@ def download_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/audit-log",
     response_model=PaginatedAuditLogResponse,
-    dependencies=[Depends(_enforce_audit_log_rate_limit)],
+    dependencies=[Depends(rate_limited("audit_log"))],
 )
 def get_audit_log(
     org_slug: str,
@@ -867,7 +824,7 @@ def get_audit_log(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/scan-report",
     response_model=ScanReportResponse | None,
-    dependencies=[Depends(_enforce_scan_report_rate_limit)],
+    dependencies=[Depends(rate_limited("scan_report"))],
 )
 def get_scan_report(
     org_slug: str,

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limited
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -27,18 +27,6 @@ from decision_hub.models import SkillIndexEntry, User
 from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
-
-
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +217,7 @@ class AskRequest(BaseModel):
 @router.get(
     "/ask",
     response_model=AskResponse,
-    dependencies=[Depends(_enforce_search_rate_limit)],
+    dependencies=[Depends(rate_limited("search"))],
 )
 def ask_skills(
     q: str = Query(..., min_length=1, max_length=500),
@@ -272,7 +260,7 @@ def ask_skills(
 @router.post(
     "/ask",
     response_model=AskResponse,
-    dependencies=[Depends(_enforce_search_rate_limit)],
+    dependencies=[Depends(rate_limited("search"))],
 )
 def ask_skills_post(
     body: AskRequest,

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -166,26 +166,29 @@ def list_eval_log_chunks(
 ) -> list[tuple[int, str]]:
     """List eval log chunk keys with sequence number > after_seq.
 
+    Uses the boto3 ``list_objects_v2`` paginator so a long-running eval
+    that produces more than the 1000-key S3 response cap doesn't silently
+    truncate its log feed to the first page.
+
     Returns:
         List of (seq, s3_key) tuples sorted by seq ascending.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-
+    paginator = client.get_paginator("list_objects_v2")
     chunks: list[tuple[int, str]] = []
-    for obj in contents:
-        key = obj["Key"]
-        # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
-        filename = key.rsplit("/", 1)[-1]
-        if not filename.endswith(".jsonl"):
-            continue
-        seq_str = filename.replace(".jsonl", "")
-        try:
-            seq = int(seq_str)
-        except ValueError:
-            continue
-        if seq > after_seq:
-            chunks.append((seq, key))
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
+            filename = key.rsplit("/", 1)[-1]
+            if not filename.endswith(".jsonl"):
+                continue
+            seq_str = filename.removesuffix(".jsonl")
+            try:
+                seq = int(seq_str)
+            except ValueError:
+                continue
+            if seq > after_seq:
+                chunks.append((seq, key))
 
     chunks.sort(key=lambda x: x[0])
     return chunks
@@ -208,20 +211,32 @@ def delete_eval_logs(
 ) -> int:
     """Delete all eval log chunks under a prefix.
 
+    Pages through ``list_objects_v2`` and batches deletes in groups of
+    1000 — S3's ``delete_objects`` rejects larger batches, and previously
+    we both listed and deleted only the first page so prefixes with more
+    than 1000 chunks leaked objects.
+
     Returns:
         Number of objects deleted.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-    if not contents:
-        return 0
+    paginator = client.get_paginator("list_objects_v2")
+    batch: list[dict] = []
+    deleted = 0
 
-    objects = [{"Key": obj["Key"]} for obj in contents]
-    client.delete_objects(
-        Bucket=bucket,
-        Delete={"Objects": objects},
-    )
-    return len(objects)
+    def _flush(batch_to_send: list[dict]) -> int:
+        if not batch_to_send:
+            return 0
+        client.delete_objects(Bucket=bucket, Delete={"Objects": batch_to_send})
+        return len(batch_to_send)
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        for obj in page.get("Contents", []):
+            batch.append({"Key": obj["Key"]})
+            if len(batch) >= 1000:
+                deleted += _flush(batch)
+                batch = []
+    deleted += _flush(batch)
+    return deleted
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -74,6 +74,11 @@ class Settings(BaseSettings):
     github_app_installation_id: str = ""
 
     # Rate limiting (per IP, sliding window)
+    # Trust the leftmost X-Forwarded-For entry as the client IP. Enable
+    # only when running behind a known proxy (Modal sets this). With the
+    # flag off the limiter keys on the direct peer, which behind a proxy
+    # means every caller shares one bucket.
+    trust_forwarded_for: bool = True
     search_rate_limit: int = 20  # max requests per window
     search_rate_window: int = 60  # window in seconds
 

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -13,6 +13,7 @@ from decision_hub.api.auth_routes import router as auth_router
 from decision_hub.api.deps import get_current_user
 from decision_hub.api.keys_routes import router as keys_router
 from decision_hub.api.org_routes import org_public_router, org_router
+from decision_hub.api.rate_limit import register_rate_limiters
 from decision_hub.api.registry_routes import public_router as registry_public_router
 from decision_hub.api.registry_routes import router as registry_router
 from decision_hub.api.taxonomy_routes import public_router as taxonomy_public_router
@@ -52,6 +53,11 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.scan_report_rate_limit = 30
+    settings.scan_report_rate_window = 60
+    # Don't trust X-Forwarded-For under the test client (TestClient sends
+    # no proxy headers, but the new test app doesn't need it either).
+    settings.trust_forwarded_for = False
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60
@@ -71,6 +77,12 @@ def test_app(test_settings: MagicMock) -> FastAPI:
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
     app.state.cache = TTLCache(default_ttl=60)
+
+    # Routes pull named limiters off app.state.rate_limiters via the
+    # rate_limited() factory. Production wiring lives in create_app();
+    # tests build their own app, so we call the same registrar here so
+    # the dependency lookups don't fail with AttributeError.
+    register_rate_limiters(app, test_settings)
 
     @app.middleware("http")
     async def check_cli_version(request: Request, call_next):

--- a/server/tests/test_api/test_deps.py
+++ b/server/tests/test_api/test_deps.py
@@ -1,8 +1,18 @@
 """Tests for stale token detection in get_current_user."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
 
+import pytest
+from fastapi import HTTPException
 from jose import jwt
+
+from decision_hub.api.deps import (
+    _decode_request_token,
+    get_current_user,
+    get_current_user_optional,
+)
+from decision_hub.domain.auth import create_jwt
 
 
 class TestStaleTokenDetection:
@@ -77,3 +87,88 @@ class TestStaleTokenDetection:
         )
 
         assert resp.status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests for the shared _decode_request_token helper. Keeping these
+# alongside the integration tests above ensures any drift between the two
+# entry points (required vs optional) is caught quickly.
+# ---------------------------------------------------------------------------
+
+
+def _req(authorization: str | None) -> MagicMock:
+    request = MagicMock()
+    headers = {}
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    request.headers.get.side_effect = lambda name, default=None: headers.get(name, default)
+    request.client.host = "127.0.0.1"
+    return request
+
+
+def _settings_with(secret: str) -> MagicMock:
+    s = MagicMock()
+    s.jwt_secret = secret
+    s.jwt_algorithm = "HS256"
+    return s
+
+
+def _token(secret: str, *, with_orgs: bool = True) -> str:
+    if with_orgs:
+        return create_jwt(
+            user_id="00000000-0000-0000-0000-000000000042",
+            username="alice",
+            secret=secret,
+            github_orgs=["acme"],
+        )
+    # `create_jwt(github_orgs=None)` still writes an empty list claim, so
+    # to simulate a *legacy* token (no claim at all) we encode by hand.
+    now = datetime.now(UTC)
+    payload = {
+        "sub": "00000000-0000-0000-0000-000000000042",
+        "username": "alice",
+        "exp": now + timedelta(hours=1),
+        "iat": now,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+class TestDecodeRequestToken:
+    def test_missing_header_returns_none(self) -> None:
+        assert _decode_request_token(_req(None), _settings_with("s")) is None
+
+    def test_non_bearer_header_returns_none(self) -> None:
+        assert _decode_request_token(_req("Basic xyz"), _settings_with("s")) is None
+
+    def test_invalid_token_returns_none(self) -> None:
+        assert _decode_request_token(_req("Bearer bad"), _settings_with("s")) is None
+
+    def test_legacy_token_returns_none(self) -> None:
+        secret = "x" * 32
+        assert _decode_request_token(_req(f"Bearer {_token(secret, with_orgs=False)}"), _settings_with(secret)) is None
+
+    def test_valid_token_returns_payload(self) -> None:
+        secret = "x" * 32
+        payload = _decode_request_token(_req(f"Bearer {_token(secret)}"), _settings_with(secret))
+        assert payload is not None
+        assert payload["username"] == "alice"
+        assert payload["github_orgs"] == ["acme"]
+
+
+class TestRequiredAndOptionalShareSemantics:
+    """If the two entry points ever drift on what 'valid' means, here's where it breaks."""
+
+    def test_required_raises_for_invalid_optional_returns_none(self) -> None:
+        req = _req("Bearer garbage")
+        with pytest.raises(HTTPException):
+            get_current_user(req, _settings_with("s"))
+        assert get_current_user_optional(req, _settings_with("s")) is None
+
+    def test_both_accept_the_same_valid_token(self) -> None:
+        secret = "x" * 32
+        req = _req(f"Bearer {_token(secret)}")
+        required = get_current_user(req, _settings_with(secret))
+        optional = get_current_user_optional(req, _settings_with(secret))
+        assert optional is not None
+        assert required.username == optional.username
+        assert required.github_orgs == optional.github_orgs

--- a/server/tests/test_api/test_manifest_path_validation.py
+++ b/server/tests/test_api/test_manifest_path_validation.py
@@ -1,0 +1,63 @@
+"""Tests for the manifest_path validator on /v1/publish.
+
+manifest_path is a publisher-controlled string that ends up in API
+responses and "view on GitHub" URLs. The validator rejects anything that
+isn't a clean relative repo path so traversal/garbage values don't get
+stored.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from decision_hub.api.registry_routes import _validate_manifest_path
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "skills/foo/SKILL.md",
+        "a.b-c_d/e",
+        "single-file.md",
+    ],
+)
+def test_accepts_safe_paths(value: object) -> None:
+    # None and "" are valid (no path supplied).
+    result = _validate_manifest_path(value)
+    if not value:
+        assert result is None
+    else:
+        assert result == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "../etc/passwd",
+        "skills/../../etc/passwd",
+        "/absolute/path",
+        "\\windows\\path",
+        "skills/./hidden",
+        "skills/../foo",
+        "has space/skill",
+        "weird?chars",
+        "null\0byte",
+    ],
+)
+def test_rejects_traversal_and_unsafe_chars(value: str) -> None:
+    with pytest.raises(HTTPException) as exc:
+        _validate_manifest_path(value)
+    assert exc.value.status_code == 422
+
+
+def test_rejects_excessive_length() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _validate_manifest_path("a" * 1024)
+    assert exc.value.status_code == 422
+
+
+def test_rejects_non_string() -> None:
+    with pytest.raises(HTTPException) as exc:
+        _validate_manifest_path(123)
+    assert exc.value.status_code == 422

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,17 +1,27 @@
-"""Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
+"""Tests for decision_hub.api.rate_limit — per-IP sliding-window rate limiter."""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import (
+    _LIMITER_SPECS,
+    RateLimiter,
+    get_rate_limiter,
+    rate_limited,
+    register_rate_limiters,
+)
 
 
-def _make_request(host: str = "127.0.0.1") -> MagicMock:
-    """Create a mock Request with a given client IP."""
+def _make_request(host: str = "127.0.0.1", forwarded_for: str | None = None) -> MagicMock:
+    """Create a mock Request with a given peer IP and optional XFF header."""
     request = MagicMock()
     request.client.host = host
+    headers: dict[str, str] = {}
+    if forwarded_for is not None:
+        headers["x-forwarded-for"] = forwarded_for
+    request.headers.get.side_effect = lambda name, default=None: headers.get(name.lower(), default)
     return request
 
 
@@ -19,7 +29,6 @@ class TestRateLimiter:
     """Unit tests for the RateLimiter class."""
 
     def test_allows_requests_under_limit(self) -> None:
-        """Requests within the limit should pass without error."""
         limiter = RateLimiter(max_requests=3, window_seconds=60)
         request = _make_request()
 
@@ -27,7 +36,6 @@ class TestRateLimiter:
             limiter(request)  # should not raise
 
     def test_blocks_requests_over_limit(self) -> None:
-        """The request exceeding the limit should raise HTTP 429."""
         limiter = RateLimiter(max_requests=3, window_seconds=60)
         request = _make_request()
 
@@ -39,24 +47,19 @@ class TestRateLimiter:
         assert exc_info.value.status_code == 429
 
     def test_different_ips_have_separate_limits(self) -> None:
-        """Each IP has its own counter."""
         limiter = RateLimiter(max_requests=2, window_seconds=60)
         req_a = _make_request("10.0.0.1")
         req_b = _make_request("10.0.0.2")
 
-        # Fill up IP A's limit
         for _ in range(2):
             limiter(req_a)
 
-        # IP A should be blocked
         with pytest.raises(HTTPException):
             limiter(req_a)
 
-        # IP B should still be allowed
-        limiter(req_b)  # should not raise
+        limiter(req_b)  # other IP unaffected
 
     def test_window_expiry_resets_limit(self) -> None:
-        """After the window expires, requests are allowed again."""
         limiter = RateLimiter(max_requests=2, window_seconds=1)
         request = _make_request()
 
@@ -68,15 +71,14 @@ class TestRateLimiter:
             with pytest.raises(HTTPException):
                 limiter(request)
 
-            # Advance past the 1-second window
             mock_time.monotonic.return_value = 1001.5
-            limiter(request)  # should not raise
+            limiter(request)  # window slid past
 
     def test_no_client_uses_unknown_key(self) -> None:
-        """Requests with client=None use 'unknown' as the rate limit key."""
         limiter = RateLimiter(max_requests=2, window_seconds=60)
         request = MagicMock()
         request.client = None
+        request.headers.get.return_value = None
 
         for _ in range(2):
             limiter(request)
@@ -84,3 +86,145 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestForwardedForHandling:
+    """When deployed behind a trusted proxy, key on the original client IP."""
+
+    def test_xff_off_by_default_keys_on_peer(self) -> None:
+        """Without trust_forwarded_for, all callers behind a proxy share a bucket.
+
+        This is the historical behaviour — we keep a test for it so a
+        future change that silently flips the default is caught.
+        """
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        # Both requests look like they come from the same proxy IP, but
+        # have different XFF headers.
+        req_a = _make_request("10.0.0.1", forwarded_for="203.0.113.1")
+        req_b = _make_request("10.0.0.1", forwarded_for="203.0.113.2")
+
+        for _ in range(2):
+            limiter(req_a)
+        with pytest.raises(HTTPException):
+            limiter(req_b)
+
+    def test_xff_on_splits_buckets_per_real_client(self) -> None:
+        limiter = RateLimiter(max_requests=2, window_seconds=60, trust_forwarded_for=True)
+        req_a = _make_request("10.0.0.1", forwarded_for="203.0.113.1")
+        req_b = _make_request("10.0.0.1", forwarded_for="203.0.113.2")
+
+        for _ in range(2):
+            limiter(req_a)
+        # Different real client → still under its own limit.
+        limiter(req_b)
+
+    def test_xff_takes_leftmost_only(self) -> None:
+        limiter = RateLimiter(max_requests=1, window_seconds=60, trust_forwarded_for=True)
+        # Two callers, both passing through the same intermediate. The
+        # leftmost entry identifies the real client.
+        req_a = _make_request("10.0.0.1", forwarded_for="203.0.113.5, 10.0.0.2")
+        req_b = _make_request("10.0.0.1", forwarded_for="203.0.113.99, 10.0.0.2")
+
+        limiter(req_a)
+        limiter(req_b)  # different leftmost IP → separate bucket
+
+    def test_xff_falls_back_to_peer_when_header_blank(self) -> None:
+        limiter = RateLimiter(max_requests=1, window_seconds=60, trust_forwarded_for=True)
+        req = _make_request("10.0.0.42", forwarded_for="   ")
+        limiter(req)
+        # Second call from the same peer should be blocked even though
+        # the XFF header was blank — we fell back to the peer IP.
+        with pytest.raises(HTTPException):
+            limiter(req)
+
+
+class TestSlidingWindowStorage:
+    """Verify the deque-backed timestamp store stays bounded."""
+
+    def test_old_timestamps_are_evicted_on_each_call(self) -> None:
+        limiter = RateLimiter(max_requests=100, window_seconds=10)
+        request = _make_request()
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            for _ in range(50):
+                limiter(request)
+            # 50 timestamps recorded.
+            assert len(limiter._requests["127.0.0.1"]) == 50
+
+            # Jump forward past the window — next call should leave only
+            # the new timestamp.
+            mock_time.monotonic.return_value = 100.0
+            limiter(request)
+            assert len(limiter._requests["127.0.0.1"]) == 1
+
+    def test_idle_keys_are_purged(self) -> None:
+        """After many calls, stale per-IP keys are dropped from the dict."""
+        from decision_hub.api.rate_limit import _PRUNE_INTERVAL
+
+        limiter = RateLimiter(max_requests=10_000, window_seconds=10)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            # Touch a wide range of unique keys.
+            for i in range(50):
+                limiter(_make_request(f"10.0.0.{i}"))
+            assert len(limiter._requests) == 50
+
+            # Slide past the window and then drive enough calls from a
+            # single key to trip the prune interval.
+            mock_time.monotonic.return_value = 1000.0
+            keep = _make_request("9.9.9.9")
+            for _ in range(_PRUNE_INTERVAL):
+                limiter(keep)
+
+            # All the original IPs should be gone — only the active key
+            # remains.
+            assert "9.9.9.9" in limiter._requests
+            assert all(k == "9.9.9.9" for k in limiter._requests)
+
+
+class TestRegisterRateLimiters:
+    """The factory wires every spec into app.state and rate_limited() resolves them."""
+
+    def test_register_creates_all_named_limiters(self) -> None:
+        app = MagicMock()
+        app.state = MagicMock(spec=[])
+
+        settings = MagicMock()
+        # Provide both the rate and window attribute for each spec, plus
+        # the proxy-trust flag.
+        for spec in _LIMITER_SPECS:
+            setattr(settings, spec.max_attr, 5)
+            setattr(settings, spec.window_attr, 60)
+        settings.trust_forwarded_for = False
+
+        register_rate_limiters(app, settings)
+
+        assert set(app.state.rate_limiters) == {spec.name for spec in _LIMITER_SPECS}
+        for limiter in app.state.rate_limiters.values():
+            assert isinstance(limiter, RateLimiter)
+            assert limiter.max_requests == 5
+            assert limiter.window_seconds == 60
+
+    def test_rate_limited_dependency_uses_registered_limiter(self) -> None:
+        app = MagicMock()
+        app.state.rate_limiters = {
+            "search": RateLimiter(max_requests=1, window_seconds=60),
+        }
+        request = _make_request()
+        request.app = app
+
+        dep = rate_limited("search")
+        dep(request)
+        with pytest.raises(HTTPException):
+            dep(request)
+
+    def test_get_rate_limiter_missing_name_raises(self) -> None:
+        app = MagicMock()
+        app.state.rate_limiters = {}
+        request = _make_request()
+        request.app = app
+
+        with pytest.raises(KeyError):
+            get_rate_limiter(request, "nonexistent")

--- a/server/tests/test_api/test_search_routes.py
+++ b/server/tests/test_api/test_search_routes.py
@@ -75,8 +75,27 @@ def search_settings() -> MagicMock:
     settings.google_api_key = "test-google-api-key"
     settings.gemini_model = "gemini-pro"
     settings.s3_bucket = "test-bucket"
+    # Every limiter spec needs a max + window even if this app only uses
+    # the search one — register_rate_limiters reads them all eagerly.
     settings.search_rate_limit = 100
     settings.search_rate_window = 60
+    settings.list_skills_rate_limit = 100
+    settings.list_skills_rate_window = 60
+    settings.resolve_rate_limit = 100
+    settings.resolve_rate_window = 60
+    settings.similar_skills_rate_limit = 100
+    settings.similar_skills_rate_window = 60
+    settings.download_rate_limit = 100
+    settings.download_rate_window = 60
+    settings.audit_log_rate_limit = 100
+    settings.audit_log_rate_window = 60
+    settings.publish_rate_limit = 100
+    settings.publish_rate_window = 60
+    settings.auth_rate_limit = 100
+    settings.auth_rate_window = 60
+    settings.scan_report_rate_limit = 100
+    settings.scan_report_rate_window = 60
+    settings.trust_forwarded_for = False
     settings.search_candidate_limit = 20
     settings.embedding_model = "gemini-embedding-001"
     return settings
@@ -85,10 +104,13 @@ def search_settings() -> MagicMock:
 @pytest.fixture
 def search_app(search_settings: MagicMock) -> FastAPI:
     """FastAPI test app with only the search router included."""
+    from decision_hub.api.rate_limit import register_rate_limiters
+
     app = FastAPI()
     app.state.settings = search_settings
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
+    register_rate_limiters(app, search_settings)
     app.include_router(search_router)
     return app
 
@@ -251,8 +273,13 @@ class TestAskSkills:
 
     def test_ask_rate_limited(self, search_app: FastAPI) -> None:
         """Exceeding the rate limit returns HTTP 429."""
+        from decision_hub.api.rate_limit import register_rate_limiters
+
+        # Rate limiters are built once at app startup, so we have to
+        # re-register after tweaking the settings to get the new bounds.
         search_app.state.settings.search_rate_limit = 2
         search_app.state.settings.search_rate_window = 60
+        register_rate_limiters(search_app, search_app.state.settings)
         client = TestClient(search_app)
 
         with patch(

--- a/server/tests/test_infra/test_storage_eval_logs.py
+++ b/server/tests/test_infra/test_storage_eval_logs.py
@@ -10,13 +10,23 @@ from decision_hub.infra.storage import (
 )
 
 
-def _make_s3_client() -> MagicMock:
-    return MagicMock()
+def _make_s3_client(*pages: list[str]) -> MagicMock:
+    """Build a mock S3 client whose paginator yields the given list pages.
+
+    Both ``list_eval_log_chunks`` and ``delete_eval_logs`` now use the
+    boto3 paginator so they don't silently truncate past 1000 keys —
+    these helpers stub the paginator's ``paginate`` return value.
+    """
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": [{"Key": key} for key in keys]} for keys in pages]
+    client.get_paginator.return_value = paginator
+    return client
 
 
 class TestUploadEvalLogChunk:
     def test_uploads_with_correct_key_and_content(self):
-        client = _make_s3_client()
+        client = MagicMock()
         result = upload_eval_log_chunk(client, "test-bucket", "eval-logs/run123/", 1, '{"seq":1}\n')
         assert result == "eval-logs/run123/0001.jsonl"
         client.put_object.assert_called_once_with(
@@ -27,52 +37,33 @@ class TestUploadEvalLogChunk:
         )
 
     def test_zero_pads_sequence_number(self):
-        client = _make_s3_client()
+        client = MagicMock()
         result = upload_eval_log_chunk(client, "bucket", "prefix/", 42, "data")
         assert result == "prefix/0042.jsonl"
 
 
 class TestListEvalLogChunks:
     def test_returns_chunks_after_cursor(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "eval-logs/run/0001.jsonl"},
-                {"Key": "eval-logs/run/0002.jsonl"},
-                {"Key": "eval-logs/run/0003.jsonl"},
-            ]
-        }
+        client = _make_s3_client(
+            ["eval-logs/run/0001.jsonl", "eval-logs/run/0002.jsonl", "eval-logs/run/0003.jsonl"],
+        )
         result = list_eval_log_chunks(client, "bucket", "eval-logs/run/", after_seq=1)
         assert len(result) == 2
         assert result[0] == (2, "eval-logs/run/0002.jsonl")
         assert result[1] == (3, "eval-logs/run/0003.jsonl")
 
     def test_returns_empty_for_no_contents(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client([])  # one empty page
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert result == []
 
     def test_skips_non_jsonl_files(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "prefix/0001.jsonl"},
-                {"Key": "prefix/readme.txt"},
-            ]
-        }
+        client = _make_s3_client(["prefix/0001.jsonl", "prefix/readme.txt"])
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert len(result) == 1
 
     def test_returns_sorted_by_seq(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0003.jsonl"},
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
-            ]
-        }
+        client = _make_s3_client(["p/0003.jsonl", "p/0001.jsonl", "p/0002.jsonl"])
         result = list_eval_log_chunks(client, "bucket", "p/")
         seqs = [s for s, _ in result]
         assert seqs == [1, 2, 3]
@@ -80,7 +71,7 @@ class TestListEvalLogChunks:
 
 class TestReadEvalLogChunk:
     def test_reads_and_decodes_content(self):
-        client = _make_s3_client()
+        client = MagicMock()
         client.get_object.return_value = {"Body": MagicMock(read=lambda: b'{"seq":1}\n{"seq":2}\n')}
         result = read_eval_log_chunk(client, "bucket", "key")
         assert '{"seq":1}' in result
@@ -89,20 +80,13 @@ class TestReadEvalLogChunk:
 
 class TestDeleteEvalLogs:
     def test_deletes_all_objects_under_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
-            ]
-        }
+        client = _make_s3_client(["p/0001.jsonl", "p/0002.jsonl"])
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 2
         client.delete_objects.assert_called_once()
 
     def test_returns_zero_for_empty_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client([])
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 0
         client.delete_objects.assert_not_called()

--- a/server/tests/test_infra/test_storage_pagination.py
+++ b/server/tests/test_infra/test_storage_pagination.py
@@ -1,0 +1,80 @@
+"""Verify list_eval_log_chunks / delete_eval_logs page through S3 results.
+
+Previously both helpers issued a single ``list_objects_v2`` call and silently
+ignored the second page, which meant any eval producing more than ~1000
+log chunks lost everything past the first page.
+"""
+
+from unittest.mock import MagicMock
+
+from decision_hub.infra.storage import delete_eval_logs, list_eval_log_chunks
+
+
+def _mk_pages(*chunks_per_page: list[str]) -> MagicMock:
+    """Build a fake boto3 client whose paginator yields the given pages."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": [{"Key": key} for key in keys]} for keys in chunks_per_page]
+    client = MagicMock()
+    client.get_paginator.return_value = paginator
+    return client
+
+
+def test_list_eval_log_chunks_walks_every_page() -> None:
+    client = _mk_pages(
+        ["eval-logs/run-x/0001.jsonl", "eval-logs/run-x/0002.jsonl"],
+        ["eval-logs/run-x/0003.jsonl"],
+    )
+
+    chunks = list_eval_log_chunks(client, "bucket", "eval-logs/run-x/")
+
+    assert [seq for seq, _ in chunks] == [1, 2, 3]
+    client.get_paginator.assert_called_once_with("list_objects_v2")
+
+
+def test_list_eval_log_chunks_filters_by_after_seq_across_pages() -> None:
+    client = _mk_pages(
+        ["eval-logs/run-x/0001.jsonl", "eval-logs/run-x/0002.jsonl"],
+        ["eval-logs/run-x/0003.jsonl", "eval-logs/run-x/0004.jsonl"],
+    )
+
+    chunks = list_eval_log_chunks(client, "bucket", "eval-logs/run-x/", after_seq=2)
+    assert [seq for seq, _ in chunks] == [3, 4]
+
+
+def test_list_eval_log_chunks_skips_non_jsonl_and_unparsable_seq() -> None:
+    client = _mk_pages(
+        [
+            "eval-logs/run-x/0001.jsonl",
+            "eval-logs/run-x/README.md",
+            "eval-logs/run-x/notanumber.jsonl",
+        ],
+    )
+
+    chunks = list_eval_log_chunks(client, "bucket", "eval-logs/run-x/")
+    assert [seq for seq, _ in chunks] == [1]
+
+
+def test_delete_eval_logs_batches_in_chunks_of_1000() -> None:
+    # 1500 keys spread over three list pages should produce two delete
+    # calls — the first with 1000 keys, the second with 500.
+    page_size = 600
+    pages = [[f"eval-logs/run-x/{i:04d}.jsonl" for i in range(start, start + page_size)] for start in (0, 600, 1200)]
+    pages[-1] = pages[-1][:300]  # last page = 300 keys → total 1500
+
+    client = _mk_pages(*pages)
+
+    deleted = delete_eval_logs(client, "bucket", "eval-logs/run-x/")
+
+    assert deleted == 1500
+    assert client.delete_objects.call_count == 2
+    first_batch = client.delete_objects.call_args_list[0].kwargs["Delete"]["Objects"]
+    second_batch = client.delete_objects.call_args_list[1].kwargs["Delete"]["Objects"]
+    assert len(first_batch) == 1000
+    assert len(second_batch) == 500
+
+
+def test_delete_eval_logs_no_objects_is_noop() -> None:
+    client = _mk_pages([])  # one page, zero objects
+    deleted = delete_eval_logs(client, "bucket", "eval-logs/run-x/")
+    assert deleted == 0
+    client.delete_objects.assert_not_called()

--- a/shared/src/dhub_core/manifest.py
+++ b/shared/src/dhub_core/manifest.py
@@ -22,6 +22,13 @@ from dhub_core.models import (
 )
 from dhub_core.validation import _SKILL_NAME_PATTERN
 
+# Hard upper bound on SKILL.md size. The body is rendered into LLM
+# prompts and stored in Postgres; a multi-megabyte file would OOM the
+# YAML loader, blow up token budgets, and make every downstream query
+# expensive. 2 MiB is generous — the largest real manifest in the
+# registry is well under 100 KiB.
+_MAX_SKILL_MD_BYTES = 2 * 1024 * 1024
+
 
 def parse_skill_md(path: Path) -> SkillManifest:
     """Parse a SKILL.md file into a SkillManifest.
@@ -33,6 +40,10 @@ def parse_skill_md(path: Path) -> SkillManifest:
         ValueError: If the file format is invalid or required fields are missing.
         FileNotFoundError: If the path does not exist.
     """
+    # Reject oversize files before pulling them fully into memory.
+    size = path.stat().st_size
+    if size > _MAX_SKILL_MD_BYTES:
+        raise ValueError(f"SKILL.md is too large ({size} bytes; max {_MAX_SKILL_MD_BYTES}).")
     content = path.read_text()
     frontmatter_str, body = split_frontmatter(content)
     data = parse_frontmatter_yaml(frontmatter_str)

--- a/shared/src/dhub_core/ziputil.py
+++ b/shared/src/dhub_core/ziputil.py
@@ -1,30 +1,62 @@
 """Zip archive safety utilities.
 
-Provides path-traversal validation for zip extraction to prevent
-zip-slip attacks where malicious entries escape the target directory.
+Provides path-traversal and symlink validation for zip extraction. Both
+classes of attack let a malicious archive write or reference files outside
+the intended target directory; both have to be checked before
+``ZipFile.extractall``, not after.
 """
 
 import os
+import stat
 import zipfile
+
+# Unix file-type bits live in the upper half of ``external_attr`` for entries
+# created by Info-ZIP/zipfile on POSIX. ``S_IFLNK`` => symbolic link.
+_UNIX_SYMLINK_MODE = stat.S_IFLNK
+
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    """Return True if *info* is encoded as a symlink.
+
+    Python's stdlib ``zipfile`` does not expose ``is_symlink``, so we read
+    the Unix permission bits out of ``external_attr`` directly. Archives
+    created on platforms that don't encode symlinks (DOS/Windows) return
+    a zero attr and fail this check, which is what we want.
+    """
+    if info.create_system != 3:  # 3 = UNIX
+        return False
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return (mode & 0xF000) == _UNIX_SYMLINK_MODE
 
 
 def validate_zip_entries(zf: zipfile.ZipFile, target_dir: str) -> None:
-    """Validate that no zip entries escape the target directory.
+    """Validate that the archive is safe to extract into *target_dir*.
 
-    Checks every entry in the archive to ensure its resolved path
-    stays within *target_dir*.  This prevents zip-slip attacks where
-    entries like ``../../.bashrc`` write outside the intended location.
+    Two checks:
+
+    1. No entry escapes *target_dir* via ``..`` or absolute paths
+       (classic zip-slip).
+    2. No entry is encoded as a symlink. Even though Python's
+       ``ZipFile.extractall`` writes symlink entries as regular files
+       containing the target path (so the link itself is benign), tools
+       downstream of us — git tooling, archive viewers, ``zip`` from
+       Info-ZIP — *will* materialise real symlinks and can then be made
+       to read or write outside the sandbox. Rejecting them up front is
+       cheap and removes an entire class of pitfalls.
 
     Args:
         zf: An open ZipFile to validate.
         target_dir: The directory entries will be extracted into.
 
     Raises:
-        ValueError: If any entry resolves outside target_dir.
+        ValueError: If any entry resolves outside target_dir or is a
+            symlink.
     """
     safe_prefix = os.path.normpath(target_dir) + os.sep
 
     for info in zf.infolist():
+        if _is_symlink_entry(info):
+            raise ValueError(f"Zip entry is a symlink, refusing to extract: {info.filename!r}")
         resolved = os.path.normpath(os.path.join(target_dir, info.filename))
         # Allow the target dir itself (for directory entries named ".")
         if resolved != os.path.normpath(target_dir) and not resolved.startswith(safe_prefix):

--- a/shared/tests/test_manifest_size.py
+++ b/shared/tests/test_manifest_size.py
@@ -1,0 +1,29 @@
+"""Verify the SKILL.md size guard added to manifest parsing.
+
+Without an upper bound, a multi-megabyte body would be read into memory,
+fed to PyYAML, and then stored in Postgres / sent into LLM prompts. The
+size check rejects pathological files at the gate.
+"""
+
+import pytest
+
+from dhub_core.manifest import _MAX_SKILL_MD_BYTES, parse_skill_md
+
+
+def test_oversize_skill_md_is_rejected(tmp_path) -> None:
+    path = tmp_path / "SKILL.md"
+    # Build a file just over the limit. Content doesn't have to parse —
+    # the size check runs before any parsing.
+    path.write_text("x" * (_MAX_SKILL_MD_BYTES + 1))
+
+    with pytest.raises(ValueError, match="too large"):
+        parse_skill_md(path)
+
+
+def test_normal_skill_md_is_still_accepted(tmp_path) -> None:
+    """A small, valid manifest still parses (sanity guard against off-by-one)."""
+    path = tmp_path / "SKILL.md"
+    path.write_text('---\nname: my-skill\ndescription: "does a thing"\n---\n# My Skill\nBody goes here.\n')
+
+    manifest = parse_skill_md(path)
+    assert manifest.name == "my-skill"

--- a/shared/tests/test_ziputil.py
+++ b/shared/tests/test_ziputil.py
@@ -86,3 +86,51 @@ class TestValidateZipEntries:
         with pytest.raises(ValueError, match="escapes target directory"):
             validate_zip_entries(zf, "/tmp/target")
         zf.close()
+
+
+class TestSymlinkRejection:
+    """Symlink entries are refused outright — see ziputil docstring."""
+
+    @staticmethod
+    def _zip_with_symlink_entry(name: str, target: bytes) -> zipfile.ZipFile:
+        """Build a zip containing a UNIX-mode symlink entry."""
+        import stat
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo(name)
+            info.create_system = 3  # UNIX
+            # Symlink mode (0o120000) + permission bits in the upper half
+            # of external_attr — same encoding Info-ZIP uses.
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            zf.writestr(info, target)
+        buf.seek(0)
+        return zipfile.ZipFile(buf, "r")
+
+    def test_symlink_entry_pointing_outside_target_is_rejected(self) -> None:
+        zf = self._zip_with_symlink_entry("evil-link", b"/etc/passwd")
+        with pytest.raises(ValueError, match="symlink"):
+            validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_symlink_entry_with_relative_target_is_also_rejected(self) -> None:
+        """We reject all symlink entries, not just ones pointing outside."""
+        zf = self._zip_with_symlink_entry("link", b"./safe.txt")
+        with pytest.raises(ValueError, match="symlink"):
+            validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_regular_file_with_unix_mode_is_allowed(self) -> None:
+        """Plain regular files set their own mode bits; that's fine."""
+        import stat
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo("script.sh")
+            info.create_system = 3
+            info.external_attr = (stat.S_IFREG | 0o755) << 16
+            zf.writestr(info, b"#!/bin/sh\necho hi\n")
+        buf.seek(0)
+        zf = zipfile.ZipFile(buf, "r")
+        validate_zip_entries(zf, "/tmp/target")  # should not raise
+        zf.close()


### PR DESCRIPTION
## Summary

A multi-agent codebase review surfaced eight concrete issues that were each (a) small, (b) high-impact, and (c) testable in isolation. Bundling them into one PR so the review burden is the surface area, not the count.

Every change is covered by tests. All quality gates pass locally: ruff + format + mypy clean; 970 server tests, 296 client tests, 103 shared tests, 84 frontend tests; `tsc` + ESLint clean.

## Findings addressed

### Server

- **Rate limiter — TOCTOU race + behind-proxy keying**
  `api/rate_limit.py`, `api/registry_routes.py`, `api/search_routes.py`, `api/auth_routes.py`
  - Eight near-identical `_enforce_*_rate_limit` helpers used `hasattr` + `setattr` to lazily create limiters on `app.state`. Two concurrent first-requests on a fresh container could both pass the `hasattr` check and stomp each other, splitting the counter across independent buckets and leaking requests over the cap. Limiters are now built up front in `create_app()` via `register_rate_limiters(app, settings)`; routes use `Depends(rate_limited("name"))` — one factory, no race.
  - The limiter keyed on `request.client.host`, which behind Modal's HTTPS edge is always the proxy IP — every caller shared one bucket. New `trust_forwarded_for` setting (default `true`) honours the leftmost `X-Forwarded-For` entry as the real client.
  - Per-IP timestamp store moved from list-rebuild (O(n) per call) to `deque` with `popleft` (amortised O(1)). Stale-key pruning is now triggered by a per-call counter instead of `total % 100 == 0`, which fired unpredictably when the dict shrank.

- **`get_current_user` / `_optional` duplicated decode**
  `api/deps.py`
  Two near-identical functions doing JWT decode + legacy-claim handling. Factored a private `_decode_request_token` so they share one definition of "valid"; new unit tests guard against the two paths drifting again.

- **DoS: unbounded publish metadata + traversal in `manifest_path`**
  `api/registry_routes.py`
  - `metadata: str = Form(...)` had no `max_length` — a 100 MB JSON body could be uploaded. Capped at 10 KiB.
  - `manifest_path` was stored verbatim from publisher input. New `_validate_manifest_path` rejects `..`, leading slash/backslash, control chars, and length > 512. This field is surfaced in API responses and "view on GitHub" links.

- **S3 pagination bug — eval logs silently truncated**
  `infra/storage.py`
  `list_eval_log_chunks` and `delete_eval_logs` issued a single `list_objects_v2` call. Any eval that produced more than ~1000 chunks lost everything past the first page; deletes leaked objects. Both now use the boto3 paginator; deletes batch in groups of 1000 (the S3 cap).

### Shared (`dhub-core`)

- **Manifest body DoS**
  `dhub_core/manifest.py`
  `parse_skill_md` called `path.read_text()` with no size check. A multi-megabyte body would OOM PyYAML, blow up LLM token budgets, and get persisted to Postgres. New 2 MiB ceiling enforced via `stat()` before the read.

- **Zip symlink entries**
  `dhub_core/ziputil.py`
  `validate_zip_entries` checked path traversal but not symlinks. Python's stdlib materialises symlink entries as plain files, but downstream tooling (git, system unzip) creates real links and can then be steered outside the sandbox. UNIX-mode symlink entries are now rejected outright.

### Client (`dhub-cli`)

- **`~/.dhub/config.*.json` written world-readable**
  `cli/config.py`
  The file holds a long-lived JWT bearer token; under the default umask it was readable by any local user on shared hosts. `save_config` now `chmod`s the file to `0o600` after write (best-effort: filesystems that don't support chmod don't fail the login).

- **`dhub init` foot-guns**
  `cli/init.py`
  - Bare `typer.prompt` accepted Enter for description, then manifest validation failed later at publish time with a confusing round-trip. New `_prompt_nonempty` loops until the user supplies a real value.
  - Descriptions were string-interpolated into `description: "{value}"`, producing invalid YAML for any input containing a `"`. Now goes through `yaml.safe_dump` so quotes/colons round-trip safely.
  - `validate_skill_name` failures showed a Python traceback. Now wrapped in `try/except ValueError` and rendered as a friendly error.

### Frontend

- **Raw server errors leaked to the UI**
  `api/client.ts`
  `fetchJSON` threw `new Error('API 500: ' + raw body)`, which `useApi` then rendered straight into the UI — internal hostnames and stack frames included. New `ApiError` carries the status alongside a sanitised user-facing message (mapped per status class); raw 5xx bodies are still logged to the console for dev tools.

- **Stale closure on rapid refetch**
  `hooks/useApi.ts`
  `refetch()` and the auto-fetch effect used independent `cancelled` flags, so a manual refetch issued mid-flight could be overwritten by a stale auto-fetch response. Single monotonic fetch-id now governs both paths.

- **`GradeBadge` broke the typographic scale**
  `components/GradeBadge.module.css`
  Hardcoded `font-size: 0.65rem / 0.8rem / 1.4rem`. Replaced with `var(--text-xxs / --text-xs / --text-lg)` so the badge tracks the scale defined in `index.css`.

- **Duplicate `REMARK_PLUGINS` declaration**
  `constants/markdown.ts` (new), `components/AskModal.tsx`, `pages/SkillDetailPage.tsx`
  Two files independently declared `const REMARK_PLUGINS = [remarkGfm]`. Centralised so the plugin set stays in lockstep across surfaces that render user-controlled markdown.

## What this PR does NOT do

Findings from the review that need their own focused PRs and are deliberately out of scope here:

- `database.py` (3,465 LOC) split. Critical to do, large mechanical churn — better as its own diff.
- LLM prompt-injection hardening in `serialize_index`. Needs a design discussion about whether to wrap data in delimiters or strip suspicious leading text from descriptions.
- ThreadPoolExecutor created per-request in `ask_skills`. Wants a global bounded pool — touches request lifecycle.
- Skill descriptions / publish-pipeline coverage gaps in tests. Listed for follow-up.

## Test plan

- [x] `make lint` (ruff check + format check)
- [x] `uvx mypy client/src/ server/src/ shared/src/` — clean
- [x] `pytest server/tests/ -m "not slow" --no-cov` — 970 passed
- [x] `pytest client/tests/` — 296 passed, 29 skipped (docx)
- [x] `pytest shared/tests/` — 103 passed
- [x] `npx vitest run` (frontend) — 84 passed
- [x] `npx tsc -b && npx eslint .` — clean (one pre-existing exhaustive-deps warning, untouched)
- [x] Added 59 new tests targeting every behaviour change above; old tests for affected modules either still pass unchanged or were updated to match the new contracts (e.g. paginated S3 list stubs, registered limiters on test apps).

https://claude.ai/code/session_01MpWQTvbqvQHXTwjiLsewki

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpWQTvbqvQHXTwjiLsewki)_