### PR TITLE
refactor: DRY rate-limit wiring + fix eval-log crash, git-clone hang, list-eval-runs N+1

### DIFF
--- a/client/src/dhub/core/git_repo.py
+++ b/client/src/dhub/core/git_repo.py
@@ -13,6 +13,32 @@ from pathlib import Path
 _GIT_URL_PREFIXES = ("https://", "http://", "git@", "ssh://", "git://")
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
 
+# Hard ceiling for git clone/checkout so an unreachable or hung remote
+# can't lock the CLI forever. Five minutes comfortably covers cold clones
+# of large repos on slow networks while still failing within the user's
+# patience window.
+_GIT_TIMEOUT_SECONDS = 300
+
+
+def _run_git(cmd: list[str], cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run a git subprocess with a bounded timeout.
+
+    Returns the completed process on success or timeout-converted to a
+    ``RuntimeError`` so callers can surface a clean message instead of
+    hanging forever. Stdout/stderr are captured so secrets the user may
+    have set on the URL never end up on the user's terminal.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"git command timed out after {_GIT_TIMEOUT_SECONDS}s: {' '.join(cmd[:2])} ...") from exc
+
 
 def git_url_to_https(url: str) -> str | None:
     """Convert a git-cloneable URL to an HTTPS browse URL.
@@ -66,32 +92,29 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Path:
     tmp_dir = Path(tempfile.mkdtemp(prefix="dhub-repo-"))
     repo_path = tmp_dir / "repo"
 
-    if ref and _looks_like_sha(ref):
-        # Commit SHAs don't work with --depth 1 --branch; do a full
-        # clone then checkout the specific commit.
-        cmd = ["git", "clone", repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
-        checkout = subprocess.run(
-            ["git", "checkout", ref],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
-        if checkout.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
-    else:
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd += ["--branch", ref]
-        cmd += [repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    try:
+        if ref and _looks_like_sha(ref):
+            # Commit SHAs don't work with --depth 1 --branch; do a full
+            # clone then checkout the specific commit.
+            result = _run_git(["git", "clone", repo_url, str(repo_path)])
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+            checkout = _run_git(["git", "checkout", ref], cwd=str(repo_path))
+            if checkout.returncode != 0:
+                raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
+        else:
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd += ["--branch", ref]
+            cmd += [repo_url, str(repo_path)]
+            result = _run_git(cmd)
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    except Exception:
+        # Any failure leaves no usable checkout, so clean the tempdir to
+        # avoid leaking partial clones into /tmp.
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return repo_path
 

--- a/client/tests/test_core/test_git_repo.py
+++ b/client/tests/test_core/test_git_repo.py
@@ -1,8 +1,12 @@
 """Tests for dhub.core.git_repo -- clone and skill discovery."""
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from dhub.core.git_repo import discover_skills
+import pytest
+
+from dhub.core.git_repo import _GIT_TIMEOUT_SECONDS, _run_git, clone_repo, discover_skills
 
 
 class TestDiscoverSkills:
@@ -73,3 +77,52 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         names = [p.name for p in result]
         assert names == sorted(names)
+
+
+class TestRunGitTimeout:
+    """Hung git remotes must not hang the CLI forever."""
+
+    def test_run_git_passes_timeout_to_subprocess(self) -> None:
+        """_run_git forwards the module timeout to subprocess.run."""
+        with patch("dhub.core.git_repo.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "--version"], returncode=0, stdout="", stderr=""
+            )
+
+            _run_git(["git", "--version"])
+
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["timeout"] == _GIT_TIMEOUT_SECONDS
+            assert kwargs["capture_output"] is True
+            assert kwargs["text"] is True
+
+    def test_run_git_converts_timeout_to_runtime_error(self) -> None:
+        """A subprocess timeout becomes a RuntimeError with a clean message."""
+        with patch("dhub.core.git_repo.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "clone"], timeout=_GIT_TIMEOUT_SECONDS)
+
+            with pytest.raises(RuntimeError, match="timed out"):
+                _run_git(["git", "clone", "https://example.invalid/repo.git"])
+
+    def test_clone_repo_cleans_tmpdir_on_timeout(self, tmp_path: Path) -> None:
+        """A timed-out clone deletes its temp dir instead of leaving a partial clone."""
+        created_paths: list[Path] = []
+
+        original_mkdtemp = __import__("tempfile").mkdtemp
+
+        def tracking_mkdtemp(*args, **kwargs):
+            path = original_mkdtemp(*args, **kwargs)
+            created_paths.append(Path(path))
+            return path
+
+        with (
+            patch("dhub.core.git_repo.tempfile.mkdtemp", side_effect=tracking_mkdtemp),
+            patch("dhub.core.git_repo.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "clone"], timeout=_GIT_TIMEOUT_SECONDS)
+
+            with pytest.raises(RuntimeError):
+                clone_repo("https://example.invalid/repo.git")
+
+        assert created_paths, "expected tempfile.mkdtemp to be called"
+        assert not created_paths[0].exists()

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,11 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limit_dependency(
+    "auth",
+    max_requests_setting="auth_rate_limit",
+    window_seconds_setting="auth_rate_window",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,6 +3,7 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -63,3 +64,52 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limit_dependency(
+    name: str,
+    *,
+    max_requests_setting: str,
+    window_seconds_setting: str,
+) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that lazily creates a per-app ``RateLimiter``.
+
+    Previously each route declared its own ``_enforce_*_rate_limit`` wrapper
+    -- nine near-identical copies across registry, search, and auth routes.
+    This factory collapses that boilerplate. The limiter is cached on
+    ``app.state`` under ``_<name>_rate_limiter`` so it is built once per
+    container, and its limits are read from settings by attribute name so
+    each route keeps its independent budget.
+
+    Args:
+        name: Used as the limiter's identifier and the attribute key on
+            ``app.state``. Pick the same short label the route is named for
+            (e.g. ``"publish"``, ``"download"``, ``"auth"``).
+        max_requests_setting: Name of the Settings attribute holding the
+            request budget (e.g. ``"publish_rate_limit"``).
+        window_seconds_setting: Name of the Settings attribute holding the
+            window length in seconds (e.g. ``"publish_rate_window"``).
+
+    Returns:
+        A callable suitable for use with ``Depends(...)``. Calling it with
+        a ``Request`` records the hit and raises HTTP 429 when over budget.
+    """
+    state_attr = f"_{name}_rate_limiter"
+
+    def _dependency(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, state_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, max_requests_setting),
+                window_seconds=getattr(settings, window_seconds_setting),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    # Give the closure a stable, debuggable name in stack traces and
+    # OpenAPI dependency lists.
+    _dependency.__name__ = f"enforce_{name}_rate_limit"
+    _dependency.__qualname__ = _dependency.__name__
+    return _dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -3,10 +3,11 @@
 import json
 import math
 import zipfile
+from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +20,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -45,7 +46,7 @@ from decision_hub.infra.database import (
     find_audit_logs,
     find_eval_report_by_skill,
     find_eval_run,
-    find_eval_runs_for_version,
+    find_eval_runs_for_version_and_user,
     find_latest_scan_report_for_skill,
     find_org_by_slug,
     find_scan_findings_for_report,
@@ -83,88 +84,45 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate-limit dependencies for each public endpoint. The factory builds a
+# closure that lazily instantiates a RateLimiter on app.state the first time
+# it runs, so we keep per-endpoint budgets without repeating the same six
+# lines of init code seven times.
+_enforce_list_skills_rate_limit = make_rate_limit_dependency(
+    "list_skills",
+    max_requests_setting="list_skills_rate_limit",
+    window_seconds_setting="list_skills_rate_window",
+)
+_enforce_resolve_rate_limit = make_rate_limit_dependency(
+    "resolve",
+    max_requests_setting="resolve_rate_limit",
+    window_seconds_setting="resolve_rate_window",
+)
+_enforce_similar_skills_rate_limit = make_rate_limit_dependency(
+    "similar_skills",
+    max_requests_setting="similar_skills_rate_limit",
+    window_seconds_setting="similar_skills_rate_window",
+)
+_enforce_download_rate_limit = make_rate_limit_dependency(
+    "download",
+    max_requests_setting="download_rate_limit",
+    window_seconds_setting="download_rate_window",
+)
+_enforce_audit_log_rate_limit = make_rate_limit_dependency(
+    "audit_log",
+    max_requests_setting="audit_log_rate_limit",
+    window_seconds_setting="audit_log_rate_window",
+)
+_enforce_scan_report_rate_limit = make_rate_limit_dependency(
+    "scan_report",
+    max_requests_setting="scan_report_rate_limit",
+    window_seconds_setting="scan_report_rate_window",
+)
+_enforce_publish_rate_limit = make_rate_limit_dependency(
+    "publish",
+    max_requests_setting="publish_rate_limit",
+    window_seconds_setting="publish_rate_window",
+)
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -1097,27 +1055,39 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
-    """Check if a running eval run has a stale heartbeat (zombie).
+def _check_zombie(conn: Connection, run):
+    """Mark a stale-heartbeat run as failed and return the (possibly updated) run.
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    If the run is in a non-terminal state and its heartbeat is older than
+    ``_STALE_HEARTBEAT_SECONDS``, the DB row is updated to ``failed`` and a
+    copy of the run is returned with those fields applied. Otherwise the
+    original run is returned unchanged. Returning the updated run lets
+    callers avoid a redundant ``find_eval_run`` round-trip.
     """
     if run.status not in ("running", "judging", "provisioning"):
-        return run.status
+        return run
     if run.heartbeat_at is None:
-        return run.status
+        return run
     elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
-    if elapsed > _STALE_HEARTBEAT_SECONDS:
-        update_eval_run_status(
-            conn,
-            run.id,
-            status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
-            completed_at=datetime.now(UTC),
-        )
-        return "failed"
-    return run.status
+    if elapsed <= _STALE_HEARTBEAT_SECONDS:
+        return run
+    error_message = f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed."
+    completed_at = datetime.now(UTC)
+    update_eval_run_status(
+        conn,
+        run.id,
+        status="failed",
+        error_message=error_message,
+        completed_at=completed_at,
+    )
+    # dataclasses.replace preserves frozen-instance semantics; EvalRun is
+    # a frozen dataclass and is otherwise read-only.
+    return replace(
+        run,
+        status="failed",
+        error_message=error_message,
+        completed_at=completed_at,
+    )
 
 
 @router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
@@ -1131,9 +1101,7 @@ def get_eval_run(
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
+    run = _check_zombie(conn, run)
     return _run_to_response(run)
 
 
@@ -1152,8 +1120,10 @@ def get_eval_run_logs(
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
 
-    # Zombie detection on read
-    effective_status = _check_zombie(conn, run)
+    # Zombie detection on read — use the returned run so subsequent fields
+    # (run_status, error_message) reflect the post-update state.
+    run = _check_zombie(conn, run)
+    effective_status = run.status
 
     # Fetch all S3 chunks for the run. The cursor is an event sequence number
     # (e.g. 50), not a chunk file sequence number (e.g. 3), so we can't use
@@ -1165,19 +1135,26 @@ def get_eval_run_logs(
         after_seq=0,
     )
 
-    # Read and parse events from each chunk, filtering by cursor
+    # Read and parse events from each chunk, filtering by cursor. Skip
+    # malformed lines (truncated writes, partial S3 multi-part uploads) so a
+    # single bad log chunk can't return HTTP 500 and break the live tail.
     all_events: list[dict] = []
     max_seq = cursor
     for _chunk_seq, s3_key in chunks:
         content = read_eval_log_chunk(s3_client, settings.s3_bucket, s3_key)
         for line in content.strip().split("\n"):
-            if line.strip():
+            if not line.strip():
+                continue
+            try:
                 event = json.loads(line)
-                event_seq = event.get("seq", 0)
-                if event_seq > cursor:
-                    all_events.append(event)
-                if event_seq > max_seq:
-                    max_seq = event_seq
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed eval-log line in {}", s3_key)
+                continue
+            event_seq = event.get("seq", 0)
+            if event_seq > cursor:
+                all_events.append(event)
+            if event_seq > max_seq:
+                max_seq = event_seq
 
     return EvalRunLogsResponse(
         events=all_events,
@@ -1194,11 +1171,14 @@ def list_eval_runs(
     conn: Connection = Depends(get_connection),
     current_user: User = Depends(get_current_user),
 ) -> list[EvalRunResponse]:
-    """List eval runs, optionally filtered by version ID."""
+    """List eval runs, optionally filtered by version ID.
+
+    Always scoped to the current user — version_id is a filter, not an
+    authorisation boundary.
+    """
     if version_id is not None:
         parsed_vid = _parse_uuid(version_id, "version_id")
-        runs = find_eval_runs_for_version(conn, parsed_vid)
-        runs = [r for r in runs if r.user_id == current_user.id]
+        runs = find_eval_runs_for_version_and_user(conn, parsed_vid, current_user.id)
     else:
         runs = find_active_eval_runs_for_user(conn, current_user.id)
     return [_run_to_response(r) for r in runs]

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,11 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limit_dependency(
+    "search",
+    max_requests_setting="search_rate_limit",
+    window_seconds_setting="search_rate_window",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2708,12 +2708,23 @@ def find_eval_run(conn: Connection, run_id: UUID) -> EvalRun | None:
     return _row_to_eval_run(row)
 
 
-def find_eval_runs_for_version(conn: Connection, version_id: UUID) -> list[EvalRun]:
-    """List all eval runs for a version, newest first."""
+def find_eval_runs_for_version_and_user(conn: Connection, version_id: UUID, user_id: UUID) -> list[EvalRun]:
+    """List a single user's eval runs for a version, newest first.
+
+    Pushes the user-id filter into the WHERE clause so the API layer no
+    longer fetches every run for the version and then filters in Python.
+    Eval runs for shared/team versions can accumulate quickly; the previous
+    approach was O(total_runs) per request even when the caller only owned
+    a handful. With this query the DB does the filter (and uses the
+    eval_runs(user_id) index where present).
+    """
     stmt = (
         sa.select(eval_runs_table)
-        .where(eval_runs_table.c.version_id == version_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        .where(
+            eval_runs_table.c.version_id == version_id,
+            eval_runs_table.c.user_id == user_id,
+        )
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
     )
     rows = conn.execute(stmt).all()
     return [_row_to_eval_run(row) for row in rows]

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -95,19 +95,15 @@ class TestGetEvalRun:
         stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
 
-        # find_eval_run is called twice: once before zombie check, once after
-        failed_run = _make_eval_run(
-            id=run.id,
-            status="failed",
-            error_message="Stale heartbeat",
-            heartbeat_at=stale_heartbeat,
-        )
-        mock_find_run.side_effect = [run, failed_run]
+        # _check_zombie now applies the failure fields locally via
+        # dataclasses.replace, so the endpoint only calls find_eval_run once.
+        mock_find_run.return_value = run
 
         resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "failed"
+        assert mock_find_run.call_count == 1
         mock_update_status.assert_called_once()
         call_kwargs = mock_update_status.call_args
         assert call_kwargs.kwargs.get("status") == "failed"
@@ -382,6 +378,44 @@ class TestGetEvalRunLogs:
 
         assert resp.status_code == 404
 
+    @patch("decision_hub.api.registry_routes.read_eval_log_chunk")
+    @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_malformed_lines_are_skipped(
+        self,
+        mock_find_run: MagicMock,
+        mock_list_chunks: MagicMock,
+        mock_read_chunk: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A corrupted line in an S3 chunk must not 500 the live tail.
+
+        Eval workers append JSON lines to S3; a partial flush or truncated
+        multi-part write can leave one broken line surrounded by valid
+        events. Before the fix, ``json.loads`` would raise inside the route
+        handler and the entire poll returned HTTP 500 -- the UI saw the run
+        as dead until the next chunk shifted past the bad line. After the
+        fix the bad line is dropped and surrounding events are streamed.
+        """
+        run = _make_eval_run()
+        mock_find_run.return_value = run
+        mock_list_chunks.return_value = [(1, "eval-logs/test-run/0001.jsonl")]
+        mock_read_chunk.return_value = (
+            '{"seq":1,"type":"setup","content":"init"}\n{not valid json\n{"seq":2,"type":"log","content":"hello"}\n'
+        )
+
+        resp = client.get(
+            f"/v1/eval-runs/{run.id}/logs?cursor=0",
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        event_seqs = [e["seq"] for e in data["events"]]
+        assert event_seqs == [1, 2]
+        assert data["next_cursor"] == 2
+
     @patch("decision_hub.api.registry_routes.update_eval_run_status")
     @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
     @patch("decision_hub.api.registry_routes.find_eval_run")
@@ -434,7 +468,7 @@ class TestListEvalRuns:
         assert len(data) == 1
         assert data[0]["id"] == str(run.id)
 
-    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version")
+    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version_and_user")
     def test_list_runs_by_version_id(
         self,
         mock_find_runs: MagicMock,
@@ -454,6 +488,11 @@ class TestListEvalRuns:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["version_id"] == str(version_id)
+        # The route passes the authenticated user's id straight to the DB
+        # function so visibility is enforced server-side.
+        args = mock_find_runs.call_args.args
+        assert args[1] == version_id
+        assert args[2] == SAMPLE_USER_ID
 
     @patch("decision_hub.api.registry_routes.find_active_eval_runs_for_user")
     def test_list_runs_empty(
@@ -469,18 +508,24 @@ class TestListEvalRuns:
         assert resp.status_code == 200
         assert resp.json() == []
 
-    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version")
+    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version_and_user")
     def test_list_by_version_filters_to_current_user(
         self,
         mock_find_runs: MagicMock,
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
-        """When filtering by version_id, only the current user's runs are returned."""
+        """When filtering by version_id, only the current user's runs come back.
+
+        The user filter is enforced inside the SQL query, so the mocked DB
+        function should already receive ``current_user.id`` and return only
+        the caller's rows. Previously the route fetched every row for the
+        version and then filtered in Python -- this regression test pins the
+        invariant that the DB function is what does the filtering.
+        """
         version_id = uuid4()
         own_run = _make_eval_run(version_id=version_id, user_id=SAMPLE_USER_ID)
-        other_run = _make_eval_run(version_id=version_id, user_id=uuid4())
-        mock_find_runs.return_value = [own_run, other_run]
+        mock_find_runs.return_value = [own_run]
 
         resp = client.get(
             f"/v1/eval-runs?version_id={version_id}",
@@ -491,6 +536,7 @@ class TestListEvalRuns:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["id"] == str(own_run.id)
+        assert mock_find_runs.call_args.args[2] == SAMPLE_USER_ID
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limit_dependency
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,63 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+def _make_state_request(state: SimpleNamespace, host: str = "10.0.0.1") -> MagicMock:
+    """Mock a Request whose ``app.state`` is the given SimpleNamespace."""
+    request = MagicMock()
+    request.client.host = host
+    request.app.state = state
+    return request
+
+
+class TestMakeRateLimitDependency:
+    """Unit tests for the FastAPI-dependency factory."""
+
+    def test_caches_limiter_on_app_state(self) -> None:
+        """First call creates a RateLimiter on state; subsequent calls reuse it."""
+        settings = SimpleNamespace(my_rate_limit=5, my_rate_window=60)
+        state = SimpleNamespace(settings=settings)
+        dep = make_rate_limit_dependency(
+            "my",
+            max_requests_setting="my_rate_limit",
+            window_seconds_setting="my_rate_window",
+        )
+
+        dep(_make_state_request(state))
+        first_limiter = state._my_rate_limiter
+        dep(_make_state_request(state))
+        assert state._my_rate_limiter is first_limiter
+
+    def test_reads_bounds_from_named_settings(self) -> None:
+        """The factory binds to the named settings attributes, not magic globals."""
+        settings = SimpleNamespace(foo_limit=2, foo_window=60)
+        state = SimpleNamespace(settings=settings)
+        dep = make_rate_limit_dependency(
+            "foo",
+            max_requests_setting="foo_limit",
+            window_seconds_setting="foo_window",
+        )
+
+        # First 2 succeed, third must 429.
+        dep(_make_state_request(state))
+        dep(_make_state_request(state))
+        with pytest.raises(HTTPException) as exc_info:
+            dep(_make_state_request(state))
+        assert exc_info.value.status_code == 429
+
+    def test_independent_dependencies_have_independent_buckets(self) -> None:
+        """Two dependencies on the same app state must not share a budget."""
+        settings = SimpleNamespace(a_limit=1, a_window=60, b_limit=1, b_window=60)
+        state = SimpleNamespace(settings=settings)
+        dep_a = make_rate_limit_dependency("a", max_requests_setting="a_limit", window_seconds_setting="a_window")
+        dep_b = make_rate_limit_dependency("b", max_requests_setting="b_limit", window_seconds_setting="b_window")
+
+        dep_a(_make_state_request(state))
+        # Hitting dep_b a single time must not blow A's already-spent budget.
+        dep_b(_make_state_request(state))
+
+    def test_debuggable_callable_name(self) -> None:
+        """The closure has a human-readable name for tracebacks and OpenAPI."""
+        dep = make_rate_limit_dependency("things", max_requests_setting="x", window_seconds_setting="y")
+        assert dep.__name__ == "enforce_things_rate_limit"


### PR DESCRIPTION
A targeted hygiene pass surfaced by a deep code review of the server and client. Each item is independently verifiable; together they remove ~140 lines of copy-paste and close five concrete failure modes — without touching schemas, deploy config, or any cross-package contracts.

## Why these five?

The review identified ~30 candidate findings; this PR ships the highest-confidence subset that is **bounded-risk** (no migrations, no LLM/infra rewrites, no large-file splits). The bigger architectural moves — splitting `database.py` (3.4k LOC) and `cli/registry.py` (1.9k LOC), adding boto3/Anthropic retry configs, and a frontend hook-test push — are noted as follow-ups but deserve dedicated PRs.

## Changes

### Code health — DRY rate-limit wiring
`api/rate_limit.py::make_rate_limit_dependency` collapses **nine near-identical `_enforce_*_rate_limit` wrappers** across `registry_routes.py`, `search_routes.py`, and `auth_routes.py` into a single factory. Each route now declares its limiter as a one-liner that names the matching settings attributes; per-app caching, per-endpoint budgets, and the existing `app.state` attribute layout are all preserved so call sites and tests keep working.

```python
_enforce_publish_rate_limit = make_rate_limit_dependency(
    "publish",
    max_requests_setting="publish_rate_limit",
    window_seconds_setting="publish_rate_window",
)
```

### Correctness — eval-log streaming no longer 500s on a corrupted line
`get_eval_run_logs` parsed every JSON line in an S3 chunk without guarding `json.loads`. A truncated/partial S3 write surfaced as HTTP 500 and froze the live-tail in the UI until the next chunk rolled past the bad line. Malformed lines are now skipped with a warning and surrounding events stream normally. New regression test pins the behaviour.

### Correctness — git clone/checkout now have a 5-minute timeout
`dhub.core.git_repo` called `subprocess.run` with no `timeout=`, so an unreachable or hung remote would lock `dhub publish` forever. All three call sites go through a new `_run_git` helper that bounds the call and raises a clean `RuntimeError` on timeout. The temp clone directory is removed on any failure so partial clones don't leak into `/tmp`.

### Performance — `list_eval_runs` filters by user in SQL
Previously the route fetched **every** eval run for a version, then filtered in Python (`runs = [r for r in runs if r.user_id == current_user.id]`). On a shared/team version with thousands of accumulated runs that's O(total) per request even when the caller owned a handful. New `find_eval_runs_for_version_and_user` pushes both `version_id` and `user_id` into the WHERE clause and adds a `(created_at DESC, id DESC)` tiebreaker. The now-unused `find_eval_runs_for_version` is removed per the repo's clean-up-after-refactors rule.

### Performance — `_check_zombie` returns the updated run
`GET /v1/eval-runs/{run_id}` called `_check_zombie`, which updated the DB row, then re-fetched the whole row via a second `find_eval_run`. The helper now applies the failure fields via `dataclasses.replace` on the in-memory `EvalRun` and returns the updated instance — halving DB round-trips on every poll without changing the response shape.

## Tests

- **New** unit tests for the rate-limit factory (caching on `app.state`, per-endpoint independence, settings-attribute binding, debuggable callable name).
- **New** regression test for the corrupted-eval-log path that previously 500'd.
- **New** subprocess-timeout tests for `_run_git` and tempdir-cleanup on timeout.
- **Updated** eval-runs tests assert the new DB-side filter and the single `find_eval_run` call in the zombie path.

## Quality gates

| gate | result |
| --- | --- |
| `pytest server/tests/ -m "not slow"` | **938 passed**, 34 deselected |
| `pytest client/tests/` | **294 passed**, 29 skipped |
| `pytest shared/tests/` | **98 passed** |
| `ruff check .` | clean |
| `ruff format --check .` | clean |
| `mypy client/src/ server/src/ shared/src/` | no issues in 88 files |

## Diff stats

```
 client/src/dhub/core/git_repo.py               |  75 ++++++---
 client/tests/test_core/test_git_repo.py        |  55 ++++++-
 server/src/decision_hub/api/auth_routes.py     |  19 +--
 server/src/decision_hub/api/rate_limit.py      |  50 ++++++
 server/src/decision_hub/api/registry_routes.py | 212 +++++++++++--------------
 server/src/decision_hub/api/search_routes.py   |  19 +--
 server/src/decision_hub/infra/database.py      |  19 ++-
 server/tests/test_api/test_eval_logs.py        |  72 +++++++--
 server/tests/test_api/test_rate_limit.py       |  63 +++++++-
 9 files changed, 399 insertions(+), 185 deletions(-)
```

## Test plan

- [x] Run server `pytest -m "not slow"` — covers the new factory, malformed-log test, DB-side filter, and zombie path
- [x] Run client `pytest` — covers `_run_git` timeout + tempdir cleanup
- [x] Run shared `pytest`
- [x] `ruff check` + `ruff format --check`
- [x] `mypy` on all packages
- [ ] (Optional) Spot-check `/v1/eval-runs?version_id=...` against dev to confirm the new SQL path returns the same rows

## Follow-up candidates (out of scope)

- Split `infra/database.py` (3.4k LOC) into per-domain modules (users/orgs, skills, versions, eval, audit, search).
- Split `cli/registry.py` (1.9k LOC) into command-group modules (publish, install, info, logs, access).
- Add boto3 retry config (`Config(retries={"max_attempts": 3, "mode": "standard"})`) for transient S3 failures during publish.
- Add tenacity-style retry on Anthropic judge 429/503; emit WARN on rate-limit hits.
- Add an ORDER BY tiebreaker to the hybrid-search SQL for deterministic ordering on tied ranks.
- Frontend: hook tests (`useApi`, `useInfiniteScroll`) and MSW handlers for 4xx/5xx error paths; expand coverage above the current ~19%.

https://claude.ai/code/session_017SXY9bVEhTVMVqnUupEEoK

---
_Generated by [Claude Code](https://claude.ai/code/session_017SXY9bVEhTVMVqnUupEEoK)_