### PR TITLE
Audit fixes: tracker mapper, zip-bomb, rate-limit dedup, public-surface tightening

### DIFF
--- a/frontend/src/pages/SkillDetailPage.module.css
+++ b/frontend/src/pages/SkillDetailPage.module.css
@@ -613,16 +613,6 @@ a.metaItem:hover {
   background: rgba(255, 230, 0, 0.08);
 }
 
-.auditQuarantine {
-  font-family: 'Share Tech Mono', monospace;
-  font-size: var(--text-xs);
-  color: var(--neon-pink);
-  padding: 4px 8px;
-  background: rgba(255, 45, 149, 0.08);
-  border-radius: 4px;
-  align-self: flex-start;
-}
-
 /* Similar Skills panel */
 .similarHeader {
   font-family: 'Rajdhani', sans-serif;

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -771,12 +771,6 @@ function AuditTab({
             {entry.check_results.length > 0 && (
               <CheckResultsGrid checks={entry.check_results} />
             )}
-
-            {entry.quarantine_s3_key && (
-              <span className={styles.auditQuarantine}>
-                Quarantined: {entry.quarantine_s3_key}
-              </span>
-            )}
           </div>
         </NeonCard>
       ))}

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -107,7 +107,6 @@ export function makeAuditLogEntry(
     ],
     llm_reasoning: null,
     publisher: "dev@example.com",
-    quarantine_s3_key: null,
     created_at: "2025-01-01T00:00:00Z",
     ...overrides,
   };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -92,7 +92,6 @@ export interface AuditLogEntry {
   check_results: CheckResult[];
   llm_reasoning: Record<string, unknown> | null;
   publisher: string;
-  quarantine_s3_key: string | null;
   created_at: string | null;
 }
 

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -25,17 +25,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limit_dependency("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/keys_routes.py
+++ b/server/src/decision_hub/api/keys_routes.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
@@ -23,10 +23,15 @@ router = APIRouter(prefix="/v1/keys", tags=["keys"])
 
 
 class StoreKeyRequest(BaseModel):
-    """Payload to store a new encrypted API key."""
+    """Payload to store a new encrypted API key.
 
-    key_name: str
-    value: str
+    Length caps keep an authenticated user from POSTing an arbitrarily
+    large payload that we'd then Fernet-encrypt, persist, and re-decrypt
+    in eval-worker memory — a cheap memory-amplification vector.
+    """
+
+    key_name: str = Field(min_length=1, max_length=128)
+    value: str = Field(min_length=1, max_length=8192)
 
 
 class StoreKeyResponse(BaseModel):

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,8 +3,40 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+
+def make_rate_limit_dependency(name: str) -> Callable[[Request], None]:
+    """Return a FastAPI dependency that enforces a named per-IP rate limit.
+
+    Looks up ``{name}_rate_limit`` and ``{name}_rate_window`` on
+    ``request.app.state.settings`` and lazily caches the limiter on
+    app.state under ``_{name}_rate_limiter`` so the same limit budget
+    is shared across all routes wired to that name.
+
+    Replaces 9 near-identical hand-rolled enforcer functions that
+    previously lived inline in each routes module.
+    """
+    limiter_attr = f"_{name}_rate_limiter"
+    limit_attr = f"{name}_rate_limit"
+    window_attr = f"{name}_rate_window"
+
+    def dependency(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, limiter_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, limiter_attr, limiter)
+        limiter(request)
+
+    dependency.__name__ = f"_enforce_{name}_rate_limit"
+    return dependency
 
 
 class RateLimiter:

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -1,12 +1,13 @@
 """Skill registry routes -- publish, resolve, and delete."""
 
+import dataclasses
 import json
 import math
 import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +20,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +84,17 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# One factory replaces nine near-identical lazy-init dependencies. Each
+# name resolves to ``settings.{name}_rate_limit`` / ``{name}_rate_window``.
+_enforce_list_skills_rate_limit = make_rate_limit_dependency("list_skills")
+_enforce_resolve_rate_limit = make_rate_limit_dependency("resolve")
+_enforce_similar_skills_rate_limit = make_rate_limit_dependency("similar_skills")
+_enforce_download_rate_limit = make_rate_limit_dependency("download")
+_enforce_audit_log_rate_limit = make_rate_limit_dependency("audit_log")
+_enforce_scan_report_rate_limit = make_rate_limit_dependency("scan_report")
+_enforce_publish_rate_limit = make_rate_limit_dependency("publish")
+_enforce_skill_read_rate_limit = make_rate_limit_dependency("skill_read")
+_enforce_stats_rate_limit = make_rate_limit_dependency("stats")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -274,7 +204,12 @@ class PaginatedSkillsResponse(BaseModel):
 
 
 class AuditLogResponse(BaseModel):
-    """A single audit log entry."""
+    """A single audit log entry.
+
+    Public-facing: intentionally omits quarantine_s3_key, which is an
+    internal S3 path used by the gauntlet pipeline to dedup-on-content
+    and is not useful to external consumers.
+    """
 
     id: str
     org_slug: str
@@ -285,7 +220,6 @@ class AuditLogResponse(BaseModel):
     check_results: list[dict]
     llm_reasoning: dict | None
     publisher: str
-    quarantine_s3_key: str | None
     created_at: str | None
 
 
@@ -556,6 +490,7 @@ def publish_skill(
 
 @public_router.get(
     "/stats",
+    dependencies=[Depends(_enforce_stats_rate_limit)],
 )
 def get_registry_stats(
     response: Response,
@@ -642,6 +577,7 @@ def list_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/summary",
     response_model=SkillSummary,
+    dependencies=[Depends(_enforce_skill_read_rate_limit)],
 )
 def get_skill_summary(
     org_slug: str,
@@ -718,6 +654,7 @@ def get_similar_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/latest-version",
     response_model=LatestVersionResponse,
+    dependencies=[Depends(_enforce_skill_read_rate_limit)],
 )
 def get_latest_version(
     org_slug: str,
@@ -850,7 +787,6 @@ def get_audit_log(
             check_results=entry.check_results,
             llm_reasoning=entry.llm_reasoning,
             publisher=entry.publisher,
-            quarantine_s3_key=entry.quarantine_s3_key,
             created_at=entry.created_at.isoformat() if entry.created_at else None,
         )
         for entry in entries
@@ -955,6 +891,7 @@ def get_scan_report(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_skill_read_rate_limit)],
 )
 def get_eval_report_by_skill(
     org_slug: str,
@@ -977,6 +914,7 @@ def get_eval_report_by_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_skill_read_rate_limit)],
 )
 def get_eval_report_by_version_path(
     org_slug: str,
@@ -1097,27 +1035,31 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
+def _check_zombie(conn: Connection, run) -> tuple[str, str | None, datetime | None]:
     """Check if a running eval run has a stale heartbeat (zombie).
 
     If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    run as failed and returns the new (status, error_message, completed_at)
+    tuple so the caller can avoid a re-fetch. Otherwise returns the
+    current values from `run`.
     """
     if run.status not in ("running", "judging", "provisioning"):
-        return run.status
+        return run.status, run.error_message, run.completed_at
     if run.heartbeat_at is None:
-        return run.status
+        return run.status, run.error_message, run.completed_at
     elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
     if elapsed > _STALE_HEARTBEAT_SECONDS:
+        completed_at = datetime.now(UTC)
+        error_message = f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed."
         update_eval_run_status(
             conn,
             run.id,
             status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
-            completed_at=datetime.now(UTC),
+            error_message=error_message,
+            completed_at=completed_at,
         )
-        return "failed"
-    return run.status
+        return "failed", error_message, completed_at
+    return run.status, run.error_message, run.completed_at
 
 
 @router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
@@ -1131,9 +1073,11 @@ def get_eval_run(
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
+    status, error_message, completed_at = _check_zombie(conn, run)
+    # The UI polls this endpoint; avoid a second find_eval_run round-trip
+    # by patching the in-memory dataclass instead.
+    if status != run.status:
+        run = dataclasses.replace(run, status=status, error_message=error_message, completed_at=completed_at)
     return _run_to_response(run)
 
 
@@ -1153,7 +1097,7 @@ def get_eval_run_logs(
         raise HTTPException(status_code=404, detail="Eval run not found")
 
     # Zombie detection on read
-    effective_status = _check_zombie(conn, run)
+    effective_status, _err, _completed = _check_zombie(conn, run)
 
     # Fetch all S3 chunks for the run. The cursor is an event sequence number
     # (e.g. 50), not a chunk file sequence number (e.g. 3), so we can't use

--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -15,23 +15,14 @@ from fastapi import HTTPException
 from loguru import logger
 from sqlalchemy.engine import Connection
 
-# Re-export pipeline functions for backward compatibility.
-# Scripts (backfills, crawler), tests, and modal_app may import these
-# from ``decision_hub.api.registry_service``.
-# Re-export private helpers used by test patches.
-from decision_hub.domain.publish_pipeline import (  # noqa: F401  # noqa: F401
-    _build_analyze_fn,
-    _build_analyze_prompt_fn,
-    _build_review_body_fn,
-    _build_review_code_fn,
+# Real callers of these two live in scripts/ (backfill_categories,
+# backfill_gauntlet, gauntlet_comparison) and in scripts/crawler/processing.py;
+# keep them re-exported here so those import paths stay stable. The other
+# pipeline helpers used to be re-exported "for test patching" but every test
+# actually patches them at the domain location, so the F401 stubs were dead.
+from decision_hub.domain.publish_pipeline import (  # noqa: F401
     classify_skill_category,
-    extract_assessment_config,
-    extract_runtime_config_dict,
-    maybe_trigger_agent_assessment,
-    parse_manifest_from_content,
-    quarantine_and_log_rejection,
     run_gauntlet_pipeline,
-    try_parse_assessment_cases,
 )
 from decision_hub.infra.database import (
     find_org_by_slug,

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dependency
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -28,17 +28,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
 
-
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limit_dependency("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/domain/publish.py
+++ b/server/src/decision_hub/domain/publish.py
@@ -39,6 +39,24 @@ _MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB per extracted file
 _MAX_TOTAL_EXTRACTED = 100 * 1024 * 1024  # 100 MB total uncompressed
 _MAX_ZIP_ENTRIES = 500  # maximum number of entries in the zip
 
+
+def _safe_read(zf: zipfile.ZipFile, name: str, remaining_budget: int) -> bytes:
+    """Read a zip member while enforcing per-file and remaining-total caps.
+
+    ZipInfo.file_size is taken from the central directory, which the
+    archive can lie about. Reading via zf.open() and accumulating the
+    actual decompressed bytes is the only honest way to bound a zip-bomb.
+    """
+    cap = min(_MAX_FILE_SIZE, remaining_budget) + 1
+    with zf.open(name) as fh:
+        data = fh.read(cap)
+    if len(data) > _MAX_FILE_SIZE:
+        raise ValueError(f"File '{name}' exceeds maximum size of {_MAX_FILE_SIZE // (1024 * 1024)} MB")
+    if len(data) > remaining_budget:
+        raise ValueError(f"Total uncompressed size exceeds limit of {_MAX_TOTAL_EXTRACTED // (1024 * 1024)} MB")
+    return data
+
+
 # File types to extract for security scanning
 _SECURITY_SCAN_EXTENSIONS = frozenset(
     {
@@ -100,32 +118,31 @@ def extract_for_evaluation(
     with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         entries = zf.infolist()
 
-        # Zip bomb prevention: check entry count and total uncompressed size
+        # Zip bomb prevention: bound the entry count immediately.  The
+        # per-file and total-size budgets are enforced during read, since
+        # ZipInfo.file_size is attacker-controlled metadata.
         if len(entries) > _MAX_ZIP_ENTRIES:
             raise ValueError(f"Zip archive contains {len(entries)} entries, exceeding limit of {_MAX_ZIP_ENTRIES}")
 
-        total_uncompressed = sum(info.file_size for info in entries)
-        if total_uncompressed > _MAX_TOTAL_EXTRACTED:
-            raise ValueError(
-                f"Total uncompressed size ({total_uncompressed // (1024 * 1024)} MB) "
-                f"exceeds limit of {_MAX_TOTAL_EXTRACTED // (1024 * 1024)} MB"
-            )
-
+        remaining_budget = _MAX_TOTAL_EXTRACTED
         for name in zf.namelist():
             if name.endswith("/"):
                 continue
 
-            if zf.getinfo(name).file_size > _MAX_FILE_SIZE:
-                raise ValueError(f"File '{name}' exceeds maximum size of {_MAX_FILE_SIZE // (1024 * 1024)} MB")
-
             basename = name.rsplit("/", 1)[-1] if "/" in name else name
 
             if basename == "SKILL.md":
-                skill_md = zf.read(name).decode()
+                data = _safe_read(zf, name, remaining_budget)
+                remaining_budget -= len(data)
+                skill_md = data.decode()
             elif basename in ("requirements.txt", "uv.lock", "poetry.lock"):
-                lockfile_content = zf.read(name).decode()
+                data = _safe_read(zf, name, remaining_budget)
+                remaining_budget -= len(data)
+                lockfile_content = data.decode()
             elif _is_scannable_file(basename):
-                source_files.append((name, zf.read(name).decode()))
+                data = _safe_read(zf, name, remaining_budget)
+                remaining_budget -= len(data)
+                source_files.append((name, data.decode()))
             else:
                 unscanned_files.append(name)
 

--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -171,110 +171,58 @@ def parse_manifest_from_content(
 # ---------------------------------------------------------------------------
 
 
-def _build_analyze_fn(settings: Settings, gemini: dict | None = None):
-    """Build a Gemini analyze callback if google_api_key is configured."""
+def _build_gemini_fn(
+    settings: Settings,
+    gemini: dict | None,
+    fn_name: str,
+):
+    """Build a Gemini-backed callback that forwards extra positional args.
+
+    Returns None when no API key is configured so callers can wire fall-back
+    behavior (the gauntlet skips LLM-dependent checks in that case).
+    The single shared factory replaces five near-identical _build_*_fn
+    closures that used to differ only in which gemini.* function they
+    invoked.
+    """
     if not settings.google_api_key:
         return None
 
-    from decision_hub.infra.gemini import analyze_code_safety, create_gemini_client
+    from decision_hub.infra import gemini as gemini_mod
 
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
+    gemini_client = gemini or gemini_mod.create_gemini_client(settings.google_api_key)
+    impl = getattr(gemini_mod, fn_name)
 
-    def analyze_fn(snippets, source_files, skill_name, skill_description):
-        return analyze_code_safety(
-            gemini_client,
-            snippets,
-            source_files,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
+    def _fn(*args):
+        return impl(gemini_client, *args, model=settings.gemini_model)
 
-    return analyze_fn
+    return _fn
+
+
+# Thin named wrappers preserve the patch surface used by ~30 test stacks
+# and the historical import in api/registry_service.py.
+def _build_analyze_fn(settings: Settings, gemini: dict | None = None):
+    """Build a Gemini analyze callback if google_api_key is configured."""
+    return _build_gemini_fn(settings, gemini, "analyze_code_safety")
 
 
 def _build_analyze_prompt_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini prompt analyze callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
-
-    from decision_hub.infra.gemini import analyze_prompt_safety, create_gemini_client
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def analyze_prompt_fn(prompt_hits, skill_name, skill_description):
-        return analyze_prompt_safety(
-            gemini_client,
-            prompt_hits,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return analyze_prompt_fn
+    return _build_gemini_fn(settings, gemini, "analyze_prompt_safety")
 
 
 def _build_review_body_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini holistic body review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
-
-    from decision_hub.infra.gemini import create_gemini_client, review_prompt_body_safety
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def review_body_fn(body, skill_name, skill_description):
-        return review_prompt_body_safety(
-            gemini_client,
-            body,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return review_body_fn
+    return _build_gemini_fn(settings, gemini, "review_prompt_body_safety")
 
 
 def _build_review_code_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini holistic code review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
-
-    from decision_hub.infra.gemini import create_gemini_client, review_code_body_safety
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def review_code_fn(source_files, skill_name, skill_description):
-        return review_code_body_safety(
-            gemini_client,
-            source_files,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return review_code_fn
+    return _build_gemini_fn(settings, gemini, "review_code_body_safety")
 
 
 def _build_analyze_credential_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini credential entropy review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
-
-    from decision_hub.infra.gemini import analyze_credential_entropy, create_gemini_client
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def analyze_credential_fn(entropy_hits, skill_name, skill_description):
-        return analyze_credential_entropy(
-            gemini_client,
-            entropy_hits,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return analyze_credential_fn
+    return _build_gemini_fn(settings, gemini, "analyze_credential_entropy")
 
 
 def run_gauntlet_pipeline(
@@ -485,7 +433,7 @@ def maybe_trigger_agent_assessment(
 
         import modal
 
-        from decision_hub.infra.database import create_engine, insert_eval_run
+        from decision_hub.infra.database import create_engine, insert_eval_run, update_eval_run_status
 
         run_uuid = uuid4()
         log_s3_prefix = f"eval-logs/{run_uuid}/"
@@ -528,18 +476,37 @@ def maybe_trigger_agent_assessment(
             settings.modal_app_name,
             "run_eval_task",
         )
-        run_eval.spawn(
-            version_id=str(version_id),
-            eval_run_id=str(eval_run.id),
-            eval_agent=eval_config.agent,
-            eval_judge_model=eval_config.judge_model,
-            eval_cases_dicts=cases_dicts,
-            s3_key=s3_key,
-            s3_bucket=s3_bucket,
-            org_slug=org_slug,
-            skill_name=skill_name,
-            user_id=str(user_id),
-        )
+        try:
+            run_eval.spawn(
+                version_id=str(version_id),
+                eval_run_id=str(eval_run.id),
+                eval_agent=eval_config.agent,
+                eval_judge_model=eval_config.judge_model,
+                eval_cases_dicts=cases_dicts,
+                s3_key=s3_key,
+                s3_bucket=s3_bucket,
+                org_slug=org_slug,
+                skill_name=skill_name,
+                user_id=str(user_id),
+            )
+        except Exception as exc:
+            # Spawn failed — the eval_run row would otherwise sit in 'pending'
+            # forever (zombie detection only covers running/judging/provisioning).
+            # Mark it failed so the CLI's tail loop terminates and the operator
+            # sees the spawn-side error.
+            logger.opt(exception=True).warning("Modal spawn failed for eval_run={}; marking failed", eval_run.id)
+            from datetime import UTC, datetime
+
+            with engine.connect() as eval_conn:
+                update_eval_run_status(
+                    eval_conn,
+                    eval_run.id,
+                    status="failed",
+                    error_message=f"Failed to spawn eval task: {exc}"[:500],
+                    completed_at=datetime.now(UTC),
+                )
+                eval_conn.commit()
+            raise
         return "pending", str(eval_run.id)
     return None, None
 

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -802,6 +802,10 @@ def process_tracker(
                     )
 
             all_failed = published_count == 0 and len(errors) > 0
+            # Preserve last_error whenever any sub-publish failed — clearing it
+            # on partial success would hide regressions on individual skills
+            # in a multi-skill repo from operators.
+            last_error = "; ".join(errors)[:500] if errors else None
             with engine.connect() as conn:
                 update_skill_tracker(
                     conn,
@@ -811,7 +815,7 @@ def process_tracker(
                     last_commit_sha=current_sha if not all_failed else None,
                     last_checked_at=now,
                     last_published_at=now if published_count > 0 else None,
-                    last_error="; ".join(errors)[:500] if all_failed else None,
+                    last_error=last_error,
                 )
                 conn.commit()
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2440,6 +2440,12 @@ def has_recent_quarantine(
     return conn.execute(stmt).scalar_one_or_none() is not None
 
 
+# Hard upper bound on a single find_audit_logs call. Skills with thousands
+# of rejected publish attempts would otherwise stream every row into memory
+# and through the response serializer when callers pass limit=None.
+_AUDIT_LOGS_MAX_LIMIT = 1000
+
+
 def find_audit_logs(
     conn: Connection,
     org_slug: str,
@@ -2456,7 +2462,8 @@ def find_audit_logs(
         org_slug: Organization slug.
         skill_name: Skill name.
         semver: Optional version to filter by.
-        limit: Maximum number of rows to return (None = all).
+        limit: Maximum number of rows to return. None or values above
+            _AUDIT_LOGS_MAX_LIMIT are capped to _AUDIT_LOGS_MAX_LIMIT.
         offset: Number of rows to skip.
 
     Returns:
@@ -2474,14 +2481,14 @@ def find_audit_logs(
     count_stmt = sa.select(sa.func.count()).select_from(eval_audit_logs_table).where(where)
     total = conn.execute(count_stmt).scalar() or 0
 
+    effective_limit = _AUDIT_LOGS_MAX_LIMIT if limit is None else min(limit, _AUDIT_LOGS_MAX_LIMIT)
     stmt = (
         sa.select(eval_audit_logs_table)
         .where(where)
         .order_by(eval_audit_logs_table.c.created_at.desc(), eval_audit_logs_table.c.id.desc())
         .offset(offset)
+        .limit(effective_limit)
     )
-    if limit is not None:
-        stmt = stmt.limit(limit)
 
     rows = conn.execute(stmt).all()
     return [_row_to_audit_log_entry(row) for row in rows], total
@@ -2788,22 +2795,14 @@ def insert_search_log(
 
 
 def _row_to_skill_tracker(row: sa.Row) -> SkillTracker:
-    """Map a database row to a SkillTracker model."""
-    return SkillTracker(
-        id=row.id,
-        user_id=row.user_id,
-        org_slug=row.org_slug,
-        repo_url=row.repo_url,
-        branch=row.branch,
-        last_commit_sha=row.last_commit_sha,
-        poll_interval_minutes=row.poll_interval_minutes,
-        enabled=row.enabled,
-        last_checked_at=row.last_checked_at,
-        last_published_at=row.last_published_at,
-        last_error=row.last_error,
-        next_check_at=row.next_check_at,
-        created_at=row.created_at,
-    )
+    """Map a database row to a SkillTracker model.
+
+    Pulls every column declared on SkillTracker from the row mapping so a new
+    column added to the model + table is picked up automatically — a previous
+    hand-rolled version silently dropped consecutive_permanent_failures.
+    """
+    fields = SkillTracker.__dataclass_fields__
+    return SkillTracker(**{k: v for k, v in row._mapping.items() if k in fields})
 
 
 def insert_skill_tracker(

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -13,7 +13,18 @@ from uuid import UUID
 
 import boto3
 from botocore.client import BaseClient
+from botocore.config import Config
 from loguru import logger
+
+# boto3 defaults to a 60s connect/read timeout and a 5-attempt "legacy"
+# retry mode, so a single stalled S3 call can hold an event-loop worker
+# for ~5 minutes. With max_inputs=100 per Modal container, a couple of
+# stalled streams is enough to wedge a replica.
+_S3_CLIENT_CONFIG = Config(
+    connect_timeout=3,
+    read_timeout=15,
+    retries={"max_attempts": 3, "mode": "standard"},
+)
 
 
 def create_s3_client(
@@ -37,6 +48,7 @@ def create_s3_client(
         "region_name": region,
         "aws_access_key_id": access_key_id,
         "aws_secret_access_key": secret_access_key,
+        "config": _S3_CLIENT_CONFIG,
     }
     if endpoint_url:
         kwargs["endpoint_url"] = endpoint_url

--- a/server/src/decision_hub/scripts/activate_trackers.py
+++ b/server/src/decision_hub/scripts/activate_trackers.py
@@ -103,18 +103,20 @@ def _run() -> None:
 
     created = 0
     skipped = 0
+    # Commit after each insert: a single shared transaction would let one
+    # IntegrityError's rollback discard every uncommitted prior insert,
+    # silently overstating `created` vs. what actually landed in the DB.
     with engine.connect() as conn:
         for repo_url, org_slug in missing:
             try:
                 insert_skill_tracker(conn, user_id=crawler_user_id, org_slug=org_slug, repo_url=repo_url)
+                conn.commit()
                 created += 1
             except IntegrityError:
-                # Race condition or duplicate — skip
                 conn.rollback()
                 skipped += 1
                 print(f"  [skip] already exists: {org_slug} | {repo_url}")
                 continue
-        conn.commit()
 
     print(f"\nDone. Created {created} trackers, skipped {skipped}.")
 

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,12 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    # Aggregate read endpoints (stats, summary, latest-version, eval-report)
+    # previously had no rate limiter; group them under a shared "read" budget.
+    skill_read_rate_limit: int = 120
+    skill_read_rate_window: int = 60
+    stats_rate_limit: int = 30
+    stats_rate_window: int = 60
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,12 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.scan_report_rate_limit = 30
+    settings.scan_report_rate_window = 60
+    settings.skill_read_rate_limit = 120
+    settings.skill_read_rate_window = 60
+    settings.stats_rate_limit = 30
+    settings.stats_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_keys_routes.py
+++ b/server/tests/test_api/test_keys_routes.py
@@ -49,6 +49,34 @@ class TestStoreKey:
         )
         assert resp.status_code == 401
 
+    def test_rejects_oversized_value(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A 10 MB value should be refused at the schema layer with 422,
+        not silently encrypted, stored, and later decrypted into the eval
+        worker — that's a cheap memory-amplification vector.
+        """
+        resp = client.post(
+            "/v1/keys",
+            json={"key_name": "huge", "value": "x" * (8192 + 1)},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_rejects_oversized_key_name(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        resp = client.post(
+            "/v1/keys",
+            json={"key_name": "x" * 129, "value": "sk-ok"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422
+
 
 class TestListKeys:
     """GET /v1/keys -- list stored API key names."""

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -860,7 +860,7 @@ class TestGetAuditLog:
             check_results=[{"check_name": "manifest_schema", "severity": "pass", "message": "ok"}],
             llm_reasoning=None,
             publisher="testuser",
-            quarantine_s3_key=None,
+            quarantine_s3_key="quarantine/test-org/my-skill/1.0.0/sha.zip",
             created_at=datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC),
         )
         mock_find.return_value = ([entry], 1)
@@ -872,6 +872,9 @@ class TestGetAuditLog:
         assert len(data["items"]) == 1
         assert data["items"][0]["grade"] == "A"
         assert data["items"][0]["publisher"] == "testuser"
+        # quarantine_s3_key is an internal S3 path and must never reach
+        # public callers, even when the underlying domain model has it set.
+        assert "quarantine_s3_key" not in data["items"][0]
         assert data["total"] == 1
         assert data["page"] == 1
 

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -291,7 +291,8 @@ class TestProcessTrackerAllFailed:
         _mock_commits,
         _mock_token,
     ):
-        """When at least one skill succeeds, SHA advances and no error is recorded."""
+        """When at least one skill succeeds, SHA advances; last_error is set
+        to the partial-failure summary so operators can see regressions."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
@@ -316,7 +317,12 @@ class TestProcessTrackerAllFailed:
             _, kwargs = mock_update.call_args
             # SHA should advance since at least one succeeded
             assert kwargs["last_commit_sha"] == "new_sha_xyz"
-            assert kwargs["last_error"] is None
+            # Regression for the old "clear last_error on partial success"
+            # bug: any failing sub-publish must surface in last_error so the
+            # tracker dashboard shows which skill regressed.
+            assert kwargs["last_error"] is not None
+            assert "skill-b" in kwargs["last_error"]
+            assert "gauntlet error" in kwargs["last_error"]
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service.has_new_commits", return_value=(True, "new_sha_xyz"))
@@ -1749,7 +1755,7 @@ class TestProcessTrackerMultiSkillPartialFailure:
     @patch("decision_hub.domain.tracker_service.discover_skills")
     @patch("decision_hub.infra.storage.create_s3_client")
     @patch("decision_hub.domain.tracker_service._publish_skill_from_tracker")
-    def test_three_of_five_succeed_advances_sha_clears_error(
+    def test_three_of_five_succeed_advances_sha_and_records_partial_error(
         self,
         mock_publish,
         _mock_s3,
@@ -1758,7 +1764,9 @@ class TestProcessTrackerMultiSkillPartialFailure:
         _mock_commits,
         _mock_token,
     ):
-        """When 3 out of 5 skills succeed and 2 fail, SHA advances and last_error is cleared."""
+        """When 3 of 5 skills succeed and 2 fail, SHA advances and the
+        partial-failure summary is recorded in last_error so operators
+        can see which sub-skills regressed."""
         tracker = self._make_tracker()
         mock_clone.return_value = Path("/tmp/fake/repo")
         mock_discover.return_value = [
@@ -1792,8 +1800,12 @@ class TestProcessTrackerMultiSkillPartialFailure:
             _, kwargs = mock_update.call_args
             # SHA advances because at least one skill succeeded
             assert kwargs["last_commit_sha"] == "new_sha_multi"
-            # last_error is None because not all failed
-            assert kwargs["last_error"] is None
+            # last_error reflects partial failure (regression for the bug
+            # that previously cleared last_error whenever any publish
+            # succeeded — silently hiding broken sub-skills).
+            assert kwargs["last_error"] is not None
+            assert "skill-b" in kwargs["last_error"]
+            assert "skill-e" in kwargs["last_error"]
             # last_published_at should be set because 3 skills were published
             assert kwargs["last_published_at"] is not None
 

--- a/server/tests/test_infra/test_cache.py
+++ b/server/tests/test_infra/test_cache.py
@@ -1,8 +1,36 @@
 """Tests for decision_hub.infra.cache -- in-memory TTL cache."""
 
-import time
+from unittest.mock import patch
+
+import pytest
 
 from decision_hub.infra.cache import TTLCache
+
+
+@pytest.fixture
+def fake_clock():
+    """A controllable monotonic clock for cache TTL tests.
+
+    Previous revisions used time.sleep(0.02) which flakes on busy CI
+    runners and slows the suite for no reason. Replacing the ``time``
+    reference imported by cache.py with a stub gives deterministic,
+    instantaneous TTL math without leaking into the global time module.
+    """
+
+    class _FakeTime:
+        def __init__(self) -> None:
+            self.now = 1000.0
+
+        def monotonic(self) -> float:
+            return self.now
+
+    fake = _FakeTime()
+
+    def advance(seconds: float) -> None:
+        fake.now += seconds
+
+    with patch("decision_hub.infra.cache.time", fake):
+        yield advance
 
 
 class TestTTLCacheBasics:
@@ -37,26 +65,26 @@ class TestTTLCacheBasics:
 
 
 class TestTTLCacheExpiration:
-    """TTL-based expiration behaviour."""
+    """TTL-based expiration behaviour (deterministic via fake clock)."""
 
-    def test_expired_entry_returns_none(self) -> None:
+    def test_expired_entry_returns_none(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=10)
-        cache.set("key", "value", ttl=0.01)
-        time.sleep(0.02)
+        cache.set("key", "value", ttl=5)
+        fake_clock(6)
         assert cache.get("key") is None
 
-    def test_per_entry_ttl_override(self) -> None:
-        cache = TTLCache(default_ttl=0.01)
-        cache.set("short", "fast", ttl=0.01)
-        cache.set("long", "slow", ttl=10)
-        time.sleep(0.02)
+    def test_per_entry_ttl_override(self, fake_clock) -> None:
+        cache = TTLCache(default_ttl=1)
+        cache.set("short", "fast", ttl=1)
+        cache.set("long", "slow", ttl=100)
+        fake_clock(2)
         assert cache.get("short") is None
         assert cache.get("long") == "slow"
 
-    def test_expired_entry_is_cleaned_on_get(self) -> None:
-        cache = TTLCache(default_ttl=0.01)
+    def test_expired_entry_is_cleaned_on_get(self, fake_clock) -> None:
+        cache = TTLCache(default_ttl=1)
         cache.set("key", "value")
-        time.sleep(0.02)
+        fake_clock(2)
         # First get should clean up the expired entry
         assert cache.get("key") is None
         # Internal store should be empty
@@ -76,11 +104,11 @@ class TestTTLCacheEviction:
         # The newest entry should still be present
         assert cache.get("c") == 3
 
-    def test_prefers_evicting_expired_entries(self) -> None:
+    def test_prefers_evicting_expired_entries(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=60, max_size=2)
-        cache.set("expired", "old", ttl=0.01)
+        cache.set("expired", "old", ttl=1)
         cache.set("fresh", "new", ttl=60)
-        time.sleep(0.02)
+        fake_clock(2)
         # Adding a third entry should evict the expired one
         cache.set("newest", "latest")
         assert cache.get("fresh") == "new"
@@ -98,12 +126,12 @@ class TestTTLCacheEviction:
 class TestTTLCacheDisabledTTL:
     """Verify zero-TTL means caching is effectively disabled."""
 
-    def test_zero_ttl_entry_expires_immediately(self) -> None:
+    def test_zero_ttl_entry_expires_immediately(self, fake_clock) -> None:
         cache = TTLCache(default_ttl=60)
         cache.set("key", "value", ttl=0)
-        # Entry should already be expired (monotonic clock precision)
-        # Give a tiny sleep to ensure monotonic moves forward
-        time.sleep(0.001)
+        # No need to advance the clock: ttl=0 sets expires_at to now,
+        # and get() treats `now > expires_at` as expired on the next tick.
+        fake_clock(0.0001)
         assert cache.get("key") is None
 
 

--- a/server/tests/test_infra/test_tracker_db.py
+++ b/server/tests/test_infra/test_tracker_db.py
@@ -36,8 +36,14 @@ def _make_tracker_row(
     enabled: bool = True,
     last_error: str | None = None,
     next_check_at: datetime | None = None,
+    consecutive_permanent_failures: int = 0,
 ) -> MagicMock:
-    """Create a mock row that simulates a skill_trackers row."""
+    """Create a mock row that simulates a skill_trackers row.
+
+    Provides both attribute access (used by older mappers) and the
+    ``_mapping`` dict-like view used by the current _row_to_skill_tracker
+    which derives its target fields from SkillTracker's dataclass fields.
+    """
     row = MagicMock()
     row.id = tracker_id or uuid4()
     row.user_id = user_id or uuid4()
@@ -51,7 +57,24 @@ def _make_tracker_row(
     row.last_published_at = None
     row.last_error = last_error
     row.next_check_at = next_check_at
+    row.consecutive_permanent_failures = consecutive_permanent_failures
     row.created_at = datetime.now(UTC)
+    row._mapping = {
+        "id": row.id,
+        "user_id": row.user_id,
+        "org_slug": row.org_slug,
+        "repo_url": row.repo_url,
+        "branch": row.branch,
+        "last_commit_sha": row.last_commit_sha,
+        "poll_interval_minutes": row.poll_interval_minutes,
+        "enabled": row.enabled,
+        "last_checked_at": row.last_checked_at,
+        "last_published_at": row.last_published_at,
+        "last_error": row.last_error,
+        "next_check_at": row.next_check_at,
+        "consecutive_permanent_failures": row.consecutive_permanent_failures,
+        "created_at": row.created_at,
+    }
     return row
 
 
@@ -73,6 +96,14 @@ class TestRowToSkillTracker:
         row = _make_tracker_row(next_check_at=now)
         tracker = _row_to_skill_tracker(row)
         assert tracker.next_check_at == now
+
+    def test_maps_consecutive_permanent_failures(self):
+        # Regression: prior hand-rolled mapper silently dropped this column,
+        # so the disable-after-N-failures policy could never disable a tracker
+        # because every read materialised the field as the dataclass default 0.
+        row = _make_tracker_row(consecutive_permanent_failures=7)
+        tracker = _row_to_skill_tracker(row)
+        assert tracker.consecutive_permanent_failures == 7
 
 
 class TestInsertSkillTracker:


### PR DESCRIPTION
## Why

Synthesis of a multi-dimension codebase audit (architecture, bugs, security, performance, testing). Each change is small, justified by a concrete failing scenario or measurable cost, and verified by existing tests plus new regressions. Tier-1 quick wins only — bigger structural work is called out below for follow-up.

## What changed

### Bug fixes

| # | Where | What |
|---|---|---|
| 1 | `infra/database.py` | `_row_to_skill_tracker` was a hand-rolled mapper that **silently dropped `consecutive_permanent_failures`** — every consumer read 0 regardless of DB state, breaking the disable-after-N-failures policy. Now derives fields from `SkillTracker.__dataclass_fields__` via `row._mapping`, so future columns are picked up automatically. Regression test added. |
| 2 | `domain/tracker_service.py` | Multi-skill tracker repos cleared `last_error` whenever *any* skill succeeded. Operators couldn't see which sub-skills regressed. Now records the partial-failure summary whenever `errors` is non-empty. Two tracker_service tests updated. |
| 3 | `scripts/activate_trackers.py` | Loop ran inside a single `engine.connect()`. An `IntegrityError` mid-loop's `conn.rollback()` discarded every prior uncommitted insert; the final `commit()` overstated the `created` count. Now commits per row. |
| 4 | `domain/publish_pipeline.py` | If `run_eval.spawn(...)` raised, the `eval_run` row sat in `pending` forever because the zombie detector only covers `running/judging/provisioning`. CLI tail loops hung. Now marks the row `failed` with the spawn error before re-raising. |
| 5 | `infra/database.py` | `find_audit_logs(limit=None, offset=N)` issued an unbounded fetch. Combined with the 30 s `statement_timeout` it could still OOM the container. Capped at 1000. |
| 6 | `api/registry_routes.py` | `get_eval_run` called `find_eval_run` twice per poll (the UI polls). `_check_zombie` now returns the new `(status, error_message, completed_at)` so the caller patches the dataclass in-process — halves DB round-trips on the hot path. |

### Security

| # | Where | What |
|---|---|---|
| 7 | `domain/publish.py` | **Zip-bomb fix.** The old check summed `info.file_size` from the central directory, which is attacker-controlled metadata. A lying header could let an over-budget payload reach `zf.read(name)` unbounded. The fix reads each member via `zf.open(name).read(_MAX_FILE_SIZE + 1)` with a running remaining-budget counter; per-file *and* total caps are enforced against actual decompressed bytes. |
| 8 | `api/registry_routes.py` + frontend | Public `AuditLogResponse` and the SkillDetail page were exposing `quarantine_s3_key` — an internal S3 path with no value to external callers and an info-disclosure on rejected publish attempts. Removed from server response model, frontend type, frontend display, and orphaned CSS. Test asserts the field is absent from the response. |
| 9 | `api/keys_routes.py` | `StoreKeyRequest` had no length caps. An authenticated user could POST a 10 MB blob to be Fernet-encrypted, persisted, and re-decrypted in eval-worker memory. Added `Field(max_length=128)` / `Field(max_length=8192)`. Two new 422-response tests. |
| 10 | `api/registry_routes.py` | Added rate limiters to previously-unprotected public endpoints — `/v1/stats`, `summary`, `latest-version`, both `eval-report` routes — via the new factory. |

### Performance

| # | Where | What |
|---|---|---|
| 11 | `infra/storage.py` | boto3 was created without a `Config`. Defaults: `connect_timeout=60s`, `read_timeout=60s`, **5 legacy retries** — a single stalled S3 call could wedge a worker for ~5 minutes, on a `max_inputs=100` Modal replica that's a likely DoS amplifier. Now configured with `connect=3`, `read=15`, `retries=standard/3`. `modal_app.py` inherits via `create_s3_client`. |

### Simplification (no behaviour change)

| # | Where | What |
|---|---|---|
| 12 | `api/rate_limit.py` | New `make_rate_limit_dependency(name)` factory replaces **nine** near-identical `_enforce_*_rate_limit` lazy-init dependencies across `registry_routes`, `search_routes`, `auth_routes`. ~60 LOC of boilerplate removed. The settings naming convention `{name}_rate_limit` / `{name}_rate_window` is now load-bearing. |
| 13 | `domain/publish_pipeline.py` | Collapsed five `_build_*_fn` Gemini closures (~100 LOC) into a single `_build_gemini_fn(settings, gemini, fn_name)` factory via `getattr`. Kept the five named one-line wrappers because ~30 patch decorators in route tests target them by name. |
| 14 | `api/registry_service.py` | Pruned dead `# noqa: F401` re-exports — eleven symbols that nothing in `server/`, `client/`, `scripts/`, or tests actually imported from this module (tests patch them at their domain location). Kept `classify_skill_category` and `run_gauntlet_pipeline` (real callers in scripts/backfills/crawler). |

### Testing

| # | Where | What |
|---|---|---|
| 15 | `tests/test_infra/test_cache.py` | Replaced five `time.sleep(0.01–0.02)` TTL-expiry tests with a `fake_clock` fixture that patches the cache module's `time` reference. Removes flakiness on busy CI runners and ~100 ms of wall-clock from the suite. |
| 16 | `tests/test_infra/test_tracker_db.py` | Tracker-row mock now carries a dict-shaped `_mapping` so the new `_row_to_skill_tracker` can iterate it; added regression test for `consecutive_permanent_failures`. |

## Verification

- **Server tests:** 931 passed, 24 deselected (`-m "not slow"`, excluding the 3.6k-line `test_arxiv_gauntlet` benchmark).
- **Client tests:** 291 passed, 29 skipped.
- **Shared tests:** 98 passed.
- **Frontend tests:** 82 passed.
- **Lint:** ruff check + format clean.
- **Frontend typecheck:** clean.

## Deferred to follow-up PRs (called out from the audit, not in scope here)

- Split `infra/database.py` (3,465 LOC) and `api/registry_routes.py` (1,352) along the section banners they already use.
- Replace the remaining 13 hand-rolled `_row_to_*` mappers with the same `_mapping`-based pattern (#1 establishes the template).
- Audit-log HMAC chain — today's `checksum` column is dedup-only despite the naming.
- Reclassify `test_arxiv_gauntlet.py` as a benchmark; introduce a `make bench` target.
- OpenTelemetry traces and a `/metrics` endpoint — currently zero metrics/tracing instrumentation.
- Rate-limiter keyed by `X-Forwarded-For` — Modal terminates TLS at the edge, so today every per-IP limiter sees the proxy IP.
- JWT default expiry: drop from 1 year to 24 h + revocation table (breaking; needs CLI coordination).
- Rename eval-log S3 chunks to include max `event_seq` so `/eval-runs/{id}/logs` polling becomes O(1) per delta instead of O(N²).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyGu22TqzGKBAVURr3Qr88

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyGu22TqzGKBAVURr3Qr88)_