### PR TITLE
refactor: consolidate rate-limit factories, fix three latent bugs

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -28,14 +28,14 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 def _enforce_auth_rate_limit(request: Request) -> None:
     """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_auth_rate_limiter",
+        max_requests=settings.auth_rate_limit,
+        window_seconds=settings.auth_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,8 +3,14 @@
 import threading
 import time
 from collections import defaultdict
+from typing import Any
 
 from fastapi import HTTPException, Request
+
+# Periodically scan for and evict stale IPs so memory growth is bounded.
+# Triggered every Nth call rather than on every call to keep the hot path
+# cheap. Counter-based so the cadence is independent of traffic shape.
+_PURGE_EVERY_N_CALLS = 1024
 
 
 class RateLimiter:
@@ -31,6 +37,12 @@ class RateLimiter:
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        # Per-instance call counter drives periodic stale-IP eviction.
+        # Earlier this used `total = sum(len(v) for v in requests.values()) % 100`,
+        # which rarely hit zero once timestamps were pruned each call and made
+        # the purge cadence depend on request rate per IP. A plain counter
+        # purges reliably every N calls regardless of traffic shape.
+        self._call_count = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -52,10 +64,9 @@ class RateLimiter:
 
             self._requests[key].append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._call_count += 1
+            if self._call_count >= _PURGE_EVERY_N_CALLS:
+                self._call_count = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:
@@ -63,3 +74,24 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def get_or_create_limiter(
+    app_state: Any,
+    attr_name: str,
+    *,
+    max_requests: int,
+    window_seconds: int,
+) -> RateLimiter:
+    """Return a RateLimiter from app.state, lazily creating it on first call.
+
+    Centralises the "check attribute, build from settings, stash on state"
+    pattern that was previously duplicated across every public route module.
+    The first caller pays the construction cost; every subsequent caller
+    reuses the same limiter instance.
+    """
+    limiter = getattr(app_state, attr_name, None)
+    if limiter is None:
+        limiter = RateLimiter(max_requests=max_requests, window_seconds=window_seconds)
+        setattr(app_state, attr_name, limiter)
+    return limiter

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,52 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
+# Each tuple is (state-attribute, max-requests setting name, window setting name).
+# Keeping the table here (rather than at module load) lets us read fresh values
+# from app.state.settings on first request, matching the previous lazy behaviour.
+_RATE_LIMIT_CONFIGS: tuple[tuple[str, str, str], ...] = (
+    ("_list_skills_rate_limiter", "list_skills_rate_limit", "list_skills_rate_window"),
+    ("_resolve_rate_limiter", "resolve_rate_limit", "resolve_rate_window"),
+    ("_similar_skills_rate_limiter", "similar_skills_rate_limit", "similar_skills_rate_window"),
+    ("_download_rate_limiter", "download_rate_limit", "download_rate_window"),
+    ("_audit_log_rate_limiter", "audit_log_rate_limit", "audit_log_rate_window"),
+    ("_scan_report_rate_limiter", "scan_report_rate_limit", "scan_report_rate_window"),
+    ("_publish_rate_limiter", "publish_rate_limit", "publish_rate_window"),
+)
+
+
+def _make_enforcer(state_attr: str, limit_attr: str, window_attr: str):
+    """Build a FastAPI dependency that enforces one rate-limit slot.
+
+    Returns a function whose ``__name__`` is unique per slot so FastAPI's
+    dependency cache treats them as distinct dependencies, matching the
+    behaviour of the previously hand-written enforcers.
+    """
+
+    def _enforce(request: Request) -> None:
+        settings: Settings = request.app.state.settings
+        limiter = get_or_create_limiter(
+            request.app.state,
+            state_attr,
+            max_requests=getattr(settings, limit_attr),
+            window_seconds=getattr(settings, window_attr),
         )
-    state._list_skills_rate_limiter(request)
+        limiter(request)
+
+    _enforce.__name__ = f"enforce{state_attr}"
+    _enforce.__qualname__ = _enforce.__name__
+    return _enforce
 
 
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+(
+    _enforce_list_skills_rate_limit,
+    _enforce_resolve_rate_limit,
+    _enforce_similar_skills_rate_limit,
+    _enforce_download_rate_limit,
+    _enforce_audit_log_rate_limit,
+    _enforce_scan_report_rate_limit,
+    _enforce_publish_rate_limit,
+) = (_make_enforcer(*cfg) for cfg in _RATE_LIMIT_CONFIGS)
 
 
 _VALID_VISIBILITIES = {"public", "org"}

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -31,14 +31,14 @@ router = APIRouter(prefix="/v1", tags=["search"])
 
 def _enforce_search_rate_limit(request: Request) -> None:
     """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_search_rate_limiter",
+        max_requests=settings.search_rate_limit,
+        window_seconds=settings.search_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/seo_routes.py
+++ b/server/src/decision_hub/api/seo_routes.py
@@ -18,18 +18,10 @@ router = APIRouter(tags=["seo"])
 _BASE_URL = "https://hub.decision.ai"
 
 
-@router.get("/sitemap.xml", include_in_schema=False)
-def sitemap_xml(
-    conn: Connection = Depends(get_connection),
-    cache: TTLCache = Depends(get_cache),
-    settings: Settings = Depends(get_settings),
-) -> Response:
-    """Generate a dynamic XML sitemap with all public skills and orgs."""
-    ttl = settings.cache_ttl_sitemap
-    cached = cache.get("sitemap_xml") if ttl else None
-    if cached is not None:
-        return cached
-
+def _build_sitemap_xml(conn: Connection) -> str:
+    """Render the sitemap body. Split out so the route caches the XML string,
+    not a Starlette ``Response`` object (which carries mutable per-request
+    state and is unsafe to share across requests)."""
     today = datetime.now(UTC).strftime("%Y-%m-%d")
 
     urls: list[tuple[str, str, str]] = [
@@ -81,8 +73,10 @@ def sitemap_xml(
     for row in conn.execute(org_stmt):
         urls.append((f"{_BASE_URL}/orgs/{row[0]}", today, "weekly"))
 
-    lines = ['<?xml version="1.0" encoding="UTF-8"?>']
-    lines.append('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ]
     for loc, lastmod, changefreq in urls:
         lines.append("  <url>")
         lines.append(f"    <loc>{escape(loc)}</loc>")
@@ -90,13 +84,25 @@ def sitemap_xml(
         lines.append(f"    <changefreq>{escape(changefreq)}</changefreq>")
         lines.append("  </url>")
     lines.append("</urlset>")
+    return "\n".join(lines)
 
-    xml = "\n".join(lines)
+
+@router.get("/sitemap.xml", include_in_schema=False)
+def sitemap_xml(
+    conn: Connection = Depends(get_connection),
+    cache: TTLCache = Depends(get_cache),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    """Generate a dynamic XML sitemap with all public skills and orgs."""
+    ttl = settings.cache_ttl_sitemap
+    xml = cache.get("sitemap_xml") if ttl else None
+    if xml is None:
+        xml = _build_sitemap_xml(conn)
+        if ttl:
+            cache.set("sitemap_xml", xml, ttl=ttl)
+
     headers = {"Cache-Control": f"public, max-age={ttl}"} if ttl else {}
-    result = Response(content=xml, media_type="application/xml", headers=headers)
-    if ttl:
-        cache.set("sitemap_xml", result, ttl=ttl)
-    return result
+    return Response(content=xml, media_type="application/xml", headers=headers)
 
 
 _PROD_HOSTS = {"hub.decision.ai", "decisionhub.dev"}

--- a/server/src/decision_hub/domain/publish.py
+++ b/server/src/decision_hub/domain/publish.py
@@ -121,11 +121,29 @@ def extract_for_evaluation(
             basename = name.rsplit("/", 1)[-1] if "/" in name else name
 
             if basename == "SKILL.md":
-                skill_md = zf.read(name).decode()
+                # SKILL.md must be valid UTF-8 — it's the source of truth
+                # for skill identity. A malformed manifest is a 422, not a 500.
+                try:
+                    skill_md = zf.read(name).decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise ValueError(f"SKILL.md is not valid UTF-8: {exc}") from exc
             elif basename in ("requirements.txt", "uv.lock", "poetry.lock"):
-                lockfile_content = zf.read(name).decode()
+                try:
+                    lockfile_content = zf.read(name).decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise ValueError(f"Lockfile '{name}' is not valid UTF-8: {exc}") from exc
             elif _is_scannable_file(basename):
-                source_files.append((name, zf.read(name).decode()))
+                # A source file with an expected extension but binary content
+                # would previously raise UnicodeDecodeError, bubbling up as a
+                # 500. Decode with ``errors="replace"`` so the scanner still
+                # gets a string and surface the file in unscanned_files so
+                # the gauntlet can flag partial coverage.
+                raw = zf.read(name)
+                try:
+                    source_files.append((name, raw.decode("utf-8")))
+                except UnicodeDecodeError:
+                    source_files.append((name, raw.decode("utf-8", errors="replace")))
+                    unscanned_files.append(name)
             else:
                 unscanned_files.append(name)
 

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,16 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import (
+    _PURGE_EVERY_N_CALLS,
+    RateLimiter,
+    get_or_create_limiter,
+)
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +89,92 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestStaleIpPurge:
+    """The purge ran on ``sum(len(v) for v in requests.values()) % 100``.
+
+    Once timestamps were pruned each call, that sum stayed small (typically
+    1 per active key after pruning), and the modulo rarely hit zero except
+    by coincidence. The new implementation uses a per-instance counter so
+    eviction runs deterministically every N requests regardless of the
+    traffic mix.
+    """
+
+    def test_idle_ips_eventually_evicted(self) -> None:
+        """A key untouched for longer than the window is dropped on purge."""
+        limiter = RateLimiter(max_requests=_PURGE_EVERY_N_CALLS * 4, window_seconds=60)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            limiter(_make_request("10.0.0.1"))
+            assert "10.0.0.1" in limiter._requests
+
+            # Walk past the rate window so the idle IP is eligible for purge.
+            mock_time.monotonic.return_value = 120.0
+
+            # Drive enough live traffic from a different IP to cross the purge
+            # threshold; the new counter purges on a fixed cadence regardless
+            # of how many distinct IPs are active.
+            live = _make_request("10.0.0.2")
+            for _ in range(_PURGE_EVERY_N_CALLS):
+                limiter(live)
+
+            assert "10.0.0.1" not in limiter._requests
+            assert "10.0.0.2" in limiter._requests
+
+    def test_purge_cadence_does_not_depend_on_per_ip_rate(self) -> None:
+        """One IP hammering the same endpoint still triggers the purge.
+
+        Under the old implementation, a single hot IP would prune its own
+        timestamps on every call, leaving ``total`` clamped at 1 and the
+        purge would only trigger on a numerical coincidence. The counter
+        approach must fire after exactly ``_PURGE_EVERY_N_CALLS`` calls.
+        """
+        limiter = RateLimiter(max_requests=_PURGE_EVERY_N_CALLS * 4, window_seconds=60)
+        hot = _make_request("10.0.0.99")
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 0.0
+            limiter(_make_request("10.0.0.1"))
+            mock_time.monotonic.return_value = 120.0
+
+            for _ in range(_PURGE_EVERY_N_CALLS):
+                limiter(hot)
+
+            assert "10.0.0.1" not in limiter._requests
+
+
+class TestGetOrCreateLimiter:
+    """The lazy-init helper used by every public route module."""
+
+    def test_creates_limiter_on_first_call(self) -> None:
+        state = SimpleNamespace()
+        limiter = get_or_create_limiter(
+            state,
+            "_some_limiter",
+            max_requests=5,
+            window_seconds=60,
+        )
+
+        assert isinstance(limiter, RateLimiter)
+        assert limiter.max_requests == 5
+        assert state._some_limiter is limiter
+
+    def test_returns_same_instance_on_subsequent_calls(self) -> None:
+        """Repeated calls must reuse the same RateLimiter — otherwise the
+        sliding-window counters would reset on every request."""
+        state = SimpleNamespace()
+        first = get_or_create_limiter(state, "_attr", max_requests=5, window_seconds=60)
+        second = get_or_create_limiter(state, "_attr", max_requests=999, window_seconds=999)
+
+        assert first is second, "must reuse, not rebuild"
+        # Updated args are ignored — the original instance is what counts.
+        assert first.max_requests == 5
+
+    def test_different_attribute_names_create_distinct_limiters(self) -> None:
+        state = SimpleNamespace()
+        a = get_or_create_limiter(state, "_limit_a", max_requests=1, window_seconds=60)
+        b = get_or_create_limiter(state, "_limit_b", max_requests=1, window_seconds=60)
+
+        assert a is not b

--- a/server/tests/test_api/test_seo_routes.py
+++ b/server/tests/test_api/test_seo_routes.py
@@ -1,0 +1,87 @@
+"""Tests for sitemap.xml caching behaviour.
+
+Earlier the sitemap endpoint stashed a Starlette ``Response`` object in the
+TTL cache. Response objects carry mutable per-request state (headers,
+charset finalisation when first sent), so reusing them across requests is
+risky. The cache should hold the rendered XML string and the route should
+build a fresh Response on each hit.
+"""
+
+from unittest.mock import MagicMock
+
+from fastapi.responses import Response
+
+from decision_hub.api.seo_routes import _build_sitemap_xml, sitemap_xml
+from decision_hub.infra.cache import TTLCache
+
+
+class TestSitemapCaching:
+    def _empty_conn(self) -> MagicMock:
+        """A conn whose ``execute()`` returns an empty iterator."""
+        conn = MagicMock()
+        conn.execute.return_value = iter([])
+        return conn
+
+    def test_cache_stores_xml_string_not_response_object(self) -> None:
+        """Caching a Response object is unsafe — cache the body instead."""
+        conn = self._empty_conn()
+        cache = TTLCache(default_ttl=60)
+        settings = MagicMock()
+        settings.cache_ttl_sitemap = 60
+
+        first = sitemap_xml(conn=conn, cache=cache, settings=settings)
+
+        assert isinstance(first, Response)
+        cached_value = cache.get("sitemap_xml")
+        assert isinstance(cached_value, str), (
+            f"Expected cache to hold the XML string, got {type(cached_value).__name__}"
+        )
+        assert cached_value.startswith('<?xml version="1.0"')
+
+    def test_cache_hit_returns_fresh_response_with_same_body(self) -> None:
+        """A second call must reuse the cached XML but build a new Response."""
+        conn = self._empty_conn()
+        cache = TTLCache(default_ttl=60)
+        settings = MagicMock()
+        settings.cache_ttl_sitemap = 60
+
+        first = sitemap_xml(conn=conn, cache=cache, settings=settings)
+        first_call_count = conn.execute.call_count
+
+        second_conn = self._empty_conn()  # Distinct conn proves we skipped DB.
+        second = sitemap_xml(conn=second_conn, cache=cache, settings=settings)
+
+        assert second_conn.execute.call_count == 0, "cache hit must skip DB queries"
+        assert conn.execute.call_count == first_call_count
+        assert first.body == second.body
+        assert first is not second, "must return a fresh Response per request"
+
+    def test_ttl_zero_disables_cache(self) -> None:
+        """When the TTL setting is zero, every call should re-render."""
+        cache = TTLCache(default_ttl=60)
+        settings = MagicMock()
+        settings.cache_ttl_sitemap = 0
+
+        first_conn = self._empty_conn()
+        second_conn = self._empty_conn()
+        sitemap_xml(conn=first_conn, cache=cache, settings=settings)
+        sitemap_xml(conn=second_conn, cache=cache, settings=settings)
+
+        assert first_conn.execute.called
+        assert second_conn.execute.called
+        assert cache.get("sitemap_xml") is None
+
+
+class TestSitemapBody:
+    def test_includes_root_and_static_pages(self) -> None:
+        conn = MagicMock()
+        conn.execute.return_value = iter([])
+
+        xml = _build_sitemap_xml(conn)
+
+        assert "https://hub.decision.ai/" in xml
+        assert "/skills" in xml
+        assert "/orgs" in xml
+        assert "/how-it-works" in xml
+        assert xml.startswith('<?xml version="1.0"')
+        assert xml.rstrip().endswith("</urlset>")

--- a/server/tests/test_domain/test_publish.py
+++ b/server/tests/test_domain/test_publish.py
@@ -269,3 +269,50 @@ class TestExtractForEvaluation:
         )
         _, _, _, unscanned = extract_for_evaluation(zip_bytes)
         assert unscanned == []
+
+
+class TestNonUtf8Handling:
+    """Non-UTF-8 bytes in source files used to surface as 500 from .decode().
+
+    Source files should now decode with ``errors="replace"`` and get flagged
+    as unscanned so the gauntlet records partial coverage. Manifest files
+    (SKILL.md, lockfiles) must still be strict UTF-8 since they drive
+    identity and dependency resolution.
+    """
+
+    def test_binary_source_file_is_replaced_and_flagged(self) -> None:
+        """A .py entry with arbitrary bytes shouldn't raise — extract surfaces it."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md", "---\nname: s\ndescription: d\n---\n")
+            zf.writestr("binary.py", b"\xff\xfe\xfd\x00garbage\x80")
+        zip_bytes = buf.getvalue()
+
+        _, sources, _lockfile, unscanned = extract_for_evaluation(zip_bytes)
+
+        assert "binary.py" in unscanned, "binary file should be flagged as unscanned"
+        source_names = [n for n, _ in sources]
+        assert "binary.py" in source_names, "binary file should still be present for scanners"
+        binary_content = next(c for n, c in sources if n == "binary.py")
+        assert "�" in binary_content or "garbage" in binary_content
+
+    def test_non_utf8_skill_md_raises_value_error(self) -> None:
+        """SKILL.md must be valid UTF-8 — fail with 422-style ValueError."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md", b"---\nname: s\xff\nd: d\n---\n")
+        zip_bytes = buf.getvalue()
+
+        with pytest.raises(ValueError, match=r"SKILL\.md is not valid UTF-8"):
+            extract_for_evaluation(zip_bytes)
+
+    def test_non_utf8_lockfile_raises_value_error(self) -> None:
+        """Lockfiles drive dependency resolution — strict UTF-8 only."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md", "---\nname: s\ndescription: d\n---\n")
+            zf.writestr("requirements.txt", b"requests\xff==2.31.0\n")
+        zip_bytes = buf.getvalue()
+
+        with pytest.raises(ValueError, match="not valid UTF-8"):
+            extract_for_evaluation(zip_bytes)


### PR DESCRIPTION
## Summary

Outcome of a deep codebase review focused on high-leverage, low-risk cleanups. Four issues, each landed with regression tests. **+371 / -123 LOC**, **945 server tests pass** (up from 933), ruff and mypy clean.

## Findings & fixes

### 1. Rate-limit factory duplication — DRY (code-health, M impact / S effort)

Nine near-identical `_enforce_*_rate_limit` functions across three route modules each did the same `hasattr(state, ...) -> RateLimiter -> stash on state` dance:

```
server/src/decision_hub/api/registry_routes.py:86-167   (7 copies)
server/src/decision_hub/api/search_routes.py:32-41      (1 copy)
server/src/decision_hub/api/auth_routes.py:29-38        (1 copy)
```

**Fix:** Centralise the lazy-init dance in `rate_limit.get_or_create_limiter(app_state, attr_name, *, max_requests, window_seconds) -> RateLimiter`. Drive the seven `registry_routes` enforcers from a `_RATE_LIMIT_CONFIGS` table via `_make_enforcer()` — each generated function keeps a unique `__name__` so FastAPI's dependency cache still treats them as distinct. The other two enforcers (`search`, `auth`) collapse to three lines apiece.

### 2. RateLimiter stale-IP purge rarely fires — bug + perf (M / S)

`server/src/decision_hub/api/rate_limit.py:57` previously read:

```python
total = sum(len(v) for v in self._requests.values())
if total % 100 == 0:
    self._purge_stale(cutoff)
```

Because each call prunes expired timestamps for its own key first, the sum stays small (typically ~1 per active IP after the per-call prune). The modulo therefore only hits zero by coincidence; under a single hot IP it never fires. Memory grows unbounded.

**Fix:** Per-instance call counter (`_PURGE_EVERY_N_CALLS = 1024`). Purge runs deterministically every N requests regardless of traffic shape.

### 3. Non-UTF-8 source files surface as HTTP 500 — bug (M / S)

`server/src/decision_hub/domain/publish.py:124-128` called `.decode()` (strict UTF-8) on every scannable file. A `.py` entry containing arbitrary bytes therefore raised `UnicodeDecodeError`, which `/v1/publish` doesn't catch — its `except` clause only handles `(ValueError, zipfile.BadZipFile)`. The user gets a 500.

**Fix:**
- Source files: decode with `errors="replace"` so the scanner still sees a string, and append to `unscanned_files` so the gauntlet's partial-coverage check downgrades the grade.
- `SKILL.md` and lockfiles: keep strict UTF-8 (they drive identity and dependency resolution); raise a clean `ValueError` (→ 422) when malformed.

### 4. `seo_routes.sitemap_xml` cached a Starlette `Response` object — bug (M / S)

`server/src/decision_hub/api/seo_routes.py` stashed the constructed `Response` in the TTL cache and returned the cached instance directly on subsequent hits. Response objects carry mutable per-request state (header finalisation, charset, etc.) and the Starlette docs are explicit they're not meant to be shared.

**Fix:** Split rendering into `_build_sitemap_xml(conn) -> str` and cache only the XML body. The route builds a fresh `Response` on every hit.

## Issues considered but deferred

- `server/src/decision_hub/infra/database.py` is 3,465 lines — splitting by domain table grouping would be valuable but is out of scope (architectural M/L).
- `server/src/decision_hub/api/registry_routes.py` is 1,352 lines and mixes registry, eval runs, visibility, and access endpoints — same reasoning.
- `_run_to_response` / `_tracker_to_response` converters duplicate ISO-format date logic — low value, skipped.

## Test plan

- [x] `uv run --package decision-hub-server --extra dev pytest server/tests -m "not slow"` — 945 passed, 34 deselected
- [x] `uv run --package dhub-core --extra dev pytest shared/tests` — 98 passed
- [x] `uvx ruff check .` — clean
- [x] `uvx ruff format --check .` — clean
- [x] `uvx mypy server/src/decision_hub/api/rate_limit.py server/src/decision_hub/api/registry_routes.py server/src/decision_hub/api/seo_routes.py server/src/decision_hub/domain/publish.py` — clean
- [x] New tests:
  - `test_rate_limit.py::TestStaleIpPurge::test_idle_ips_eventually_evicted` — idle IPs dropped after the window
  - `test_rate_limit.py::TestStaleIpPurge::test_purge_cadence_does_not_depend_on_per_ip_rate` — single hot IP still triggers purge
  - `test_rate_limit.py::TestGetOrCreateLimiter` — lazy init / identity / distinctness
  - `test_publish.py::TestNonUtf8Handling::test_binary_source_file_is_replaced_and_flagged`
  - `test_publish.py::TestNonUtf8Handling::test_non_utf8_skill_md_raises_value_error`
  - `test_publish.py::TestNonUtf8Handling::test_non_utf8_lockfile_raises_value_error`
  - `test_seo_routes.py::TestSitemapCaching::test_cache_stores_xml_string_not_response_object`
  - `test_seo_routes.py::TestSitemapCaching::test_cache_hit_returns_fresh_response_with_same_body`
  - `test_seo_routes.py::TestSitemapCaching::test_ttl_zero_disables_cache`

https://claude.ai/code/session_016diHyWN9knNJAKe5VwmezW

---
_Generated by [Claude Code](https://claude.ai/code/session_016diHyWN9knNJAKe5VwmezW)_