### PR TITLE
fix: deterministic pagination + batched orphaned tracker updates

### DIFF
--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -841,8 +841,13 @@ def _try_store_scan_result(
             )
             fresh_conn.commit()
     except Exception:
+        # Side-operation: never block publish on scan-storage failure (CLAUDE.md
+        # "Isolate side operations" rule). Capture enough identifiers so the
+        # orphaned scan can be backfilled from logs via backfill_scan_reports.
         logger.opt(exception=True).warning(
-            "Failed to store scan report for {}/{} — scan data lost but publish succeeded",
+            "Failed to store scan report for {}/{} version={} version_id={} — scan data lost but publish succeeded",
             org_slug,
             skill_name,
+            version,
+            version_id,
         )

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -613,30 +613,34 @@ def _persist_orphaned_tracker_errors(
     *,
     error_msg: str,
 ) -> None:
-    """Update last_error for trackers whose Modal containers died before writing a result."""
-    from decision_hub.infra.database import update_skill_tracker
+    """Update last_error for trackers whose Modal containers died before writing a result.
+
+    Issues a single batched UPDATE rather than one per tracker so a wave of
+    Modal failures doesn't translate into N database round-trips.
+    """
+    from decision_hub.infra.database import batch_mark_trackers_orphaned
 
     if not orphaned_ids:
         return
 
     now = datetime.now(UTC)
     tracker_by_id = {t.id: t for t, _ in changed_trackers}
+    for tid in orphaned_ids:
+        tracker = tracker_by_id.get(tid)
+        logger.warning(
+            "tracker_id={} repo={} status=orphaned_failure error={}",
+            tid,
+            tracker.repo_url if tracker else "?",
+            error_msg,
+        )
     try:
         with engine.connect() as conn:
-            for tid in orphaned_ids:
-                tracker = tracker_by_id.get(tid)
-                logger.warning(
-                    "tracker_id={} repo={} status=orphaned_failure error={}",
-                    tid,
-                    tracker.repo_url if tracker else "?",
-                    error_msg,
-                )
-                update_skill_tracker(
-                    conn,
-                    tid,
-                    last_checked_at=now,
-                    last_error=error_msg,
-                )
+            batch_mark_trackers_orphaned(
+                conn,
+                list(orphaned_ids),
+                checked_at=now,
+                error_message=error_msg,
+            )
             conn.commit()
     except Exception:
         logger.opt(exception=True).error("Failed to persist orphaned tracker errors")
@@ -802,6 +806,10 @@ def process_tracker(
                     )
 
             all_failed = published_count == 0 and len(errors) > 0
+            # Surface per-skill errors even on partial success — previously the
+            # tracker recorded last_error=None when any skill succeeded, hiding
+            # broken skills from operators until the next commit churned them.
+            error_msg = "; ".join(errors)[:500] if errors else None
             with engine.connect() as conn:
                 update_skill_tracker(
                     conn,
@@ -811,7 +819,7 @@ def process_tracker(
                     last_commit_sha=current_sha if not all_failed else None,
                     last_checked_at=now,
                     last_published_at=now if published_count > 0 else None,
-                    last_error="; ".join(errors)[:500] if all_failed else None,
+                    last_error=error_msg,
                 )
                 conn.commit()
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2040,7 +2040,13 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # Tiebreaker: when multiple skills share an FTS rank, sort by (org_slug, skill_name)
+        # so the LIMIT cut is deterministic across requests and pagination is stable.
+        fts_stmt = fts_stmt.order_by(
+            sa.text("fts_rank DESC"),
+            organizations_table.c.slug.asc(),
+            skills_table.c.name.asc(),
+        ).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2058,13 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        # Tiebreaker: identical cosine distances are rare but possible; sort by
+        # (org_slug, skill_name) so the LIMIT slice is deterministic.
+        vec_stmt = vec_stmt.order_by(
+            sa.text("vec_dist ASC"),
+            organizations_table.c.slug.asc(),
+            skills_table.c.name.asc(),
+        ).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2125,7 +2137,11 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        .order_by(
+            sa.text("vec_dist ASC"),
+            organizations_table.c.slug.asc(),
+            skills_table.c.name.asc(),
+        )
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2724,7 +2740,9 @@ def find_active_eval_runs_for_user(conn: Connection, user_id: UUID, limit: int =
     stmt = (
         sa.select(eval_runs_table)
         .where(eval_runs_table.c.user_id == user_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        # id is a unique tiebreaker so two runs created in the same instant
+        # don't reorder between requests.
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
         .limit(limit)
     )
     rows = conn.execute(stmt).all()
@@ -3036,6 +3054,29 @@ def batch_set_tracker_errors(conn: Connection, tracker_ids: list[UUID], error_me
     return conn.execute(stmt).rowcount
 
 
+def batch_mark_trackers_orphaned(
+    conn: Connection,
+    tracker_ids: list[UUID],
+    *,
+    checked_at: datetime,
+    error_message: str,
+) -> int:
+    """Update last_checked_at and last_error for orphaned trackers in one UPDATE.
+
+    Replaces a per-tracker loop calling ``update_skill_tracker`` (N round-trips)
+    with a single statement, which matters when a Modal container failure orphans
+    a whole batch of trackers at once.
+    """
+    if not tracker_ids:
+        return 0
+    stmt = (
+        sa.update(skill_trackers_table)
+        .where(skill_trackers_table.c.id.in_(tracker_ids))
+        .values(last_checked_at=checked_at, last_error=error_message)
+    )
+    return conn.execute(stmt).rowcount
+
+
 def batch_defer_trackers(conn: Connection, tracker_ids: list[UUID], error_message: str) -> int:
     """Set last_error and clear next_check_at for multiple trackers. Returns rowcount."""
     if not tracker_ids:
@@ -3249,7 +3290,12 @@ def insert_tracker_metrics(
 
 def list_tracker_metrics(conn: Connection, *, limit: int = 50) -> list[TrackerMetrics]:
     """Return recent tracker metrics rows, newest first."""
-    stmt = sa.select(tracker_metrics_table).order_by(tracker_metrics_table.c.recorded_at.desc()).limit(limit)
+    stmt = (
+        sa.select(tracker_metrics_table)
+        # id breaks ties when batch_duration_seconds writes land in the same instant.
+        .order_by(tracker_metrics_table.c.recorded_at.desc(), tracker_metrics_table.c.id.desc())
+        .limit(limit)
+    )
     rows = conn.execute(stmt).all()
     return [_row_to_tracker_metrics(row) for row in rows]
 

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -314,9 +314,12 @@ class TestProcessTrackerAllFailed:
 
             mock_update.assert_called_once()
             _, kwargs = mock_update.call_args
-            # SHA should advance since at least one succeeded
+            # SHA should advance since at least one succeeded.
             assert kwargs["last_commit_sha"] == "new_sha_xyz"
-            assert kwargs["last_error"] is None
+            # Partial failure must remain visible — previously last_error was
+            # silently cleared, hiding the broken skill until the next commit.
+            assert kwargs["last_error"] is not None
+            assert "gauntlet error" in kwargs["last_error"]
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
@@ -630,32 +633,35 @@ class TestDispatchChangedTrackers:
         assert processed == 0
         assert failed == 1
 
-    @patch("decision_hub.infra.database.update_skill_tracker")
-    def test_persist_orphaned_tracker_errors(self, mock_update):
-        """When Modal containers die (timeout/OOM), last_error should be persisted."""
-        tracker = self._make_tracker()
-        changed = [(tracker, "new_sha")]
+    @patch("decision_hub.infra.database.batch_mark_trackers_orphaned")
+    def test_persist_orphaned_tracker_errors(self, mock_batch_mark):
+        """When Modal containers die (timeout/OOM), last_error should be persisted via a single batched UPDATE."""
+        tracker_a = self._make_tracker()
+        tracker_b = self._make_tracker()
+        changed = [(tracker_a, "new_sha_a"), (tracker_b, "new_sha_b")]
         mock_engine = MagicMock()
         mock_conn = MagicMock()
         mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
 
         _persist_orphaned_tracker_errors(
-            {tracker.id},
+            {tracker_a.id, tracker_b.id},
             changed,
             mock_engine,
             error_msg="Modal container failed (timeout/OOM)",
         )
 
-        mock_update.assert_called_once()
-        call_kwargs = mock_update.call_args
-        assert call_kwargs[0][1] == tracker.id
-        assert "timeout" in call_kwargs[1]["last_error"]
-        assert call_kwargs[1]["last_checked_at"] is not None
+        # One batched UPDATE for both orphans, not N per-tracker round-trips.
+        mock_batch_mark.assert_called_once()
+        args, kwargs = mock_batch_mark.call_args
+        assert args[0] is mock_conn
+        assert set(args[1]) == {tracker_a.id, tracker_b.id}
+        assert "timeout" in kwargs["error_message"]
+        assert kwargs["checked_at"] is not None
         mock_conn.commit.assert_called_once()
 
-    @patch("decision_hub.infra.database.update_skill_tracker")
-    def test_persist_orphaned_no_op_when_all_completed(self, mock_update):
+    @patch("decision_hub.infra.database.batch_mark_trackers_orphaned")
+    def test_persist_orphaned_no_op_when_all_completed(self, mock_batch_mark):
         """When all trackers completed, no DB update should happen."""
         mock_engine = MagicMock()
 
@@ -666,7 +672,7 @@ class TestDispatchChangedTrackers:
             error_msg="should not be written",
         )
 
-        mock_update.assert_not_called()
+        mock_batch_mark.assert_not_called()
         mock_engine.connect.assert_not_called()
 
 
@@ -1790,11 +1796,14 @@ class TestProcessTrackerMultiSkillPartialFailure:
 
             mock_update.assert_called_once()
             _, kwargs = mock_update.call_args
-            # SHA advances because at least one skill succeeded
+            # SHA advances because at least one skill succeeded.
             assert kwargs["last_commit_sha"] == "new_sha_multi"
-            # last_error is None because not all failed
-            assert kwargs["last_error"] is None
-            # last_published_at should be set because 3 skills were published
+            # Partial failures must remain visible to operators — both failing
+            # skills should appear in last_error even though three succeeded.
+            assert kwargs["last_error"] is not None
+            assert "skill-b" in kwargs["last_error"]
+            assert "skill-e" in kwargs["last_error"]
+            # last_published_at should be set because 3 skills were published.
             assert kwargs["last_published_at"] is not None
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")

--- a/server/tests/test_infra/test_tracker_db.py
+++ b/server/tests/test_infra/test_tracker_db.py
@@ -16,6 +16,7 @@ from decision_hub.infra.database import (
     batch_clear_tracker_errors,
     batch_defer_trackers,
     batch_disable_trackers,
+    batch_mark_trackers_orphaned,
     batch_set_tracker_errors,
     claim_due_trackers,
     delete_skill_tracker,
@@ -272,6 +273,37 @@ class TestBatchSetTrackerErrors:
         conn.execute.assert_called_once()
 
 
+class TestBatchMarkTrackersOrphaned:
+    def test_empty_list_skips_db(self):
+        conn = MagicMock()
+        result = batch_mark_trackers_orphaned(
+            conn,
+            [],
+            checked_at=datetime.now(UTC),
+            error_message="modal died",
+        )
+        assert result == 0
+        conn.execute.assert_not_called()
+
+    def test_non_empty_issues_single_update(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 5
+        ids = [uuid4() for _ in range(5)]
+        now = datetime.now(UTC)
+
+        result = batch_mark_trackers_orphaned(
+            conn,
+            ids,
+            checked_at=now,
+            error_message="Modal container failed (timeout/OOM)",
+        )
+
+        assert result == 5
+        # Critical: must be exactly ONE execute call (not N), to avoid
+        # N round-trips when a whole Modal batch dies.
+        conn.execute.assert_called_once()
+
+
 class TestBatchDeferTrackers:
     def test_empty_list_skips_db(self):
         conn = MagicMock()
@@ -411,3 +443,17 @@ class TestListTrackerMetrics:
 
         result = list_tracker_metrics(conn)
         assert result == []
+
+    def test_orders_by_recorded_at_with_id_tiebreaker(self):
+        """Two rows recorded in the same instant must order deterministically by id."""
+        conn = MagicMock()
+        conn.execute.return_value.all.return_value = []
+
+        list_tracker_metrics(conn, limit=10)
+
+        # Inspect the compiled SQL: ORDER BY recorded_at DESC, id DESC.
+        executed_stmt = conn.execute.call_args[0][0]
+        sql = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+        # Strip newlines/extra whitespace so the assertion is stable across SQLAlchemy versions.
+        normalized = " ".join(sql.split()).lower()
+        assert "order by tracker_metrics.recorded_at desc, tracker_metrics.id desc" in normalized


### PR DESCRIPTION
## Why

I did a deep architectural pass over the server hot paths (`database.py`, `tracker_service.py`, `publish_pipeline.py`, `search_routes.py`). The pass surfaced four issues that all violate rules the project sets for itself in `CLAUDE.md`:

- *"Every query with `LIMIT` must have an explicit `ORDER BY` with a unique tiebreaker"*
- *"Don't advance state on failure"*
- *"Isolate side operations"*

This PR fixes them in one focused commit, with tests. I picked the changes ruthlessly — there are other findings I deliberately left for follow-up PRs (shared `httpx.AsyncClient` lifecycle, magic-number truncation constants, mobile breakpoint audit) because they each warrant their own review.

## Changes

### 1. Deterministic pagination (correctness, P1)

Five queries had `ORDER BY <non-unique-column>` followed by `LIMIT`, which makes result ordering — and therefore pagination cuts — **undefined** when ties exist. Postgres is free to return tied rows in any order, and in practice it changes between requests as soon as the planner picks a different path.

| Function | File:line | Old | New |
|---|---|---|---|
| `search_skills_hybrid` (FTS) | `database.py:2043` | `fts_rank DESC` | `fts_rank DESC, org_slug, skill_name` |
| `search_skills_hybrid` (vector) | `database.py:2055` | `vec_dist ASC` | `vec_dist ASC, org_slug, skill_name` |
| `fetch_similar_skills` | `database.py:2128` | `vec_dist ASC` | `vec_dist ASC, org_slug, skill_name` |
| `find_active_eval_runs_for_user` | `database.py:2727` | `created_at DESC` | `created_at DESC, id DESC` |
| `list_tracker_metrics` | `database.py:3252` | `recorded_at DESC` | `recorded_at DESC, id DESC` |

Skills can plausibly share an FTS rank (short manifests, similar wording); metrics rows written in the same batch can share `recorded_at` down to the microsecond. Either caused the same query to return rows in a different order across requests, silently shifting page boundaries.

### 2. Visibility on partial tracker failure (correctness, P1)

`process_tracker` cleared `last_error` whenever *any* skill in a multi-skill repo published successfully, even when others failed in the same commit. Operators only saw the errors in transient logs — never in the DB or UI — so broken skills sat stale until the next commit happened to touch them.

The intentional design ("don't replay the same commit") still holds: SHA still advances on partial success. But errors are now persisted on every failure, partial or total, so operators see the broken skills.

```diff
- last_error="; ".join(errors)[:500] if all_failed else None,
+ error_msg = "; ".join(errors)[:500] if errors else None
+ ...
+ last_error=error_msg,
```

Two existing tests pinned the old silent-clear behavior; updated them to assert the new (correct) behavior with comments explaining why.

### 3. Batched orphaned-tracker error writes (perf, P1)

`_persist_orphaned_tracker_errors` looped over orphaned IDs calling `update_skill_tracker` per ID — N round-trips when a whole Modal batch dies (which is exactly when this code runs). Added `batch_mark_trackers_orphaned` in `database.py` (mirrors the existing `batch_set_tracker_errors`, `batch_defer_trackers`, etc. pattern) and switched the call site to one batched UPDATE.

```diff
- with engine.connect() as conn:
-     for tid in orphaned_ids:
-         update_skill_tracker(conn, tid, last_checked_at=now, last_error=error_msg)
-     conn.commit()
+ with engine.connect() as conn:
+     batch_mark_trackers_orphaned(conn, list(orphaned_ids), checked_at=now, error_message=error_msg)
+     conn.commit()
```

Updated the existing test to enforce that exactly one execute happens regardless of orphan count.

### 4. Better log context on scan-report side-failures (DX, P2)

`_store_scan_result_safely` in `publish_pipeline.py` still swallows failures (intentional per CLAUDE.md's "isolate side operations" rule — publish must not block on Cisco scan storage), but the warning now includes `semver` and `version_id` so an orphaned scan can be re-attached via `backfill_scan_reports.py` without grepping S3.

## Verification

- `uvx ruff check` + `format --check` clean on the touched files
- `uvx mypy` clean on the touched files
- `pytest server/tests/ -m "not slow"` — **936 passed, 0 failures, 0 regressions**
- New / updated tests:
  - `TestBatchMarkTrackersOrphaned` — asserts a single `execute` regardless of N
  - `TestListTrackerMetrics::test_orders_by_recorded_at_with_id_tiebreaker` — asserts the compiled SQL contains the tiebreaker
  - `test_persist_orphaned_tracker_errors` — rewritten for batched API
  - `test_partial_success_advances_sha` / `test_three_of_five_succeed_advances_sha_clears_error` — pinned to new visibility-preserving behavior

## Test plan

- [ ] CI green on `lint`, `typecheck`, `test-server`, `migrate-check`, `schema-drift`
- [ ] Spot-check on dev that `/v1/skills/ask` still returns stable result ordering for a query that produces ties (e.g. very generic terms — try `q=skill`)
- [ ] Spot-check `/v1/trackers/metrics` returns identical ordering across two back-to-back requests

## Out of scope (follow-up candidates)

These showed up in the audit but warrant separate PRs:

- **Shared `httpx.AsyncClient` lifecycle** — `search_routes.py:257,299` creates a fresh client per request, defeating connection pooling. Needs lifespan wiring + a dependency.
- **Truncation magic numbers** — `[:500]`, `[:200]`, `[:100]` scattered across `gauntlet.py`, `tracker_service.py`, `evals.py`, `crawler/processing.py`. Worth a `MAX_ERROR_MSG_LEN` constant.
- **Mobile-first audit** — `OrgDetailPage.tsx` has inline `fontSize: "4rem"` 404 heading that's unreadable at 400px. `SkillsPage.module.css` mobile breakpoint starts at 640px instead of 480px per the CLAUDE.md rule.
- **Authorization matrix tests** — no parameterized tests for `(anon, org-member, non-member) × (public, org, private)` visibility paths.

---

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018stKPHcR6ZBtE2FrX6bgiE

---
_Generated by [Claude Code](https://claude.ai/code/session_018stKPHcR6ZBtE2FrX6bgiE)_