### PR TITLE
Harden review findings: git credential leaks, org rate limits, code health

### DIFF
--- a/client/src/dhub/core/git_repo.py
+++ b/client/src/dhub/core/git_repo.py
@@ -13,6 +13,26 @@ from pathlib import Path
 _GIT_URL_PREFIXES = ("https://", "http://", "git@", "ssh://", "git://")
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
 
+# Generous ceiling so legitimate large clones still succeed, but a hung
+# clone (e.g. git prompting for credentials on a non-TTY) can't block the
+# CLI forever.
+_GIT_TIMEOUT_SECONDS = 300
+
+# Matches the "userinfo@" portion of a URL (e.g. "x-access-token:ghp_xxx@").
+# Used to strip embedded credentials out of error output before it is shown.
+_URL_CREDENTIALS_RE = re.compile(r"//[^/@\s]+@")
+
+
+def _redact_credentials(text: str) -> str:
+    """Strip any ``userinfo@`` credentials embedded in URLs in *text*.
+
+    A user may pass an authenticated clone URL such as
+    ``https://x-access-token:<TOKEN>@github.com/...``. git echoes the URL
+    back in its error output, so we scrub it before surfacing the message
+    to the console or wrapping it in an exception.
+    """
+    return _URL_CREDENTIALS_RE.sub("//", text)
+
 
 def git_url_to_https(url: str) -> str | None:
     """Convert a git-cloneable URL to an HTTPS browse URL.
@@ -66,32 +86,51 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Path:
     tmp_dir = Path(tempfile.mkdtemp(prefix="dhub-repo-"))
     repo_path = tmp_dir / "repo"
 
+    def _run_git(cmd: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
+        """Run a git command with a timeout, cleaning up on failure.
+
+        Stderr is redacted before it ever reaches an exception message so an
+        authenticated clone URL can't leak a token into the console or logs.
+        """
+        try:
+            return subprocess.run(
+                cmd,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=_GIT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise RuntimeError(
+                f"git timed out after {_GIT_TIMEOUT_SECONDS}s — the repository may be "
+                "unreachable or prompting for credentials."
+            ) from exc
+
     if ref and _looks_like_sha(ref):
         # Commit SHAs don't work with --depth 1 --branch; do a full
         # clone then checkout the specific commit.
-        cmd = ["git", "clone", repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = _run_git(["git", "clone", repo_url, str(repo_path)])
         if result.returncode != 0:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
-        checkout = subprocess.run(
-            ["git", "checkout", ref],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
+            raise RuntimeError(
+                f"git clone failed (exit {result.returncode}):\n{_redact_credentials(result.stderr.strip())}"
+            )
+        checkout = _run_git(["git", "checkout", ref], cwd=str(repo_path))
         if checkout.returncode != 0:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
+            raise RuntimeError(f"git checkout {ref} failed:\n{_redact_credentials(checkout.stderr.strip())}")
     else:
         cmd = ["git", "clone", "--depth", "1"]
         if ref:
             cmd += ["--branch", ref]
         cmd += [repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = _run_git(cmd)
         if result.returncode != 0:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+            raise RuntimeError(
+                f"git clone failed (exit {result.returncode}):\n{_redact_credentials(result.stderr.strip())}"
+            )
 
     return repo_path
 

--- a/client/tests/test_core/test_git_repo.py
+++ b/client/tests/test_core/test_git_repo.py
@@ -1,8 +1,12 @@
 """Tests for dhub.core.git_repo -- clone and skill discovery."""
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from dhub.core.git_repo import discover_skills
+import pytest
+
+from dhub.core.git_repo import _redact_credentials, clone_repo, discover_skills
 
 
 class TestDiscoverSkills:
@@ -73,3 +77,47 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         names = [p.name for p in result]
         assert names == sorted(names)
+
+
+class TestRedactCredentials:
+    def test_strips_token_userinfo_from_https_url(self) -> None:
+        text = "fatal: could not read from https://x-access-token:ghp_SECRET@github.com/o/r.git"
+        redacted = _redact_credentials(text)
+        assert "ghp_SECRET" not in redacted
+        assert "x-access-token" not in redacted
+        assert "https://github.com/o/r.git" in redacted
+
+    def test_strips_basic_auth_userinfo(self) -> None:
+        assert "hunter2" not in _redact_credentials("clone https://user:hunter2@example.com/r")
+
+    def test_leaves_credential_free_urls_untouched(self) -> None:
+        text = "fatal: repository 'https://github.com/o/r.git' not found"
+        assert _redact_credentials(text) == text
+
+
+class TestCloneErrorHandling:
+    def test_clone_failure_redacts_credentials_in_error(self) -> None:
+        """A token embedded in the clone URL must never reach the raised error."""
+        failed = subprocess.CompletedProcess(
+            args=[],
+            returncode=128,
+            stdout="",
+            stderr="fatal: Authentication failed for https://x-access-token:ghp_SECRET@github.com/o/r.git",
+        )
+        with (
+            patch("dhub.core.git_repo.subprocess.run", return_value=failed),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            clone_repo("https://x-access-token:ghp_SECRET@github.com/o/r.git")
+        assert "ghp_SECRET" not in str(exc_info.value)
+
+    def test_clone_timeout_raises_clean_error(self) -> None:
+        """A hung clone must raise a timeout RuntimeError rather than block forever."""
+        with (
+            patch(
+                "dhub.core.git_repo.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="git clone", timeout=300),
+            ),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            clone_repo("https://github.com/o/r.git")

--- a/server/src/decision_hub/api/org_routes.py
+++ b/server/src/decision_hub/api/org_routes.py
@@ -2,13 +2,14 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from decision_hub.api.deps import get_cache, get_connection, get_current_user, get_settings
+from decision_hub.api.rate_limit import RateLimiter
 from decision_hub.domain.orgs import validate_org_slug
 from decision_hub.infra.cache import TTLCache
 from decision_hub.infra.database import (
@@ -26,6 +27,18 @@ from decision_hub.settings import Settings
 
 org_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
 org_public_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
+
+
+def _enforce_org_rate_limit(request: Request) -> None:
+    """Rate-limit the public org endpoints. Limiter is initialised lazily from settings."""
+    state = request.app.state
+    if not hasattr(state, "_org_rate_limiter"):
+        settings: Settings = state.settings
+        state._org_rate_limiter = RateLimiter(
+            max_requests=settings.org_rate_limit,
+            window_seconds=settings.org_rate_window,
+        )
+    state._org_rate_limiter(request)
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +164,11 @@ class OrgStatsResponse(BaseModel):
     items: list[OrgStatsEntry]
 
 
-@org_public_router.get("/stats", response_model=OrgStatsResponse)
+@org_public_router.get(
+    "/stats",
+    response_model=OrgStatsResponse,
+    dependencies=[Depends(_enforce_org_rate_limit)],
+)
 def get_org_stats(
     response: Response,
     search: str | None = Query(None, max_length=200),
@@ -190,7 +207,11 @@ def get_org_stats(
     return result
 
 
-@org_public_router.get("/profiles", response_model=list[OrgProfile])
+@org_public_router.get(
+    "/profiles",
+    response_model=list[OrgProfile],
+    dependencies=[Depends(_enforce_org_rate_limit)],
+)
 def list_org_profiles(
     response: Response,
     conn: Connection = Depends(get_connection),
@@ -223,7 +244,11 @@ def list_org_profiles(
     return result
 
 
-@org_public_router.get("/{slug}/profile", response_model=OrgProfile)
+@org_public_router.get(
+    "/{slug}/profile",
+    response_model=OrgProfile,
+    dependencies=[Depends(_enforce_org_rate_limit)],
+)
 def get_org_profile(
     slug: str,
     response: Response,

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -952,6 +952,29 @@ def get_scan_report(
     )
 
 
+def _fetch_visible_eval_report(
+    conn: Connection,
+    org_slug: str,
+    skill_name: str,
+    semver: str,
+    current_user: User | None,
+) -> EvalReportResponse | None:
+    """Shared body for the two eval-report endpoints (query- and path-based).
+
+    Gates on skill visibility first: a skill the caller cannot see returns
+    404 (not an empty body), so private skills aren't disclosed via the
+    eval-report path.
+    """
+    user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
+    skill = find_skill_by_slug(conn, org_slug, skill_name, user_org_ids=user_org_ids)
+    if skill is None:
+        raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found in {org_slug}")
+    report = find_eval_report_by_skill(conn, org_slug, skill_name, semver)
+    if report is None:
+        return None
+    return _report_to_response(report)
+
+
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
@@ -964,14 +987,7 @@ def get_eval_report_by_skill(
     current_user: User | None = Depends(get_current_user_optional),
 ) -> EvalReportResponse | None:
     """Get the eval report for a specific skill version."""
-    user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
-    skill = find_skill_by_slug(conn, org_slug, skill_name, user_org_ids=user_org_ids)
-    if skill is None:
-        raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found in {org_slug}")
-    report = find_eval_report_by_skill(conn, org_slug, skill_name, semver)
-    if report is None:
-        return None
-    return _report_to_response(report)
+    return _fetch_visible_eval_report(conn, org_slug, skill_name, semver, current_user)
 
 
 @public_router.get(
@@ -986,14 +1002,7 @@ def get_eval_report_by_version_path(
     current_user: User | None = Depends(get_current_user_optional),
 ) -> EvalReportResponse | None:
     """Get the eval report for a specific skill version (path-based)."""
-    user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
-    skill = find_skill_by_slug(conn, org_slug, skill_name, user_org_ids=user_org_ids)
-    if skill is None:
-        raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found in {org_slug}")
-    report = find_eval_report_by_skill(conn, org_slug, skill_name, semver)
-    if report is None:
-        return None
-    return _report_to_response(report)
+    return _fetch_visible_eval_report(conn, org_slug, skill_name, semver, current_user)
 
 
 @router.delete(

--- a/server/src/decision_hub/domain/gauntlet.py
+++ b/server/src/decision_hub/domain/gauntlet.py
@@ -1343,13 +1343,6 @@ def run_static_checks(
     grade = compute_grade(result_tuple, elevated)
     summary = build_gauntlet_summary(result_tuple, elevated)
 
-    from loguru import logger
-
-    logger.info(
-        "Gauntlet grading: elevated={} grade={} source_files={}",
-        elevated,
-        grade,
-        [name for name, _ in source_files],
-    )
-
+    # No logging here: this is a pure domain function. The caller
+    # (run_gauntlet_pipeline) logs the resulting grade.
     return GauntletReport(results=result_tuple, grade=grade, gauntlet_summary=summary)

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2861,11 +2861,17 @@ def upsert_skill_tracker(
 
 def has_active_tracker_for_repo(conn: Connection, repo_url: str) -> bool:
     """Return True if at least one enabled tracker exists for the given repo URL."""
-    stmt = sa.select(sa.literal(True)).where(
-        sa.and_(
-            skill_trackers_table.c.repo_url == repo_url,
-            skill_trackers_table.c.enabled.is_(True),
+    # LIMIT 1: this is an existence check, so stop at the first match instead
+    # of letting Postgres materialise every enabled tracker for the repo.
+    stmt = (
+        sa.select(sa.literal(True))
+        .where(
+            sa.and_(
+                skill_trackers_table.c.repo_url == repo_url,
+                skill_trackers_table.c.enabled.is_(True),
+            )
         )
+        .limit(1)
     )
     return conn.execute(stmt).first() is not None
 

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -88,6 +88,11 @@ class Settings(BaseSettings):
     download_rate_window: int = 60  # window in seconds
     audit_log_rate_limit: int = 30  # max requests per window
     audit_log_rate_window: int = 60  # window in seconds
+    # Public org endpoints (stats / profiles / single profile). The stats
+    # endpoint takes an attacker-varied `search` param that bypasses the
+    # TTL cache, so it needs its own per-IP limiter like other public routes.
+    org_rate_limit: int = 120  # max requests per window
+    org_rate_window: int = 60  # window in seconds
     publish_rate_limit: int = 10  # max requests per window
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,8 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.org_rate_limit = 120
+    settings.org_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_org_routes.py
+++ b/server/tests/test_api/test_org_routes.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from decision_hub.models import Organization, OrgMember
@@ -297,3 +298,34 @@ class TestGetOrg:
         """Should return 401 without auth headers."""
         resp = client.get("/v1/orgs/some-org")
         assert resp.status_code == 401
+
+
+class TestOrgRateLimit:
+    """Public org endpoints must be rate-limited (DOS protection)."""
+
+    @patch("decision_hub.api.org_routes.fetch_org_stats")
+    def test_org_stats_rate_limited(
+        self,
+        mock_fetch_stats: MagicMock,
+        test_app: FastAPI,
+    ) -> None:
+        """Exceeding the per-IP limit on /v1/orgs/stats returns HTTP 429.
+
+        The `search` param varies the cache key, so the TTL cache cannot
+        absorb an attacker hammering this DB-backed endpoint — the limiter
+        is the real protection.
+        """
+        mock_fetch_stats.return_value = []
+        test_app.state.settings.org_rate_limit = 2
+        test_app.state.settings.org_rate_window = 60
+        # Disable caching so every request reaches the limiter.
+        test_app.state.settings.cache_ttl_org_stats = 0
+        client = TestClient(test_app)
+
+        for i in range(2):
+            resp = client.get("/v1/orgs/stats", params={"search": f"q{i}"})
+            assert resp.status_code == 200
+
+        resp = client.get("/v1/orgs/stats", params={"search": "q-final"})
+        assert resp.status_code == 429
+        assert "Rate limit exceeded" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

This PR implements a set of high-leverage, low-risk fixes surfaced by a deep architect/principal-engineer review of the codebase. Each change is small, well-commented, and covered by tests. They span security, performance, and code health.

### Security

- **CLI git credential leak + hang** (`client/src/dhub/core/git_repo.py`)
  - A user can pass an authenticated clone URL like `https://x-access-token:<TOKEN>@github.com/...`. git echoes that URL back in its error output, so the token previously leaked into the console and any logs. All git stderr is now redacted (`_redact_credentials`) before being wrapped in a `RuntimeError`.
  - `git clone`/`checkout` had **no timeout**, so a clone that hangs (e.g. git prompting for credentials on a non-TTY) would block the CLI forever. Added a generous 300s timeout that raises a clean error on `TimeoutExpired`, per the project's subprocess rules.

- **Missing rate limiters on public org endpoints** (`server/src/decision_hub/api/org_routes.py`, `settings.py`)
  - `/v1/orgs/stats`, `/v1/orgs/profiles`, and `/v1/orgs/{slug}/profile` are unauthenticated and DB-backed, but had no per-IP limiter. `/stats` takes a `search` param that varies the TTL-cache key, so the cache can't absorb an attacker hammering the endpoint. Added an `_enforce_org_rate_limit` dependency following the existing pattern, plus `org_rate_limit` / `org_rate_window` settings (defaults 120/60s).

### Performance

- **`has_active_tracker_for_repo`** (`server/src/decision_hub/infra/database.py`) — this is an existence check but had no `LIMIT`. Added `LIMIT 1` so Postgres stops at the first match instead of materialising every enabled tracker for the repo.

### Code health

- **Duplicate eval-report endpoints** (`server/src/decision_hub/api/registry_routes.py`) — `get_eval_report_by_skill` and `get_eval_report_by_version_path` had identical bodies. Collapsed into one shared, visibility-gated helper (`_fetch_visible_eval_report`) so the 404-on-private-skill logic lives in a single place.
- **Domain-layer logging** (`server/src/decision_hub/domain/gauntlet.py`) — removed the `loguru` call from the pure function `run_static_checks`; the caller (`run_gauntlet_pipeline`) already logs the resulting grade. Restores the "domain functions don't log" rule.

### Tests added

- `client/tests/test_core/test_git_repo.py`: credential redaction, clone-failure redaction, and clone-timeout handling.
- `server/tests/test_api/test_org_routes.py`: `/v1/orgs/stats` returns 429 once the per-IP limit is exceeded (with cache disabled so every request reaches the limiter).

## Notes / deliberately out of scope

The review surfaced several deeper items intentionally **not** included here to keep the PR focused and low-risk:
- IDOR hardening (pushing visibility filters down into `find_audit_logs` / `find_eval_report_by_skill` / scan-report fallback) — the existing existence-gate protects these today; pushing filtering into the query layer is a larger, separate change.
- Tracker partial-failure error reporting — current behavior (`last_error=None` on partial success) is explicitly asserted by an existing test, so flipping it warrants a separate discussion.
- God-function decomposition (`tracker_service.check_all_due_trackers`, gauntlet reconciliation helpers) and the broader `domain/` → `services/` separation.

## Test plan

- [x] `make test-client` (git_repo suite) — 14 passed
- [x] `make test-server` touched suites (test_api, test_gauntlet, test_infra) — 566 passed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `mypy client/src server/src` — no issues

https://claude.ai/code/session_01PUHu36ABCKzpP2HW1SVdwe

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUHu36ABCKzpP2HW1SVdwe)_