### PR TITLE
refactor: collapse rate-limit + UUID-parse boilerplate into shared helpers

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -25,17 +25,10 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+# Reads settings.auth_rate_limit / settings.auth_rate_window lazily on first
+# request and caches the limiter on app.state — see
+# decision_hub.api.rate_limit.make_rate_limit_dep.
+_enforce_auth_rate_limit = make_rate_limit_dep("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/deps.py
+++ b/server/src/decision_hub/api/deps.py
@@ -97,6 +97,20 @@ def get_current_user(
     )
 
 
+def parse_uuid_param(value: str, name: str) -> UUID:
+    """Parse a path/query parameter string as a UUID, raising HTTP 422 otherwise.
+
+    Centralises the conversion so route handlers don't each grow their own
+    private ``_parse_uuid`` helper. The 422 detail format ("Invalid UUID for
+    {name}: '{value}'") is asserted by ``tests/test_api/test_eval_logs.py``
+    — keep it stable.
+    """
+    try:
+        return UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
+
+
 def get_current_user_optional(
     request: Request,
     settings: Settings = Depends(get_settings),

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,6 +3,7 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -63,3 +64,54 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limit_dep(name: str) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that enforces a named rate limit.
+
+    The factory reads ``settings.{name}_rate_limit`` and
+    ``settings.{name}_rate_window`` from ``request.app.state.settings``
+    on first use, builds a :class:`RateLimiter`, and caches it on
+    ``app.state._{name}_rate_limiter``. Subsequent requests reuse the same
+    limiter instance so the sliding window persists across calls.
+
+    Replaces the family of ``_enforce_<name>_rate_limit(request)`` helpers
+    that were copy-pasted across every route module — each one was the same
+    9-line ``hasattr`` / ``setattr`` dance with only the setting names
+    changing. Now adding a new rate-limited endpoint is one line at the
+    module top::
+
+        _enforce_publish_rate_limit = make_rate_limit_dep("publish")
+
+        @router.post("/publish", dependencies=[Depends(_enforce_publish_rate_limit)])
+        ...
+
+    Args:
+        name: Logical name of the rate limit. Must match the prefix of the
+            ``Settings`` fields (e.g. ``"publish"`` for ``publish_rate_limit``
+            / ``publish_rate_window``).
+
+    Returns:
+        A dependency callable suitable for ``fastapi.Depends(...)``.
+    """
+    state_attr = f"_{name}_rate_limiter"
+    limit_attr = f"{name}_rate_limit"
+    window_attr = f"{name}_rate_window"
+
+    def dependency(request: Request) -> None:
+        state = request.app.state
+        limiter: RateLimiter | None = getattr(state, state_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    # Give the closure a stable name so FastAPI's dependency-cache key
+    # and any debugging output (e.g. tracebacks) carry the intent.
+    dependency.__name__ = f"_enforce_{name}_rate_limit"
+    dependency.__qualname__ = dependency.__name__
+    return dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -4,9 +4,8 @@ import json
 import math
 import zipfile
 from datetime import UTC, datetime
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -18,8 +17,9 @@ from decision_hub.api.deps import (
     get_current_user_optional,
     get_s3_client,
     get_settings,
+    parse_uuid_param,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,99 +83,19 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate limiters — one factory call per endpoint group. The factory reads
+# settings.{name}_rate_limit / settings.{name}_rate_window lazily and caches
+# the limiter on app.state. See decision_hub.api.rate_limit.make_rate_limit_dep.
+_enforce_list_skills_rate_limit = make_rate_limit_dep("list_skills")
+_enforce_resolve_rate_limit = make_rate_limit_dep("resolve")
+_enforce_similar_skills_rate_limit = make_rate_limit_dep("similar_skills")
+_enforce_download_rate_limit = make_rate_limit_dep("download")
+_enforce_audit_log_rate_limit = make_rate_limit_dep("audit_log")
+_enforce_scan_report_rate_limit = make_rate_limit_dep("scan_report")
+_enforce_publish_rate_limit = make_rate_limit_dep("publish")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a UUID string, raising 422 with a clear message on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
 
 
 # ---------------------------------------------------------------------------
@@ -1127,7 +1047,7 @@ def get_eval_run(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunResponse:
     """Get eval run metadata by run ID."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid_param(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
@@ -1147,7 +1067,7 @@ def get_eval_run_logs(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunLogsResponse:
     """Get eval run log events with cursor-based pagination."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid_param(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
@@ -1196,7 +1116,7 @@ def list_eval_runs(
 ) -> list[EvalRunResponse]:
     """List eval runs, optionally filtered by version ID."""
     if version_id is not None:
-        parsed_vid = _parse_uuid(version_id, "version_id")
+        parsed_vid = parse_uuid_param(version_id, "version_id")
         runs = find_eval_runs_for_version(conn, parsed_vid)
         runs = [r for r in runs if r.user_id == current_user.id]
     else:

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -28,17 +28,10 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
 
-
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+# Reads settings.search_rate_limit / settings.search_rate_window lazily on
+# first request and caches the limiter on app.state — see
+# decision_hub.api.rate_limit.make_rate_limit_dep.
+_enforce_search_rate_limit = make_rate_limit_dep("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -1,7 +1,6 @@
 """CRUD API routes for skill trackers."""
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -9,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from decision_hub.api.deps import get_connection, get_current_user, get_settings
+from decision_hub.api.deps import get_connection, get_current_user, get_settings, parse_uuid_param
 from decision_hub.domain.tracker import (
     build_canonical_repo_url,
     check_repo_accessible,
@@ -87,14 +86,6 @@ def _tracker_to_response(tracker) -> TrackerResponse:
         last_error=tracker.last_error,
         created_at=tracker.created_at.isoformat() if tracker.created_at else None,
     )
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a string as UUID, raising HTTP 422 on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid {name}: {value}") from None
 
 
 def _resolve_org_slug(conn: Connection, user: User, org_slug: str | None) -> str:
@@ -210,7 +201,7 @@ def get_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Get details of a specific tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_param(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -225,7 +216,7 @@ def update_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Update a tracker's settings."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_param(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -273,7 +264,7 @@ def delete_tracker(
     user: User = Depends(get_current_user),
 ) -> None:
     """Remove a tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_param(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")

--- a/server/tests/test_api/test_deps.py
+++ b/server/tests/test_api/test_deps.py
@@ -1,8 +1,40 @@
-"""Tests for stale token detection in get_current_user."""
+"""Tests for stale token detection in get_current_user and shared helpers in deps.py."""
 
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
+import pytest
+from fastapi import HTTPException
 from jose import jwt
+
+from decision_hub.api.deps import parse_uuid_param
+
+
+class TestParseUuidParam:
+    """Unit tests for the shared parse_uuid_param helper.
+
+    Both registry and tracker routes used to ship their own copy of this
+    function with slightly different error messages. We standardised on
+    the message asserted by test_eval_logs.py — keep that contract.
+    """
+
+    def test_valid_uuid_returns_uuid_instance(self) -> None:
+        value = "12345678-1234-5678-1234-567812345678"
+        assert parse_uuid_param(value, "tracker_id") == UUID(value)
+
+    def test_invalid_uuid_raises_422_with_named_field(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            parse_uuid_param("not-a-uuid", "tracker_id")
+        assert exc_info.value.status_code == 422
+        # The "Invalid UUID" prefix is asserted by test_eval_logs.py — must stay.
+        assert "Invalid UUID" in exc_info.value.detail
+        assert "tracker_id" in exc_info.value.detail
+        assert "not-a-uuid" in exc_info.value.detail
+
+    def test_empty_string_raises_422(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            parse_uuid_param("", "run_id")
+        assert exc_info.value.status_code == 422
 
 
 class TestStaleTokenDetection:

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limit_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,96 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# make_rate_limit_dep factory
+# ---------------------------------------------------------------------------
+
+
+def _make_request_with_app(host: str = "127.0.0.1", **settings_attrs) -> MagicMock:
+    """Mock Request where `request.app.state` exposes settings + storage.
+
+    The factory reads `<name>_rate_limit` / `<name>_rate_window` off
+    `state.settings` and stashes the built limiter on `state._<name>_rate_limiter`.
+    A `SimpleNamespace` lets us use getattr/setattr just like in production,
+    instead of fighting MagicMock's auto-attribute creation.
+    """
+    request = MagicMock()
+    request.client.host = host
+    request.app.state = SimpleNamespace(settings=SimpleNamespace(**settings_attrs))
+    return request
+
+
+class TestMakeRateLimitDep:
+    """Unit tests for the `make_rate_limit_dep` factory."""
+
+    def test_lazy_initializes_limiter_from_settings(self) -> None:
+        """First call reads <name>_rate_limit / <name>_rate_window and builds a RateLimiter."""
+        dep = make_rate_limit_dep("publish")
+        request = _make_request_with_app(publish_rate_limit=2, publish_rate_window=60)
+
+        # Before any call the slot doesn't exist yet
+        assert not hasattr(request.app.state, "_publish_rate_limiter")
+
+        dep(request)
+
+        limiter = request.app.state._publish_rate_limiter
+        assert isinstance(limiter, RateLimiter)
+        assert limiter.max_requests == 2
+        assert limiter.window_seconds == 60
+
+    def test_reuses_limiter_across_calls(self) -> None:
+        """Repeated calls hit the same limiter instance, so the window persists."""
+        dep = make_rate_limit_dep("publish")
+        request = _make_request_with_app(publish_rate_limit=2, publish_rate_window=60)
+
+        dep(request)
+        first = request.app.state._publish_rate_limiter
+        dep(request)
+        second = request.app.state._publish_rate_limiter
+
+        assert first is second
+
+    def test_enforces_limit_after_factory_init(self) -> None:
+        """The 3rd request when limit=2 hits the limiter and 429s."""
+        dep = make_rate_limit_dep("search")
+        request = _make_request_with_app(search_rate_limit=2, search_rate_window=60)
+
+        dep(request)
+        dep(request)
+
+        with pytest.raises(HTTPException) as exc_info:
+            dep(request)
+        assert exc_info.value.status_code == 429
+
+    def test_different_names_get_independent_limiters(self) -> None:
+        """Two factories for different names produce two limiters on app.state."""
+        dep_a = make_rate_limit_dep("publish")
+        dep_b = make_rate_limit_dep("search")
+        request = _make_request_with_app(
+            publish_rate_limit=1,
+            publish_rate_window=60,
+            search_rate_limit=5,
+            search_rate_window=60,
+        )
+
+        dep_a(request)
+        dep_b(request)
+
+        assert request.app.state._publish_rate_limiter.max_requests == 1
+        assert request.app.state._search_rate_limiter.max_requests == 5
+        assert request.app.state._publish_rate_limiter is not request.app.state._search_rate_limiter
+
+    def test_dependency_has_descriptive_name(self) -> None:
+        """The returned callable carries an _enforce_<name>_rate_limit name for debug clarity."""
+        dep = make_rate_limit_dep("scan_report")
+        assert dep.__name__ == "_enforce_scan_report_rate_limit"
+        assert dep.__qualname__ == "_enforce_scan_report_rate_limit"
+
+    def test_missing_settings_field_raises_attribute_error(self) -> None:
+        """A typo in the name surfaces as AttributeError, not silent zero-limit behaviour."""
+        dep = make_rate_limit_dep("doesnotexist")
+        request = _make_request_with_app()  # settings has no doesnotexist_rate_limit
+        with pytest.raises(AttributeError):
+            dep(request)


### PR DESCRIPTION
## Summary

This is a focused, behaviour-preserving cleanup of two duplication hotspots in the API layer, surfaced by a codebase-wide architectural review.

### What got duplicated

**1. Rate-limit dependency boilerplate (9 copies).** Every public route module shipped its own `_enforce_<name>_rate_limit(request)` function: 7 in `registry_routes.py`, 1 in `search_routes.py`, 1 in `auth_routes.py`. Each was the same 8-line `hasattr` / `setattr` dance on `app.state` — only the setting names changed.

```python
# Repeated 9× with name-only variations:
def _enforce_publish_rate_limit(request: Request) -> None:
    state = request.app.state
    if not hasattr(state, "_publish_rate_limiter"):
        settings: Settings = state.settings
        state._publish_rate_limiter = RateLimiter(
            max_requests=settings.publish_rate_limit,
            window_seconds=settings.publish_rate_window,
        )
    state._publish_rate_limiter(request)
```

**2. `_parse_uuid` (2 copies).** `registry_routes.py` and `tracker_routes.py` each carried a private `_parse_uuid` that converted a path string to a `UUID` and raised HTTP 422 on failure. The two copies had subtly different error-message formats (`"Invalid UUID for {name}: '{value}'"` vs `"Invalid {name}: {value}"`).

### What this PR does

- **Add `make_rate_limit_dep(name)`** in `decision_hub/api/rate_limit.py`. Reads `settings.<name>_rate_limit` / `<name>_rate_window`, lazy-initialises a `RateLimiter`, caches it on `app.state._<name>_rate_limiter`. Sets `__name__` so the dependency surfaces as `_enforce_<name>_rate_limit` in tracebacks.
- **Replace all 9 call sites** with one-line declarations:
  ```python
  _enforce_publish_rate_limit = make_rate_limit_dep("publish")
  ```
- **Move `_parse_uuid` to `api/deps.py` as `parse_uuid_param`.** Unify on the `"Invalid UUID for {name}: '{value}'"` format — the one already asserted by `tests/test_api/test_eval_logs.py:511,520,529`. Drop the local copies from `registry_routes.py` and `tracker_routes.py`.

### Why this matters

- **Adding a new rate-limited endpoint** drops from "copy 8 lines of boilerplate + register a setting" to "register a setting + one-liner factory call".
- **Single place to fix bugs** in the lazy-init dance (e.g. if we ever want to honour `X-Forwarded-For`).
- **Consistent 422 error format** across UUID validation — tests that pin the format no longer drift from un-pinned callers.

### Diffstat

```
 server/src/decision_hub/api/auth_routes.py     |  19 ++---
 server/src/decision_hub/api/deps.py            |  14 ++++
 server/src/decision_hub/api/rate_limit.py      |  52 ++++++++++++
 server/src/decision_hub/api/registry_routes.py | 112 ++++---------------------
 server/src/decision_hub/api/search_routes.py   |  19 ++---
 server/src/decision_hub/api/tracker_routes.py  |  17 +---
 server/tests/test_api/test_deps.py             |  34 +++++++-
 server/tests/test_api/test_rate_limit.py       |  96 ++++++++++++++++++++-
```

Net **-37 lines** of `src/` duplication, **+126 lines** of new tests.

### New tests

`TestMakeRateLimitDep`:
- `test_lazy_initializes_limiter_from_settings` — first call materialises the limiter from the named settings fields
- `test_reuses_limiter_across_calls` — second call hits the cached instance (so the sliding window persists)
- `test_enforces_limit_after_factory_init` — limit=2 → 3rd call 429s
- `test_different_names_get_independent_limiters` — `publish` and `search` get separate buckets on app.state
- `test_dependency_has_descriptive_name` — `__name__` reads `_enforce_<name>_rate_limit` for traceback clarity
- `test_missing_settings_field_raises_attribute_error` — a typo in the name surfaces loudly instead of silently becoming a zero-limit

`TestParseUuidParam`:
- `test_valid_uuid_returns_uuid_instance`
- `test_invalid_uuid_raises_422_with_named_field` — pins the "Invalid UUID" prefix that `test_eval_logs.py` already asserts
- `test_empty_string_raises_422`

### Out of scope (deferred from the review)

A full architectural review surfaced larger targets that don't belong in a behaviour-preserving cleanup PR:

- `infra/database.py` (3,465 LoC, 103 top-level defs) → split per domain
- `cli/registry.py` (1,912 LoC) → split per verb
- `domain/gauntlet.py` (1,355), `infra/gemini.py` (1,154), `domain/tracker_service.py` (1,048), `domain/publish_pipeline.py` (848), `api/registry_routes.py` (1,352 → now 1,240) all exceed the 800-LoC working limit
- Eval-run/eval-report endpoints currently embedded in `registry_routes.py` — should be their own router
- `RateLimiter` keys on `request.client.host` — behind Modal's proxy that's the proxy IP, not the real client; needs trusted-proxy config

Each of these is a separate PR.

## Test plan

- [x] `pytest server/tests/test_api/test_rate_limit.py server/tests/test_api/test_deps.py -v` — 17 passed
- [x] `pytest server/tests/ -m "not slow"` — **942 passed, 34 deselected** (full server suite, no regressions)
- [x] `pytest server/tests/test_api/test_registry_routes.py server/tests/test_api/test_search_routes.py server/tests/test_api/test_tracker_routes.py server/tests/test_api/test_auth_routes.py server/tests/test_api/test_eval_logs.py` — 123 passed (all routes that lost their private helpers)
- [x] `uvx ruff@0.15.3 check .` — clean
- [x] `uvx ruff@0.15.3 format --check .` — 197 files already formatted
- [x] `uvx mypy` on all 6 modified source files — no issues

https://claude.ai/code/session_01T4VjanKc3ryxpkEJ1pZTif

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4VjanKc3ryxpkEJ1pZTif)_