### PR TITLE
refactor: tighten registry + search hot paths (counter ordering, batched UPDATEs, DRY rate limiters)

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limit_dependency("_auth_rate_limiter", "auth_rate_limit", "auth_rate_window")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,6 +3,7 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -63,3 +64,38 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limit_dependency(
+    state_attr: str,
+    max_requests_attr: str,
+    window_seconds_attr: str,
+) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that lazily initialises a :class:`RateLimiter`.
+
+    The limiter is stored on ``request.app.state`` under ``state_attr`` so a
+    single instance is shared across the process while still being created
+    on demand from the application settings.
+
+    Args:
+        state_attr: Attribute name on ``app.state`` for the cached limiter
+            (e.g. ``"_publish_rate_limiter"``).
+        max_requests_attr: Settings field name holding the request cap
+            (e.g. ``"publish_rate_limit"``).
+        window_seconds_attr: Settings field name holding the window size
+            (e.g. ``"publish_rate_window"``).
+    """
+
+    def dependency(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, state_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, max_requests_attr),
+                window_seconds=getattr(settings, window_seconds_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    return dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,30 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate-limit dependencies are constructed via a shared factory so each route
+# only declares which settings field it reads. The limiter instance itself is
+# lazily cached on ``app.state`` by the factory.
+_enforce_list_skills_rate_limit = make_rate_limit_dependency(
+    "_list_skills_rate_limiter", "list_skills_rate_limit", "list_skills_rate_window"
+)
+_enforce_resolve_rate_limit = make_rate_limit_dependency(
+    "_resolve_rate_limiter", "resolve_rate_limit", "resolve_rate_window"
+)
+_enforce_similar_skills_rate_limit = make_rate_limit_dependency(
+    "_similar_skills_rate_limiter", "similar_skills_rate_limit", "similar_skills_rate_window"
+)
+_enforce_download_rate_limit = make_rate_limit_dependency(
+    "_download_rate_limiter", "download_rate_limit", "download_rate_window"
+)
+_enforce_audit_log_rate_limit = make_rate_limit_dependency(
+    "_audit_log_rate_limiter", "audit_log_rate_limit", "audit_log_rate_window"
+)
+_enforce_scan_report_rate_limit = make_rate_limit_dependency(
+    "_scan_report_rate_limiter", "scan_report_rate_limit", "scan_report_rate_window"
+)
+_enforce_publish_rate_limit = make_rate_limit_dependency(
+    "_publish_rate_limiter", "publish_rate_limit", "publish_rate_window"
+)
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -768,13 +710,15 @@ def resolve_skill(
             detail=f"Version '{spec}' not found for {org_slug}/{skill_name}",
         )
 
-    increment_skill_downloads(conn, version.skill_id)
-
+    # Mint the presigned URL first; if S3 fails we must not advance the
+    # download counter for an attempt the caller never received.
     download_url = generate_presigned_url(
         s3_client,
         settings.s3_bucket,
         version.s3_key,
     )
+
+    increment_skill_downloads(conn, version.skill_id)
 
     return ResolveResponse(
         version=version.semver,
@@ -806,9 +750,11 @@ def download_skill(
             detail=f"Version '{spec}' not found for {org_slug}/{skill_name}",
         )
 
+    # Fetch the zip first; if S3 fails we must not advance the download
+    # counter for an attempt the caller never received.
+    data = download_zip_from_s3(s3_client, settings.s3_bucket, version.s3_key)
     increment_skill_downloads(conn, version.skill_id)
 
-    data = download_zip_from_s3(s3_client, settings.s3_bucket, version.s3_key)
     filename = f"{org_slug}_{skill_name}_{version.semver}.zip"
     return Response(
         content=data,

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,14 +7,19 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
-from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
+from decision_hub.api.rate_limit import make_rate_limit_dependency
+from decision_hub.domain.search import (
+    build_index_entry_from_row,
+    format_trust_score,
+    resolve_author_display,
+    serialize_index,
+)
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
 from decision_hub.infra.gemini import (
@@ -29,16 +34,9 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limit_dependency(
+    "_search_rate_limiter", "search_rate_limit", "search_rate_window"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -86,26 +84,7 @@ def _run_retrieval(
     if not candidates:
         return None
 
-    entries = tuple(
-        build_index_entry(
-            org_slug=row["org_slug"],
-            skill_name=row["skill_name"],
-            description=row.get("description", ""),
-            latest_version=row["latest_version"],
-            eval_status=row["eval_status"],
-            author=resolve_author_display(row.get("published_by", "")),
-            category=row.get("category", ""),
-            download_count=row.get("download_count", 0),
-            source_repo_url=row.get("source_repo_url"),
-            gauntlet_summary=row.get("gauntlet_summary"),
-            github_stars=row.get("github_stars"),
-            github_forks=row.get("github_forks"),
-            github_license=row.get("github_license"),
-            source_repo_removed=row.get("source_repo_removed", False),
-            github_is_archived=row.get("github_is_archived"),
-        )
-        for row in candidates
-    )
+    entries = tuple(build_index_entry_from_row(row) for row in candidates)
     index_content = serialize_index(list(entries))
 
     return RetrievalResult(

--- a/server/src/decision_hub/domain/search.py
+++ b/server/src/decision_hub/domain/search.py
@@ -1,6 +1,8 @@
 """Search index building and trust score formatting."""
 
 import json
+from collections.abc import Mapping
+from typing import Any
 
 from decision_hub.models import SkillIndexEntry
 
@@ -61,6 +63,34 @@ def build_index_entry(
         github_forks=github_forks,
         github_license=github_license,
         source_status=source_status,
+    )
+
+
+def build_index_entry_from_row(row: Mapping[str, Any]) -> SkillIndexEntry:
+    """Build a :class:`SkillIndexEntry` directly from a skill summary row.
+
+    The row is the dict produced by ``_row_to_skill_summary()`` (see
+    ``infra/database.py``), driven by ``_SKILL_SUMMARY_COLUMNS``. Centralising
+    the row→entry mapping here means new columns flow through the search
+    pipeline automatically as soon as they're added to that list, without
+    touching every call site that builds index entries.
+    """
+    return build_index_entry(
+        org_slug=row["org_slug"],
+        skill_name=row["skill_name"],
+        description=row.get("description", "") or "",
+        latest_version=row["latest_version"],
+        eval_status=row["eval_status"],
+        author=resolve_author_display(row.get("published_by", "") or ""),
+        category=row.get("category", "") or "",
+        download_count=row.get("download_count", 0) or 0,
+        source_repo_url=row.get("source_repo_url"),
+        gauntlet_summary=row.get("gauntlet_summary"),
+        github_stars=row.get("github_stars"),
+        github_forks=row.get("github_forks"),
+        github_license=row.get("github_license"),
+        source_repo_removed=row.get("source_repo_removed", False) or False,
+        github_is_archived=row.get("github_is_archived"),
     )
 
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -598,6 +598,16 @@ skill_trackers_table = Table(
     sa.UniqueConstraint("user_id", "repo_url", "branch"),
 )
 
+# Partial index that backs claim_due_trackers (ORDER BY next_check_at ASC NULLS
+# FIRST + FOR UPDATE SKIP LOCKED) — defined in migration
+# 20260219_230810_add_next_check_at.sql, repeated here so the schema-drift
+# replay produces matching metadata and so create_all() works in tests.
+sa.Index(
+    "ix_skill_trackers_next_check",
+    skill_trackers_table.c.next_check_at.asc().nulls_first(),
+    postgresql_where=skill_trackers_table.c.enabled.is_(True),
+)
+
 tracker_metrics_table = Table(
     "tracker_metrics",
     metadata,
@@ -1180,6 +1190,18 @@ def update_skill_manifest_path(conn: Connection, skill_id: UUID, manifest_path: 
     conn.execute(stmt)
 
 
+def _matches_repo_url(repo_url_col: sa.Column, repo_url: str) -> sa.ColumnElement[bool]:
+    """Predicate matching skills whose source_repo_url is *repo_url* or a sub-path.
+
+    Tracker rows may live in a subdirectory of the repo (``…/owner/repo/path``),
+    so we match both the exact URL and any URL that starts with ``repo_url/``.
+    """
+    return sa.or_(
+        repo_url_col == repo_url,
+        repo_url_col.like(f"{repo_url}/%"),
+    )
+
+
 def batch_update_github_stars(conn: Connection, repo_stars: dict[str, int]) -> None:
     """Batch-update github_stars on the skills table by source_repo_url.
 
@@ -1187,19 +1209,25 @@ def batch_update_github_stars(conn: Connection, repo_stars: dict[str, int]) -> N
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
     subdirectories of the same repo).
+
+    Issues a single UPDATE driven by a VALUES table so a crawler batch of N
+    repos costs one round-trip instead of N.
     """
-    for repo_url, stars in repo_stars.items():
-        stmt = (
-            sa.update(skills_table)
-            .where(
-                sa.or_(
-                    skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
-                )
-            )
-            .values(github_stars=stars)
-        )
-        conn.execute(stmt)
+    if not repo_stars:
+        return
+
+    pairs = sa.values(
+        sa.column("repo_url", Text),
+        sa.column("stars", sa.Integer),
+        name="repo_stars",
+    ).data(list(repo_stars.items()))
+
+    stmt = (
+        sa.update(skills_table)
+        .values(github_stars=pairs.c.stars)
+        .where(_matches_repo_url(skills_table.c.source_repo_url, pairs.c.repo_url))
+    )
+    conn.execute(stmt)
 
 
 def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str, dict]) -> None:
@@ -1210,24 +1238,43 @@ def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str,
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
     subdirectories of the same repo).
+
+    Issues a single UPDATE driven by a VALUES table so a crawler batch of N
+    repos costs one round-trip instead of N.
     """
-    for repo_url, meta in repo_metadata.items():
-        stmt = (
-            sa.update(skills_table)
-            .where(
-                sa.or_(
-                    skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
-                )
-            )
-            .values(
-                github_forks=meta.get("forks"),
-                github_watchers=meta.get("watchers"),
-                github_is_archived=meta.get("is_archived"),
-                github_license=meta.get("license"),
-            )
+    if not repo_metadata:
+        return
+
+    rows = [
+        (
+            repo_url,
+            meta.get("forks"),
+            meta.get("watchers"),
+            meta.get("is_archived"),
+            meta.get("license"),
         )
-        conn.execute(stmt)
+        for repo_url, meta in repo_metadata.items()
+    ]
+    pairs = sa.values(
+        sa.column("repo_url", Text),
+        sa.column("forks", sa.Integer),
+        sa.column("watchers", sa.Integer),
+        sa.column("is_archived", Boolean),
+        sa.column("license", Text),
+        name="repo_meta",
+    ).data(rows)
+
+    stmt = (
+        sa.update(skills_table)
+        .values(
+            github_forks=pairs.c.forks,
+            github_watchers=pairs.c.watchers,
+            github_is_archived=pairs.c.is_archived,
+            github_license=pairs.c.license,
+        )
+        .where(_matches_repo_url(skills_table.c.source_repo_url, pairs.c.repo_url))
+    )
+    conn.execute(stmt)
 
 
 def insert_skill_access_grant(

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limit_dependency
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +84,60 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestMakeRateLimitDependency:
+    """The factory builds the dependency closure used by every rate-limited route."""
+
+    def _request_with_settings(self, **rate_settings: int) -> MagicMock:
+        request = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.app.state = MagicMock(spec=[])  # bare state, no cached limiter
+        request.app.state.settings = MagicMock(**rate_settings)
+        return request
+
+    def test_lazy_initialises_limiter_on_first_call(self) -> None:
+        dep = make_rate_limit_dependency("_demo_limiter", "demo_limit", "demo_window")
+        request = self._request_with_settings(demo_limit=5, demo_window=60)
+
+        assert not hasattr(request.app.state, "_demo_limiter")
+        dep(request)
+
+        limiter = request.app.state._demo_limiter
+        assert isinstance(limiter, RateLimiter)
+        assert limiter.max_requests == 5
+        assert limiter.window_seconds == 60
+
+    def test_reuses_cached_limiter_across_calls(self) -> None:
+        dep = make_rate_limit_dependency("_demo_limiter", "demo_limit", "demo_window")
+        request = self._request_with_settings(demo_limit=10, demo_window=60)
+
+        dep(request)
+        first = request.app.state._demo_limiter
+        dep(request)
+        assert request.app.state._demo_limiter is first
+
+    def test_enforces_configured_limit(self) -> None:
+        dep = make_rate_limit_dependency("_demo_limiter", "demo_limit", "demo_window")
+        request = self._request_with_settings(demo_limit=2, demo_window=60)
+
+        for _ in range(2):
+            dep(request)
+
+        with pytest.raises(HTTPException) as exc_info:
+            dep(request)
+        assert exc_info.value.status_code == 429
+
+    def test_different_attr_names_isolate_limiters(self) -> None:
+        """Two factory instances on the same state are independent."""
+        dep_a = make_rate_limit_dependency("_a_limiter", "a_limit", "a_window")
+        dep_b = make_rate_limit_dependency("_b_limiter", "b_limit", "b_window")
+        request = self._request_with_settings(a_limit=1, a_window=60, b_limit=5, b_window=60)
+
+        dep_a(request)
+        with pytest.raises(HTTPException):
+            dep_a(request)
+
+        # _b_limiter has plenty of budget left and uses its own bucket.
+        for _ in range(5):
+            dep_b(request)

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -5,6 +5,7 @@ from datetime import UTC
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from decision_hub.models import Organization, OrgMember, Skill, Version
@@ -808,6 +809,34 @@ class TestResolveSkill:
         call_kwargs = mock_resolve.call_args
         assert call_kwargs.kwargs.get("allow_risky") is True
 
+    @patch("decision_hub.api.registry_routes.increment_skill_downloads")
+    @patch("decision_hub.api.registry_routes.generate_presigned_url")
+    @patch("decision_hub.api.registry_routes.resolve_version")
+    def test_resolve_does_not_increment_when_presign_fails(
+        self,
+        mock_resolve: MagicMock,
+        mock_presign: MagicMock,
+        mock_increment: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """If presigned URL generation fails the download counter must not advance.
+
+        Guards against the 'state advanced on failure' anti-pattern that CLAUDE.md
+        calls out: the count would diverge from real downloads on every S3 outage.
+        """
+        org = _make_org()
+        skill = _make_skill(org)
+        version = _make_version(skill)
+
+        mock_resolve.return_value = version
+        mock_presign.side_effect = RuntimeError("S3 boom")
+
+        # The TestClient re-raises server exceptions; we care that no DB
+        # mutation happened before the failure bubbled up.
+        with pytest.raises(RuntimeError, match="S3 boom"):
+            client.get("/v1/resolve/test-org/my-skill?spec=latest")
+        mock_increment.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/skills/{org_slug}/{skill_name}/audit-log
@@ -1489,6 +1518,52 @@ class TestDownloadSkillVisibility:
         assert resp.status_code == 404
         mock_resolve.assert_called_once()
         assert mock_resolve.call_args.kwargs["user_org_ids"] is None
+
+    @patch("decision_hub.api.registry_routes.increment_skill_downloads")
+    @patch("decision_hub.api.registry_routes.download_zip_from_s3")
+    @patch("decision_hub.api.registry_routes.resolve_version")
+    def test_download_does_not_increment_when_s3_fails(
+        self,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+        mock_increment: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """If the S3 fetch fails the download counter must not advance."""
+        org = _make_org()
+        skill = _make_skill(org)
+        version = _make_version(skill)
+
+        mock_resolve.return_value = version
+        mock_download.side_effect = RuntimeError("S3 boom")
+
+        with pytest.raises(RuntimeError, match="S3 boom"):
+            client.get("/v1/skills/test-org/my-skill/download")
+        mock_increment.assert_not_called()
+
+    @patch("decision_hub.api.registry_routes.increment_skill_downloads")
+    @patch("decision_hub.api.registry_routes.download_zip_from_s3")
+    @patch("decision_hub.api.registry_routes.resolve_version")
+    def test_download_increments_after_successful_fetch(
+        self,
+        mock_resolve: MagicMock,
+        mock_download: MagicMock,
+        mock_increment: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Successful download must bump the counter exactly once with the skill id."""
+        org = _make_org()
+        skill = _make_skill(org)
+        version = _make_version(skill)
+
+        mock_resolve.return_value = version
+        mock_download.return_value = b"zip bytes"
+
+        resp = client.get("/v1/skills/test-org/my-skill/download")
+
+        assert resp.status_code == 200
+        mock_increment.assert_called_once()
+        assert mock_increment.call_args[0][1] == version.skill_id
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_domain/test_search.py
+++ b/server/tests/test_domain/test_search.py
@@ -2,6 +2,7 @@
 
 from decision_hub.domain.search import (
     build_index_entry,
+    build_index_entry_from_row,
     format_trust_score,
     serialize_index,
 )
@@ -112,3 +113,89 @@ def test_serialize_index_includes_github_metadata():
 def test_serialize_empty():
     jsonl = serialize_index([])
     assert jsonl == ""
+
+
+def test_build_index_entry_from_row_full():
+    """Building from a complete row should populate every public field."""
+    row = {
+        "org_slug": "acme",
+        "skill_name": "weather",
+        "description": "Forecasting",
+        "latest_version": "1.2.3",
+        "eval_status": "passed",
+        "published_by": "alice",
+        "category": "analytics",
+        "download_count": 17,
+        "source_repo_url": "https://github.com/acme/weather",
+        "gauntlet_summary": "no issues",
+        "github_stars": 200,
+        "github_forks": 5,
+        "github_license": "MIT",
+        "source_repo_removed": False,
+        "github_is_archived": False,
+    }
+    entry = build_index_entry_from_row(row)
+    assert entry.org_slug == "acme"
+    assert entry.skill_name == "weather"
+    assert entry.author == "alice"
+    assert entry.category == "analytics"
+    assert entry.download_count == 17
+    assert entry.trust_score == "A"
+    assert entry.source_status == "active"
+    assert entry.github_stars == 200
+    assert entry.github_forks == 5
+    assert entry.github_license == "MIT"
+
+
+def test_build_index_entry_from_row_handles_missing_fields():
+    """Missing or None columns should not blow up the helper."""
+    row = {
+        "org_slug": "acme",
+        "skill_name": "weather",
+        "latest_version": "1.0.0",
+        "eval_status": "pending",
+        # description / category / download_count / etc. intentionally absent
+    }
+    entry = build_index_entry_from_row(row)
+    assert entry.description == ""
+    assert entry.category == ""
+    assert entry.download_count == 0
+    assert entry.author == ""
+    assert entry.source_status == "active"
+
+
+def test_build_index_entry_from_row_marks_tracker_author_as_auto_sync():
+    """published_by = 'tracker:<uuid>' should resolve to the 'auto-sync' label."""
+    row = {
+        "org_slug": "acme",
+        "skill_name": "weather",
+        "latest_version": "1.0.0",
+        "eval_status": "passed",
+        "published_by": "tracker:00000000-0000-0000-0000-000000000000",
+    }
+    entry = build_index_entry_from_row(row)
+    assert entry.author == "auto-sync"
+
+
+def test_build_index_entry_from_row_marks_removed_source():
+    row = {
+        "org_slug": "acme",
+        "skill_name": "weather",
+        "latest_version": "1.0.0",
+        "eval_status": "passed",
+        "source_repo_removed": True,
+    }
+    entry = build_index_entry_from_row(row)
+    assert entry.source_status == "removed"
+
+
+def test_build_index_entry_from_row_marks_archived_source():
+    row = {
+        "org_slug": "acme",
+        "skill_name": "weather",
+        "latest_version": "1.0.0",
+        "eval_status": "passed",
+        "github_is_archived": True,
+    }
+    entry = build_index_entry_from_row(row)
+    assert entry.source_status == "archived"

--- a/server/tests/test_infra/test_batch_github_metadata.py
+++ b/server/tests/test_infra/test_batch_github_metadata.py
@@ -1,0 +1,92 @@
+"""Tests for the batched GitHub metadata UPDATEs in infra.database.
+
+These functions used to issue one UPDATE per repo URL, which is the most
+frequent DB workload on this codebase (every crawler/tracker poll).  The
+batched implementation issues a single UPDATE driven by a VALUES table.
+"""
+
+from unittest.mock import MagicMock
+
+import sqlalchemy as sa
+
+from decision_hub.infra.database import (
+    batch_update_github_repo_metadata,
+    batch_update_github_stars,
+)
+
+
+def _captured_statements(conn: MagicMock) -> list[sa.sql.Executable]:
+    """Return the SQL statements the function passed to conn.execute()."""
+    return [call.args[0] for call in conn.execute.call_args_list]
+
+
+class TestBatchUpdateGithubStars:
+    def test_empty_input_skips_db_round_trip(self):
+        conn = MagicMock()
+        batch_update_github_stars(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_issues_exactly_one_update_for_many_repos(self):
+        """Three repos must collapse into a single UPDATE."""
+        conn = MagicMock()
+        batch_update_github_stars(
+            conn,
+            {
+                "https://github.com/a/one": 1,
+                "https://github.com/b/two": 2,
+                "https://github.com/c/three": 3,
+            },
+        )
+        assert conn.execute.call_count == 1
+        stmt = _captured_statements(conn)[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        # Verify it's an UPDATE on skills with a derived VALUES table and that
+        # every repo URL flows through bound parameters (no N updates).
+        assert compiled.startswith("UPDATE skills")
+        assert "github_stars" in compiled
+        for url in ("a/one", "b/two", "c/three"):
+            assert url in compiled
+
+
+class TestBatchUpdateGithubRepoMetadata:
+    def test_empty_input_skips_db_round_trip(self):
+        conn = MagicMock()
+        batch_update_github_repo_metadata(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_issues_exactly_one_update_for_many_repos(self):
+        conn = MagicMock()
+        batch_update_github_repo_metadata(
+            conn,
+            {
+                "https://github.com/a/one": {
+                    "forks": 1,
+                    "watchers": 10,
+                    "is_archived": False,
+                    "license": "MIT",
+                },
+                "https://github.com/b/two": {
+                    "forks": 2,
+                    "watchers": 20,
+                    "is_archived": True,
+                    "license": "Apache-2.0",
+                },
+            },
+        )
+        assert conn.execute.call_count == 1
+        stmt = _captured_statements(conn)[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert compiled.startswith("UPDATE skills")
+        for field in ("github_forks", "github_watchers", "github_is_archived", "github_license"):
+            assert field in compiled
+        for url in ("a/one", "b/two"):
+            assert url in compiled
+
+    def test_tolerates_missing_metadata_keys(self):
+        """Partial metadata dicts must not crash — missing keys become NULL."""
+        conn = MagicMock()
+        batch_update_github_repo_metadata(
+            conn,
+            {"https://github.com/a/one": {"forks": 1}},
+        )
+        assert conn.execute.call_count == 1


### PR DESCRIPTION
## Summary

Five focused improvements surfaced by a deep architecture/code review across registry, search, and the database layer. Each change is small and well-scoped; together they fix two real bugs, kill a hot-path N+1, and remove ~140 lines of duplication without touching public behaviour.

## Findings & fixes

### 1. Bug — download counter advanced on S3 failure  *(`registry_routes.py`)*
`resolve_skill` and `download_skill` called `increment_skill_downloads()` **before** the presigned-URL mint / S3 fetch, so the counter diverged from real deliveries on every transient S3 error — violating the **"don't advance state on failure"** rule in `CLAUDE.md`. Re-ordered so the counter only moves after the side-effect succeeds.

```python
# before
increment_skill_downloads(conn, version.skill_id)
download_url = generate_presigned_url(...)        # if this fails, counter is wrong

# after
download_url = generate_presigned_url(...)
increment_skill_downloads(conn, version.skill_id)
```

### 2. Bug — schema drift on `ix_skill_trackers_next_check`  *(`infra/database.py`)*
Migration `20260219_230810_add_next_check_at.sql` creates the partial index that backs `claim_due_trackers` (`ORDER BY next_check_at ASC NULLS FIRST + FOR UPDATE SKIP LOCKED`), but the SQLAlchemy metadata in `database.py` was missing it. Added the matching `sa.Index(..., postgresql_where=enabled.is_(True))` so `metadata.create_all()` (used by tests and `check_schema_drift.py`) builds an identical schema.

### 3. Perf — N+1 in tracker batch updates  *(`infra/database.py`)*
`batch_update_github_stars` and `batch_update_github_repo_metadata` issued one UPDATE per repo URL, multiplying every crawler poll by N round-trips. Both now issue a single UPDATE driven by a `VALUES` table (`sa.values(...).data(...)`); empty inputs short-circuit with no DB hit.

```python
# was: for repo_url, stars in repo_stars.items(): conn.execute(UPDATE …)
# now: conn.execute(UPDATE skills SET github_stars = repo_stars.stars
#                   FROM (VALUES (...), (...), ...) AS repo_stars
#                   WHERE matches_repo_url(...))
```

### 4. DRY — 8 rate-limit dependency closures  *(`api/rate_limit.py`, `registry_routes.py`, `search_routes.py`, `auth_routes.py`)*
`registry_routes.py` (7 limiters), `search_routes.py` (1) and `auth_routes.py` (1) all reimplemented the same `if not hasattr(state, "…"): state.… = RateLimiter(…)` pattern. Extracted `make_rate_limit_dependency(state_attr, max_attr, window_attr)` so every call site becomes a one-liner declaring which settings field to read.

### 5. DRY — manual row → `SkillIndexEntry` expansion  *(`domain/search.py`, `api/search_routes.py`)*
`_run_retrieval` was hand-mapping 15 row keys into `build_index_entry` kwargs (duplicated again on the ask-enrichment path). Added `build_index_entry_from_row(row)` so adding a column to `_SKILL_SUMMARY_COLUMNS` flows through the search pipeline without touching call sites — matching the single-source-of-truth pattern documented in `CLAUDE.md`.

## What I deliberately did **not** include in this PR

These came out of the same review but are kept out so this PR stays focused. Happy to file follow-ups:

- Splitting the god modules (`database.py` 3,465 LOC, `registry_routes.py` 1,352 LOC, `gauntlet.py` 1,355 LOC).
- Per-user LLM spend quotas to harden `/v1/ask` against distributed-IP abuse.
- Rate limits on the visibility / access-grant mutation endpoints.
- Extending `check_schema_drift.py` to diff indexes (would have caught finding #2 at PR time).
- Removing the real-`time.sleep` calls in `tests/test_infra/test_cache.py` (flakiness risk).

## Test plan

- [x] `pytest server/tests -m "not slow"` — **950 pass** (was 933 → +17 new tests)
- [x] `pytest shared/tests` — 98 pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy client/src server/src shared/src` — clean
- [x] New tests cover:
  - rate-limit factory: lazy init, instance reuse, enforcement, isolation
  - download counter: stays at 0 when S3 or presign fails; increments exactly once on success
  - `build_index_entry_from_row`: full row, missing fields, tracker author, removed/archived source
  - batched github-metadata UPDATEs: single statement for many repos, no-op on empty input, partial-metadata tolerance
- [ ] CI will exercise `migrate-check` and `schema-drift` against fresh Postgres (Docker isn't available in this sandbox)

https://claude.ai/code/session_018ZJcXKjBxrRTCrhW4tiKcg

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZJcXKjBxrRTCrhW4tiKcg)_