### PR TITLE
refactor(server): rate-limiter perf+memory, single-engine eval bg, one-read zombie

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -28,14 +28,14 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 def _enforce_auth_rate_limit(request: Request) -> None:
     """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        name="auth",
+        max_requests=settings.auth_rate_limit,
+        window_seconds=settings.auth_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -1,22 +1,41 @@
-"""In-memory sliding-window rate limiter for FastAPI dependencies."""
+"""In-memory sliding-window rate limiter for FastAPI dependencies.
+
+The limiter is per-IP and intentionally container-local: each Modal
+container enforces its own quota, which is fine for stopping a single
+client from hammering a single container.  If the deployment ever
+auto-scales beyond one container, this protection becomes per-replica
+— move to a shared store (Redis) at that point.
+"""
 
 import threading
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+# How often the limiter scans its IP table to drop stale entries.
+# A fraction of the window is a good balance: fresh enough to bound
+# memory, sparse enough that the scan itself is amortised cheaply.
+_PURGE_INTERVAL_FRACTION = 0.5
 
 
 class RateLimiter:
     """Per-IP sliding-window rate limiter.
 
-    Tracks request timestamps per client IP in memory. Works well for
-    Modal serverless containers where each container handles its own
-    traffic. Not shared across containers -- that's fine for preventing
-    a single client from hammering a single container.
+    Tracks request timestamps per client IP in memory.  Each IP has a
+    bounded deque of recent monotonic timestamps; admission is decided
+    by counting timestamps inside the window.
 
-    Thread-safe: FastAPI runs sync dependencies in a threadpool, so
-    concurrent access to shared state is guarded by a lock.
+    Thread-safe: FastAPI runs sync dependencies in a threadpool, so the
+    shared dict is guarded by a single lock.  All operations under the
+    lock are O(k) where k is the number of expired timestamps for the
+    current IP, not O(N-ips).
+
+    Memory: stale IPs are evicted on a time-driven schedule rather than
+    on a request counter, so a low-traffic instance still trims its
+    table predictably and a high-traffic instance does not pay the
+    sweep cost on every request.
 
     Usage as a FastAPI dependency::
 
@@ -26,40 +45,92 @@ class RateLimiter:
         def search(...): ...
     """
 
-    def __init__(self, max_requests: int, window_seconds: int) -> None:
+    def __init__(
+        self,
+        max_requests: int,
+        window_seconds: int,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        self._requests: dict[str, list[float]] = defaultdict(list)
+        # Optional injected clock for unit tests.  When ``None`` we
+        # resolve ``time.monotonic`` on every call so the existing
+        # ``patch("decision_hub.api.rate_limit.time")`` test pattern
+        # keeps working.
+        self._clock = clock
+        self._requests: dict[str, deque[float]] = defaultdict(deque)
         self._lock = threading.Lock()
+        # Drive eviction by elapsed time, not by request count.  The
+        # previous ``total % 100 == 0`` heuristic fired on every cold
+        # start (total = 0) and could fail to fire for hours under a
+        # traffic shape that never hit an exact multiple.
+        self._purge_interval = max(1.0, window_seconds * _PURGE_INTERVAL_FRACTION)
+        self._next_purge_at = self._now() + self._purge_interval
+
+    def _now(self) -> float:
+        return self._clock() if self._clock is not None else time.monotonic()
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
-        now = time.monotonic()
+        now = self._now()
         cutoff = now - self.window_seconds
 
         with self._lock:
-            # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            # popleft is O(1) and prunes only the expired front of the
+            # deque -- the previous list comprehension rebuilt the
+            # entire list on every request, which is O(n) per call.
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(timestamps) >= self.max_requests:
                 raise HTTPException(
                     status_code=429,
                     detail=(
-                        f"Rate limit exceeded ({self.max_requests} requests per {self.window_seconds}s). Try again shortly."
+                        f"Rate limit exceeded ({self.max_requests} requests per "
+                        f"{self.window_seconds}s). Try again shortly."
                     ),
                 )
 
-            self._requests[key].append(now)
+            timestamps.append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            if now >= self._next_purge_at:
                 self._purge_stale(cutoff)
+                self._next_purge_at = now + self._purge_interval
 
     def _purge_stale(self, cutoff: float) -> None:
-        """Remove IPs with no recent activity. Caller must hold self._lock."""
-        stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
+        """Drop IPs whose most recent request is older than the window.
+
+        Caller must hold ``self._lock``.  An empty deque also counts as
+        stale -- it can be left behind by ``defaultdict`` access in a
+        rejected admission.
+        """
+        stale = [k for k, ts in self._requests.items() if not ts or ts[-1] <= cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def get_or_create_limiter(
+    state,
+    name: str,
+    max_requests: int,
+    window_seconds: int,
+) -> RateLimiter:
+    """Lazily attach a named ``RateLimiter`` to ``app.state``.
+
+    Each endpoint that needs rate limiting calls this from its own
+    one-line ``Depends`` shim.  Keeping the limiter on ``app.state``
+    means it lives for the lifetime of the container (one bucket per
+    endpoint per container), which is the intended scope.
+
+    The previous implementation duplicated a 12-line ``hasattr`` block
+    per endpoint in every router module -- this helper collapses all of
+    them into a single, tested function.
+    """
+    attr = f"_rate_limiter__{name}"
+    limiter = getattr(state, attr, None)
+    if limiter is None:
+        limiter = RateLimiter(max_requests=max_requests, window_seconds=window_seconds)
+        setattr(state, attr, limiter)
+    return limiter

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,36 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
+# Each endpoint that needs a rate limit goes through this single helper
+# rather than its own ``hasattr`` block.  ``get_or_create_limiter``
+# lazily attaches a named limiter to ``app.state`` (one bucket per
+# endpoint per container) and reads its parameters from settings.
+def _rate_limit_dep(name: str, limit_attr: str, window_attr: str):
+    """Build a FastAPI dependency that enforces a named rate limit."""
+
+    def _dep(request: Request) -> None:
+        settings: Settings = request.app.state.settings
+        limiter = get_or_create_limiter(
+            request.app.state,
+            name=name,
+            max_requests=getattr(settings, limit_attr),
+            window_seconds=getattr(settings, window_attr),
         )
-    state._list_skills_rate_limiter(request)
+        limiter(request)
+
+    _dep.__name__ = f"_enforce_{name}_rate_limit"
+    return _dep
 
 
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_list_skills_rate_limit = _rate_limit_dep("list_skills", "list_skills_rate_limit", "list_skills_rate_window")
+_enforce_resolve_rate_limit = _rate_limit_dep("resolve", "resolve_rate_limit", "resolve_rate_window")
+_enforce_similar_skills_rate_limit = _rate_limit_dep(
+    "similar_skills", "similar_skills_rate_limit", "similar_skills_rate_window"
+)
+_enforce_download_rate_limit = _rate_limit_dep("download", "download_rate_limit", "download_rate_window")
+_enforce_audit_log_rate_limit = _rate_limit_dep("audit_log", "audit_log_rate_limit", "audit_log_rate_window")
+_enforce_scan_report_rate_limit = _rate_limit_dep("scan_report", "scan_report_rate_limit", "scan_report_rate_window")
+_enforce_publish_rate_limit = _rate_limit_dep("publish", "publish_rate_limit", "publish_rate_window")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -1097,27 +1045,42 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
+def _check_zombie(conn: Connection, run):
     """Check if a running eval run has a stale heartbeat (zombie).
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    Returns the eval run, possibly with its status mutated in place if
+    a stale heartbeat caused us to flip it to ``failed``.  The caller
+    therefore does not need to re-read the row after this call.
     """
     if run.status not in ("running", "judging", "provisioning"):
-        return run.status
+        return run
     if run.heartbeat_at is None:
-        return run.status
+        return run
     elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
-    if elapsed > _STALE_HEARTBEAT_SECONDS:
-        update_eval_run_status(
-            conn,
-            run.id,
-            status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
-            completed_at=datetime.now(UTC),
-        )
-        return "failed"
-    return run.status
+    if elapsed <= _STALE_HEARTBEAT_SECONDS:
+        return run
+
+    error_message = f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed."
+    completed_at = datetime.now(UTC)
+    update_eval_run_status(
+        conn,
+        run.id,
+        status="failed",
+        error_message=error_message,
+        completed_at=completed_at,
+    )
+    # Mirror the DB update on the in-memory model so callers see the
+    # post-update state without a second SELECT.  The dataclass is
+    # frozen, so we use ``dataclasses.replace`` to build the updated
+    # copy.
+    from dataclasses import replace
+
+    return replace(
+        run,
+        status="failed",
+        error_message=error_message,
+        completed_at=completed_at,
+    )
 
 
 @router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
@@ -1131,9 +1094,9 @@ def get_eval_run(
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
+    # _check_zombie returns the (possibly mutated) run so we avoid an
+    # extra SELECT after the optional UPDATE.
+    run = _check_zombie(conn, run)
     return _run_to_response(run)
 
 
@@ -1152,8 +1115,11 @@ def get_eval_run_logs(
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
 
-    # Zombie detection on read
-    effective_status = _check_zombie(conn, run)
+    # Zombie detection on read.  ``_check_zombie`` returns the run with
+    # status flipped to ``failed`` in memory if its heartbeat was stale,
+    # so we use the returned object rather than re-reading from the DB.
+    run = _check_zombie(conn, run)
+    effective_status = run.status
 
     # Fetch all S3 chunks for the run. The cursor is an event sequence number
     # (e.g. 50), not a chunk file sequence number (e.g. 3), so we can't use

--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -17,9 +17,9 @@ from sqlalchemy.engine import Connection
 
 # Re-export pipeline functions for backward compatibility.
 # Scripts (backfills, crawler), tests, and modal_app may import these
-# from ``decision_hub.api.registry_service``.
-# Re-export private helpers used by test patches.
-from decision_hub.domain.publish_pipeline import (  # noqa: F401  # noqa: F401
+# from ``decision_hub.api.registry_service``.  Private helpers
+# (``_build_*``) are re-exported so existing test patches keep working.
+from decision_hub.domain.publish_pipeline import (  # noqa: F401
     _build_analyze_fn,
     _build_analyze_prompt_fn,
     _build_review_body_fn,
@@ -93,9 +93,16 @@ def run_assessment_background(
     from decision_hub.infra.database import create_engine, get_api_keys_for_eval
     from decision_hub.infra.modal_client import get_agent_config, validate_api_key
 
+    # One engine for the entire task lifecycle, success or failure.  The
+    # previous implementation created up to three separate engines per
+    # invocation (success path + two error handlers) which thrashed the
+    # connection pool and never disposed them.  ``engine.dispose()`` in
+    # the ``finally`` block returns connections cleanly even when the
+    # Modal container is reused for another assessment.
+    engine = create_engine(settings.database_url)
+
     try:
         logger.info("Assessment phase 1: loading API keys for {}/{}", org_slug, skill_name)
-        engine = create_engine(settings.database_url)
 
         # --- Phase 1: read API keys then release the connection ---
         # Retrieve the publishing user's own API keys for the assessment
@@ -214,16 +221,16 @@ def run_assessment_background(
     except Exception as e:
         logger.error("Agent assessment failed for version {}: {}", version_id, e)
 
-        # Update run row if using streaming pipeline
+        # Update run row if using streaming pipeline.  Reuses the same
+        # engine that the success path uses -- previously this opened a
+        # second engine, and the report insert opened a third.
         if run_id is not None:
             try:
                 from datetime import datetime
 
-                from decision_hub.infra.database import create_engine as _ce
                 from decision_hub.infra.database import update_eval_run_status
 
-                err_engine = _ce(settings.database_url)
-                with err_engine.connect() as err_conn:
+                with engine.connect() as err_conn:
                     update_eval_run_status(
                         err_conn,
                         run_id,
@@ -235,13 +242,11 @@ def run_assessment_background(
             except Exception as inner:
                 logger.error("Failed to update run {}: {}", run_id, inner)
 
-        # INSERT an error report
+        # INSERT an error report (also reuses the success-path engine).
         try:
-            from decision_hub.infra.database import create_engine as _create_engine
             from decision_hub.infra.database import insert_eval_report
 
-            err_engine = _create_engine(settings.database_url)
-            with err_engine.connect() as err_conn:
+            with engine.connect() as err_conn:
                 insert_eval_report(
                     err_conn,
                     version_id=version_id,
@@ -261,3 +266,9 @@ def run_assessment_background(
                 version_id,
                 inner,
             )
+
+    finally:
+        # Return pooled connections so the next eval in this container
+        # starts with a clean pool.  Modal may reuse a container across
+        # invocations of the eval task.
+        engine.dispose()

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -31,14 +31,14 @@ router = APIRouter(prefix="/v1", tags=["search"])
 
 def _enforce_search_rate_limit(request: Request) -> None:
     """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        name="search",
+        max_requests=settings.search_rate_limit,
+        window_seconds=settings.search_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -91,26 +91,28 @@ class TestGetEvalRun:
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
-        """A running eval with a heartbeat >5 min stale is marked failed."""
+        """A running eval with a heartbeat >5 min stale is marked failed.
+
+        Also asserts ``find_eval_run`` is called exactly once -- the
+        previous implementation re-read the row after the zombie
+        UPDATE; ``_check_zombie`` now mirrors the update in memory and
+        the route returns the mutated object directly.
+        """
         stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
-
-        # find_eval_run is called twice: once before zombie check, once after
-        failed_run = _make_eval_run(
-            id=run.id,
-            status="failed",
-            error_message="Stale heartbeat",
-            heartbeat_at=stale_heartbeat,
-        )
-        mock_find_run.side_effect = [run, failed_run]
+        mock_find_run.return_value = run
 
         resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "failed"
+        # Regression guard: the zombie path must not trigger a second
+        # SELECT against eval_runs on a read endpoint.
+        assert mock_find_run.call_count == 1
         mock_update_status.assert_called_once()
         call_kwargs = mock_update_status.call_args
         assert call_kwargs.kwargs.get("status") == "failed"
+        assert "Stale heartbeat" in (call_kwargs.kwargs.get("error_message") or "")
 
     @patch("decision_hub.api.registry_routes.update_eval_run_status")
     @patch("decision_hub.api.registry_routes.find_eval_run")
@@ -407,6 +409,9 @@ class TestGetEvalRunLogs:
         assert resp.status_code == 200
         assert resp.json()["run_status"] == "failed"
         mock_update_status.assert_called_once()
+        # Regression guard: log fetch must not re-read the run row
+        # after the zombie UPDATE.
+        assert mock_find_run.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, get_or_create_limiter
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -13,6 +14,19 @@ def _make_request(host: str = "127.0.0.1") -> MagicMock:
     request = MagicMock()
     request.client.host = host
     return request
+
+
+class _FakeClock:
+    """Deterministic clock for limiter purge / window tests."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, delta: float) -> None:
+        self.t += delta
 
 
 class TestRateLimiter:
@@ -84,3 +98,72 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestRateLimiterPurge:
+    """The limiter must trim stale IPs so memory stays bounded.
+
+    Regression coverage for the previous ``total % 100 == 0`` purge
+    heuristic, which never fired on traffic shapes that didn't hit an
+    exact multiple of 100 active timestamps.
+    """
+
+    def test_stale_ips_are_purged_after_window(self) -> None:
+        """IPs with no recent activity should be dropped from the table."""
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=5, window_seconds=10, clock=clock)
+
+        # 50 distinct IPs each issue one request.
+        for i in range(50):
+            limiter(_make_request(f"10.0.0.{i}"))
+        assert len(limiter._requests) == 50
+
+        # Advance past the window plus the half-window purge cadence,
+        # then issue a single request from a new IP -- that call should
+        # also trigger the purge sweep and drop every now-stale entry.
+        clock.advance(16)
+        limiter(_make_request("192.168.0.1"))
+        assert len(limiter._requests) == 1
+        assert "192.168.0.1" in limiter._requests
+
+    def test_active_ips_are_not_purged(self) -> None:
+        """IPs that issued a request inside the window survive a purge."""
+        clock = _FakeClock()
+        limiter = RateLimiter(max_requests=5, window_seconds=10, clock=clock)
+
+        limiter(_make_request("active"))
+        # Half a window later -- still inside the window, still active.
+        clock.advance(5)
+        limiter(_make_request("active"))
+        # Cross the purge threshold; a new IP triggers the sweep.
+        clock.advance(6)
+        limiter(_make_request("trigger"))
+        assert "active" in limiter._requests
+
+
+class TestGetOrCreateLimiter:
+    """The factory must lazily attach one limiter per name to app.state."""
+
+    def test_returns_same_instance_for_same_name(self) -> None:
+        state = SimpleNamespace()
+        a = get_or_create_limiter(state, name="search", max_requests=10, window_seconds=60)
+        b = get_or_create_limiter(state, name="search", max_requests=10, window_seconds=60)
+        assert a is b
+
+    def test_distinct_names_get_distinct_limiters(self) -> None:
+        state = SimpleNamespace()
+        a = get_or_create_limiter(state, name="search", max_requests=10, window_seconds=60)
+        b = get_or_create_limiter(state, name="publish", max_requests=10, window_seconds=60)
+        assert a is not b
+
+    def test_subsequent_calls_ignore_changed_parameters(self) -> None:
+        """The first call wins -- limiter parameters are not hot-reloaded.
+
+        That matches the previous per-route ``hasattr`` behaviour and
+        makes settings stable for the container lifetime.
+        """
+        state = SimpleNamespace()
+        first = get_or_create_limiter(state, name="x", max_requests=5, window_seconds=60)
+        second = get_or_create_limiter(state, name="x", max_requests=999, window_seconds=999)
+        assert first is second
+        assert second.max_requests == 5

--- a/server/tests/test_domain/test_registry_service_evals.py
+++ b/server/tests/test_domain/test_registry_service_evals.py
@@ -215,3 +215,65 @@ class TestMaybeTriggerAgentAssessment:
             "prompt": "Do something",
             "judge_criteria": "PASS: works\nFAIL: breaks",
         }
+
+
+class TestRunAssessmentBackgroundEngineReuse:
+    """``run_assessment_background`` must reuse one SQLAlchemy engine.
+
+    The previous implementation created a new engine on the success
+    path and a separate one for *each* error-handler branch (run-status
+    update + error-report insert), producing up to three engines per
+    invocation.  Modal can keep containers warm across multiple eval
+    tasks, so engine churn -- and missing ``dispose()`` calls -- meant
+    the connection pool drifted with every failure.
+    """
+
+    def test_failure_path_reuses_single_engine_and_disposes(self) -> None:
+        from decision_hub.api.registry_service import run_assessment_background
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_engine.connect.return_value = mock_conn
+
+        # ``run_assessment_background`` imports ``create_engine`` and
+        # ``get_api_keys_for_eval`` lazily from ``infra.database``; we
+        # patch at the source module.  Forcing the API-key lookup to
+        # raise exits through the error path that previously created
+        # two additional engines (one for the run-status update, one
+        # for the error-report insert).
+        with (
+            patch(
+                "decision_hub.infra.database.create_engine",
+                return_value=mock_engine,
+            ) as mock_create_engine,
+            patch(
+                "decision_hub.infra.database.get_api_keys_for_eval",
+                side_effect=RuntimeError("simulated DB failure"),
+            ),
+            patch(
+                "decision_hub.infra.modal_client.get_agent_config",
+                return_value=MagicMock(key_env_var="ANTHROPIC_API_KEY"),
+            ),
+            patch("decision_hub.infra.database.update_eval_run_status"),
+            patch("decision_hub.infra.database.insert_eval_report"),
+        ):
+            run_assessment_background(
+                version_id=uuid4(),
+                assessment_config=_make_eval_config(),
+                assessment_cases=_make_eval_cases(1),
+                skill_zip=b"",
+                org_slug="org",
+                skill_name="skill",
+                settings=_make_settings(),
+                user_id=uuid4(),
+                run_id=uuid4(),
+            )
+
+            # One engine for the whole invocation -- success path + both
+            # error-handler branches reuse it.
+            assert mock_create_engine.call_count == 1
+            # ``finally`` must dispose the pool so a reused Modal container
+            # starts the next eval with a clean slate.
+            mock_engine.dispose.assert_called_once()


### PR DESCRIPTION
## Summary

Surgical cleanups uncovered by a principal-engineer-level review of the server. Every change is paired with a regression test. No public API or schema changes, no DB migrations.

**Tests**: server 939/0 (`-m "not slow"`), client 291/0 (29 skipped), shared 98/0, ruff clean, mypy clean on changed files.

```
 server/src/decision_hub/api/auth_routes.py        |  18 +-
 server/src/decision_hub/api/rate_limit.py         | 115 +++++++++++---
 server/src/decision_hub/api/registry_routes.py    | 164 +++++++--------------
 server/src/decision_hub/api/registry_service.py   |  35 +++--
 server/src/decision_hub/api/search_routes.py      |  18 +-
 server/tests/test_api/test_eval_logs.py           |  25 ++-
 server/tests/test_api/test_rate_limit.py          |  85 +++++++++-
 server/tests/test_domain/test_registry_service_evals.py | 62 ++++++++
 8 files changed, 360 insertions(+), 162 deletions(-)
```

## What changed

### 1. `RateLimiter` — performance, memory, and a factory (`api/rate_limit.py`)

**Data structure (perf).** Per-IP timestamps move from `list` → `collections.deque`. Pruning is now `popleft()` while the front is expired (O(k-expired)). The previous list-comprehension rebuilt the whole timestamp list on **every** request — O(n) per call where n = requests-in-window.

**Purge cadence (memory + correctness).** Dropped this:
```python
total = sum(len(v) for v in self._requests.values())   # O(N-ips) on every request
if total % 100 == 0:
    self._purge_stale(cutoff)
```
- Fires immediately on cold start (`total=0`) — purges before any IPs exist.
- Under traffic shapes that never hit an exact multiple of 100, can fail to fire for hours, leaking memory.
- Pays O(N-ips) on every call.

Replaced with a time-driven sweep at half-window cadence — single `now >= self._next_purge_at` comparison.

**Factory.** Added `get_or_create_limiter(state, name, max_requests, window_seconds)` and collapsed 9 near-identical 12-line `_enforce_*_rate_limit` blocks in `registry_routes.py`, `search_routes.py`, and `auth_routes.py` into one shared factory (in `registry_routes.py` via a tiny `_rate_limit_dep(name, limit_attr, window_attr)` builder; the other two route files call the factory directly).

**Testability.** Optional `clock: Callable[[], float] | None` parameter. The default falls through to `time.monotonic` at call time so the existing `patch("decision_hub.api.rate_limit.time")` pattern in `test_rate_limit.py` keeps working unchanged; new tests use the injected clock instead.

### 2. Eliminate redundant DB read on eval-run zombie path (`api/registry_routes.py`)

`_check_zombie` previously updated `eval_runs` and the caller re-read the row:
```python
_check_zombie(conn, run)
# Re-read after potential zombie update
run = find_eval_run(conn, parsed_id)
```

The function now returns the run with the new status mirrored in memory via `dataclasses.replace`, so every `GET /v1/eval-runs/{id}` and `GET /v1/eval-runs/{id}/logs` issues **one SELECT** on the zombie path instead of two. Test asserts `mock_find_run.call_count == 1`.

### 3. Reuse one SQLAlchemy engine in `run_assessment_background` (`api/registry_service.py`)

The background task created a fresh `Engine` on the success path and **a separate engine in each of the two error-handler branches** (run-status update + error-report insert). Up to 3 engines per invocation, none disposed. Modal keeps containers warm across eval tasks, so this churned the connection pool every failure.

Now one engine at the top, reused in all paths, `engine.dispose()` in `finally`. Test asserts `create_engine` is called exactly once on the failure path and `dispose()` runs.

Also fixed `# noqa: F401  # noqa: F401` typo (duplicate directive on the same line).

## Tests added

- `TestRateLimiterPurge::test_stale_ips_are_purged_after_window` — 50 distinct IPs evicted after window + purge cadence.
- `TestRateLimiterPurge::test_active_ips_are_not_purged` — IPs with recent activity survive.
- `TestGetOrCreateLimiter` — same name returns same instance, distinct names get distinct limiters, parameters from the first call win (preserves the existing `hasattr`-style behaviour).
- `TestRunAssessmentBackgroundEngineReuse::test_failure_path_reuses_single_engine_and_disposes`.
- Tightened existing zombie tests in `test_eval_logs.py` to assert exactly one `find_eval_run` call.

## Why not more in this PR

The review surfaced ~15 high-leverage items. I deliberately kept this PR small and reversible — items that need wider thought (transactional publish pipeline, splitting `database.py` and CLI `registry.py`, centralised visibility filter, JWT lifetime / revocation, distributed rate-limit store) are described in the review but left for follow-ups so each can be reviewed on its own.

## Test plan

- [x] `make test-server` (`pytest -m "not slow"`) → 939 passed
- [x] `make test-client` → 291 passed, 29 skipped
- [x] `make test-shared` → 98 passed
- [x] `uvx ruff@0.15.3 check server/` → clean
- [x] `uvx ruff@0.15.3 format --check server/` → clean
- [x] `uvx mypy` on the 5 changed source files → clean
- [ ] Manual: deploy to dev, exercise `/v1/eval-runs/{id}` and rate-limited public endpoints

https://claude.ai/code/session_01NxF4SzEML6axbNqEYv14zB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxF4SzEML6axbNqEYv14zB)_