### PR TITLE
fix: rate limiter purge, GitHub timeouts, AskSkillRef sync, log args

### DIFF
--- a/frontend/src/components/AskModal.test.tsx
+++ b/frontend/src/components/AskModal.test.tsx
@@ -37,6 +37,7 @@ const ASK_RESPONSE: AskResponse = {
       source_repo_url: "https://github.com/acme/data-tool",
       gauntlet_summary: null,
       github_stars: 120,
+      github_forks: 30,
       github_license: "MIT",
     },
   ],

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -207,6 +207,7 @@ export interface AskSkillRef {
   source_repo_url: string | null;
   gauntlet_summary: string | null;
   github_stars: number | null;
+  github_forks: number | null;
   github_license: string | null;
 }
 

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -26,11 +26,19 @@ class RateLimiter:
         def search(...): ...
     """
 
+    _PURGE_EVERY = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        # Monotonic counter — drives the periodic purge. Previously we summed
+        # all timestamps in `_requests` and checked `total % 100 == 0`, but
+        # `total` recomputed each call almost never landed exactly on a
+        # multiple of 100, so `_purge_stale` effectively never ran and IPs
+        # accumulated for the lifetime of the (long-lived) Modal container.
+        self._calls_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -40,9 +48,10 @@ class RateLimiter:
         with self._lock:
             # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            timestamps = [t for t in timestamps if t > cutoff]
+            self._requests[key] = timestamps
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(timestamps) >= self.max_requests:
                 raise HTTPException(
                     status_code=429,
                     detail=(
@@ -50,12 +59,13 @@ class RateLimiter:
                     ),
                 )
 
-            self._requests[key].append(now)
+            timestamps.append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            # Bound memory growth by purging IPs whose entries are all older
+            # than the window once every _PURGE_EVERY calls.
+            self._calls_since_purge += 1
+            if self._calls_since_purge >= self._PURGE_EVERY:
+                self._calls_since_purge = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -186,7 +186,12 @@ _OFF_TOPIC_ANSWER = (
 
 
 class AskSkillRef(BaseModel):
-    """A skill referenced in the conversational answer."""
+    """A skill referenced in the conversational answer.
+
+    Keep this in lockstep with ``SkillIndexEntry`` (shared/models.py) and
+    ``frontend/src/types/api.ts::AskSkillRef`` — see CLAUDE.md
+    ``_SKILL_SUMMARY_COLUMNS`` sync rule.
+    """
 
     org_slug: str
     skill_name: str
@@ -200,6 +205,7 @@ class AskSkillRef(BaseModel):
     source_repo_url: str | None = None
     gauntlet_summary: str | None = None
     github_stars: int | None = None
+    github_forks: int | None = None
     github_license: str | None = None
 
 
@@ -403,6 +409,7 @@ def _ask_skills_inner(
                 source_repo_url=e.source_repo_url,
                 gauntlet_summary=e.gauntlet_summary,
                 github_stars=e.github_stars,
+                github_forks=e.github_forks,
                 github_license=e.github_license,
             )
             for e in result.entries[:5]
@@ -476,6 +483,7 @@ def _ask_skills_inner(
                     source_repo_url=row.get("source_repo_url"),
                     gauntlet_summary=row.get("gauntlet_summary"),
                     github_stars=row.get("github_stars"),
+                    github_forks=row.get("github_forks"),
                     github_license=row.get("github_license"),
                 )
             )

--- a/server/src/decision_hub/infra/github.py
+++ b/server/src/decision_hub/infra/github.py
@@ -22,6 +22,12 @@ GITHUB_USER_ORGS_URL = "https://api.github.com/user/orgs"
 
 _ACCEPT_JSON = "application/json"
 
+# Overall request budget for any single GitHub API call. Without this, a slow
+# or unresponsive upstream will hold the FastAPI worker (and any in-flight
+# OAuth device flow) open indefinitely. 30s is well above p99 GitHub latency
+# while still bounding worst-case worker-hours.
+_GITHUB_HTTP_TIMEOUT = 30.0
+
 
 class AuthorizationPending(Exception):
     """Raised when the user has not yet completed GitHub authorization."""
@@ -44,7 +50,7 @@ async def request_device_code(client_id: str) -> DeviceCodeResponse:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.post(
             GITHUB_DEVICE_CODE_URL,
             data={"client_id": client_id, "scope": "read:org"},
@@ -79,7 +85,7 @@ async def poll_for_access_token(client_id: str, device_code: str, interval: int 
         RuntimeError: If the user denies access or the device code expires.
         httpx.HTTPStatusError: If the GitHub API returns an unexpected error.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.post(
             GITHUB_ACCESS_TOKEN_URL,
             data={
@@ -123,7 +129,7 @@ async def get_github_user(access_token: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             GITHUB_USER_URL,
             headers={
@@ -168,7 +174,7 @@ async def list_user_orgs(access_token: str) -> list[dict]:
     orgs: list[dict] = []
     url: str | None = f"{GITHUB_USER_ORGS_URL}?per_page=100"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         while url is not None:
             response = await client.get(
                 url,
@@ -201,7 +207,7 @@ async def check_org_membership(access_token: str, org: str, username: str) -> bo
     Returns:
         True if the user is a member of the organization.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org}/members/{username}",
             headers={
@@ -235,7 +241,7 @@ async def fetch_org_metadata(access_token: str, org_login: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org_login}",
             headers={
@@ -270,7 +276,7 @@ async def fetch_user_metadata(access_token: str, username: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/users/{username}",
             headers={

--- a/server/src/decision_hub/scripts/backfill_embeddings.py
+++ b/server/src/decision_hub/scripts/backfill_embeddings.py
@@ -54,6 +54,7 @@ def backfill(batch_size: int = 100) -> None:
                     )
                 )
                 .where(skills_table.c.embedding.is_(None))
+                .order_by(skills_table.c.id)  # CLAUDE.md: every LIMIT needs an explicit ORDER BY
                 .limit(batch_size)
             )
             rows = conn.execute(stmt).all()
@@ -97,9 +98,11 @@ def backfill(batch_size: int = 100) -> None:
                 update_skill_embedding(conn, row.id, embedding)
 
             conn.commit()
-            total_processed += len(rows)
+            batch_count = len(rows)
+            total_processed += batch_count
             consecutive_errors = 0  # reset circuit breaker on success
-            logger.info("Backfilled {}/{} skills", total_processed, total_processed)
+            # Previously logged total_processed twice, masking batch progress.
+            logger.info("Backfilled batch of {} (total: {})", batch_count, total_processed)
 
     logger.info(
         "Backfill complete: {} skills processed, {} errors",

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -84,3 +84,42 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_purge_stale_drops_expired_ips(self) -> None:
+        """Stale IPs are evicted from the internal dict every _PURGE_EVERY
+        calls, bounding memory growth.
+
+        Regression test for a bug where the purge used a modulo over the
+        live count (``total % 100 == 0``), which almost never fired, so the
+        dict grew unbounded over the container's lifetime.
+        """
+        # Tight knob: purge every 5 calls instead of 100.
+        limiter = RateLimiter(max_requests=10, window_seconds=1)
+        limiter._PURGE_EVERY = 5  # type: ignore[misc]
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            # Five distinct stale IPs at t=1000.
+            mock_time.monotonic.return_value = 1000.0
+            for i in range(5):
+                limiter(_make_request(f"10.0.0.{i}"))
+            assert len(limiter._requests) == 5
+
+            # Advance well past the window so all five are stale.
+            mock_time.monotonic.return_value = 1100.0
+            # Five more calls from a fresh IP — the 5th call should purge
+            # the stale entries (calls_since_purge wraps).
+            for _ in range(5):
+                limiter(_make_request("10.0.0.99"))
+
+            # Only the active IP should remain.
+            assert list(limiter._requests.keys()) == ["10.0.0.99"]
+
+    def test_purge_counter_advances_every_call(self) -> None:
+        """Each call increments the purge counter exactly once, regardless
+        of how many timestamps already exist for the caller's IP."""
+        limiter = RateLimiter(max_requests=100, window_seconds=60)
+        request = _make_request()
+
+        for n in range(1, 11):
+            limiter(request)
+            assert limiter._calls_since_purge == n % limiter._PURGE_EVERY

--- a/server/tests/test_api/test_search_routes.py
+++ b/server/tests/test_api/test_search_routes.py
@@ -249,6 +249,65 @@ class TestAskSkills:
         call_kwargs = mock_hybrid.call_args
         assert call_kwargs[1]["category"] == "Data Science"
 
+    @patch("decision_hub.api.search_routes.parse_query_with_guard", return_value=_GUARD_PASS)
+    @patch("decision_hub.api.search_routes.embed_query", return_value=_FIXED_EMBEDDING)
+    @patch("decision_hub.api.search_routes.search_skills_hybrid")
+    @patch("decision_hub.api.search_routes.ask_conversational")
+    def test_ask_response_includes_github_forks(
+        self,
+        mock_llm: MagicMock,
+        mock_hybrid: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_guard: MagicMock,
+        search_client: TestClient,
+    ) -> None:
+        """github_forks round-trips through the LLM-success enrichment path.
+
+        Regression test for the CLAUDE.md ``_SKILL_SUMMARY_COLUMNS`` sync
+        chain — the field was already in ``SkillIndexEntry`` and the DB
+        query, but ``AskSkillRef`` dropped it on the way out.
+        """
+        candidate = dict(_SAMPLE_CANDIDATES[0])
+        candidate["github_forks"] = 42
+        candidate["github_stars"] = 100
+        mock_hybrid.return_value = [candidate]
+        mock_llm.return_value = {
+            "answer": "Try acme/weather.",
+            "referenced_skills": [
+                {"org_slug": "acme", "skill_name": "weather", "reason": "matches"},
+            ],
+        }
+
+        resp = search_client.get("/v1/ask", params={"q": "weather forecast"})
+
+        assert resp.status_code == 200
+        skill = resp.json()["skills"][0]
+        assert skill["github_forks"] == 42
+        assert skill["github_stars"] == 100
+
+    @patch("decision_hub.api.search_routes.parse_query_with_guard", return_value=_GUARD_PASS)
+    @patch("decision_hub.api.search_routes.embed_query", return_value=_FIXED_EMBEDDING)
+    @patch("decision_hub.api.search_routes.search_skills_hybrid")
+    @patch("decision_hub.api.search_routes.ask_conversational", side_effect=Exception("Gemini down"))
+    def test_ask_fallback_includes_github_forks(
+        self,
+        _mock_llm: MagicMock,
+        mock_hybrid: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_guard: MagicMock,
+        search_client: TestClient,
+    ) -> None:
+        """github_forks also round-trips through the LLM-failure fallback path."""
+        candidate = dict(_SAMPLE_CANDIDATES[0])
+        candidate["github_forks"] = 7
+        mock_hybrid.return_value = [candidate]
+
+        resp = search_client.get("/v1/ask", params={"q": "weather forecast"})
+
+        assert resp.status_code == 200
+        skill = resp.json()["skills"][0]
+        assert skill["github_forks"] == 7
+
     def test_ask_rate_limited(self, search_app: FastAPI) -> None:
         """Exceeding the rate limit returns HTTP 429."""
         search_app.state.settings.search_rate_limit = 2

--- a/server/tests/test_infra/test_github.py
+++ b/server/tests/test_infra/test_github.py
@@ -199,3 +199,28 @@ class TestFetchUserMetadata:
 
         with pytest.raises(httpx.HTTPStatusError):
             await fetch_user_metadata("gh-token", "ghost")
+
+
+class TestRequestTimeouts:
+    """Every GitHub API helper must apply an explicit per-request timeout.
+
+    Without this, a slow upstream hangs the worker (and any in-flight OAuth
+    device flow) indefinitely. Asserting the constant value here is a
+    cheap guard against accidentally removing it in a future refactor.
+    """
+
+    def test_timeout_constant_is_defined_and_finite(self) -> None:
+        from decision_hub.infra.github import _GITHUB_HTTP_TIMEOUT
+
+        assert _GITHUB_HTTP_TIMEOUT is not None
+        assert 0 < _GITHUB_HTTP_TIMEOUT <= 60
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_request_times_out_on_slow_upstream(self) -> None:
+        """A hanging GitHub endpoint must raise within the configured budget,
+        not block the worker indefinitely."""
+        respx.get("https://api.github.com/orgs/slow-org").mock(side_effect=httpx.ReadTimeout("Read timeout"))
+
+        with pytest.raises(httpx.ReadTimeout):
+            await fetch_org_metadata("gh-token", "slow-org")


### PR DESCRIPTION
## Summary

Six small, high-leverage fixes surfaced by a deep architect + principal-engineer review of `main` (commit `59f483c`). The review itself ran six parallel exploration agents — architecture, bugs/correctness, security, performance, testing, dead-code/DRY — cross-verified against the source. This PR lands the safe, easily-verified subset; the broader architectural recommendations (split `database.py`, introduce a service layer between API and infra, extract domain ports for storage/embeddings) are intentionally **not** in this PR — they need their own focused PRs.

The full review document with all findings is at the bottom of this description.

## Changes

### 1. `rate_limit.py` — purge condition never fired (memory leak)
The periodic-purge check was `total % 100 == 0` against a freshly recomputed sum of every IP's timestamps. That sum almost never landed exactly on a multiple of 100, so `_purge_stale` was effectively dead code. In long-lived Modal containers serving many distinct client IPs (crawlers, CDNs, bots) `self._requests` grew unbounded for the container's lifetime. Replaced with a monotonic `_calls_since_purge` counter that triggers a real purge every `_PURGE_EVERY` (=100) calls. **Two regression tests added.**

### 2. `infra/github.py` — no per-request timeout (worker hang)
All 7 `httpx.AsyncClient()` constructors omitted `timeout=`. A slow GitHub edge endpoint could hang the OAuth device flow, `list_user_orgs`, `check_org_membership`, or `fetch_org_metadata` indefinitely, holding the FastAPI worker. Introduced `_GITHUB_HTTP_TIMEOUT = 30.0` applied to every client. **One regression test using `httpx.ReadTimeout` via respx, plus a constant-presence guard.**

### 3. `AskSkillRef` drops `github_forks` (CLAUDE.md sync-rule violation)
`SkillIndexEntry` exposes `github_forks` and `_SKILL_SUMMARY_COLUMNS` already selects it, but both API enrichment paths (LLM success + Gemini-failure fallback) and the frontend `AskSkillRef` interface silently dropped it. Updated all five touch-points listed in CLAUDE.md's `_SKILL_SUMMARY_COLUMNS` rule. **Two regression tests — one per enrichment path.**

### 4. `scripts/backfill_embeddings.py` — duplicated log argument
`logger.info("Backfilled {}/{} skills", total_processed, total_processed)` showed the same number twice, masking per-batch progress. Logs the batch size now.

### 5. `scripts/backfill_embeddings.py` — `LIMIT` without `ORDER BY`
Added `ORDER BY skills.id`. The loop's `WHERE embedding IS NULL` clause makes ordering largely cosmetic in this case, but CLAUDE.md mandates the project convention.

### 6. `frontend/src/components/AskModal.test.tsx` — fixture
TypeScript would not compile after adding `github_forks` to the interface; updated the fixture.

## Test plan

All quality gates run locally:

- [x] **939 server tests** pass (`uvx pytest server/tests/ -m "not slow"`)
- [x] **291 client tests** pass (`uvx pytest client/tests/`)
- [x] **98 shared tests** pass (`uvx pytest shared/tests/`)
- [x] **82 frontend tests** pass (`vitest run`)
- [x] **5 new regression tests** added and passing:
  - `test_rate_limit.py::test_purge_stale_drops_expired_ips`
  - `test_rate_limit.py::test_purge_counter_advances_every_call`
  - `test_github.py::TestRequestTimeouts::test_timeout_constant_is_defined_and_finite`
  - `test_github.py::TestRequestTimeouts::test_request_times_out_on_slow_upstream`
  - `test_search_routes.py::test_ask_response_includes_github_forks`
  - `test_search_routes.py::test_ask_fallback_includes_github_forks`
- [x] **ruff check + format** clean
- [x] **mypy** clean on changed files
- [x] **frontend tsc** clean (the new `github_forks` field caught a missing fixture field — exactly what good types are for)
- [x] **eslint** unchanged (only pre-existing warning)

## Out of scope (next PRs)

These came out of the same review but are intentionally deferred:

- **Architecture** — split `server/src/decision_hub/infra/database.py` (3,465 LOC, mixing schema + 100+ queries + row mappers) into `schema.py` + `queries/*.py` + `mappers.py`. High leverage but ripples through every domain/route file.
- **Architecture** — introduce a thin `SkillService` facade between `api/registry_routes.py` (which imports 25 DB functions directly) and infra. Unlocks single-object mocking in route tests.
- **Architecture** — define `StoragePort` / `EmbeddingPort` Protocols and inject into domain functions instead of `from decision_hub.infra.storage import upload_skill_zip`.
- **Security** — honour `X-Forwarded-For` in the rate limiter; currently a single attacker behind a proxy burns the whole limit. Needs trusted-proxy config and operator input.
- **Security** — sanitise `str(exc)` returned directly to clients in 8+ places. Real concern but risks breaking the CLI's error-display UX; needs UX review.
- **Testing** — `infra/database.py` (3,465 LOC) and `infra/storage.py` (271 LOC) have **zero** dedicated test files. Phase-1 plan in the review doc.
- **Code health** — extract `create_skill_zip()` to `shared/dhub_core/ziputil.py` (duplicated in client and server with asymmetric entry-count limit).

---

<details>
<summary><strong>Full review document (top 15 high-leverage changes + per-category findings + 3-phase test plan)</strong></summary>

# Decision Hub — Architect / Principal Engineer Review

## High-Level Summary

Decision Hub is a uv-workspace monorepo housing a public skills registry: a FastAPI backend (Modal-deployed, Postgres + S3 + Gemini/Anthropic), a `dhub-cli` Typer CLI (PyPI), a `dhub-core` shared package, and a React 19 frontend bundled into the container at deploy time. ~18.6K LOC server, ~4K CLI, ~7K frontend, ~22K test LOC.

**Strengths.** Clean dependency direction (api → domain → infra; nothing flows back). Shared models actually live in `shared/` so client and server never drift on manifest parsing. Postgres RLS is enabled across tables. Zip-bomb guards, encrypted API keys at rest, request-ID middleware, statement timeouts, parametrised SQL. Pre-commit + CI gates (ruff, mypy, vitest, migration replay, schema drift).

**Risks.** `infra/database.py` is a 3.5K-LOC god module mixing schema, queries, and row mappers — touching one column ripples everywhere. Domain layer imports infra directly (no ports), so unit testing requires 25-function mocks. Test count exceeds production code (22K vs 18K) but is integration-heavy with weak assertions (~82 `status_code==200`-only tests). Several real correctness bugs found in active code paths (this PR fixes three).

**Outlook.** The architecture is functional and shipping. Highest leverage for the next 3–6 months: split `database.py`, introduce a thin service layer between API and infra, and fix the testing pyramid by adding focused unit tests around `publish_pipeline` and `tracker_service`.

## Top 15 High-Leverage Changes

| # | Title | Category | Impact | Effort | This PR? |
|---|-------|----------|--------|--------|----------|
| 1 | Fix rate limiter purge condition | bugs | H | S | ✅ |
| 2 | Add timeouts to all `httpx.AsyncClient` in `github.py` | bugs | H | S | ✅ |
| 3 | Sync `AskSkillRef` to include `github_forks` | code-health | M | S | ✅ |
| 4 | Sanitise raw exception strings in HTTP error responses | security | M | S | ⏸ needs UX review |
| 5 | Split `database.py` into schema/queries/mappers | architecture | H | L | ⏸ separate PR |
| 6 | Introduce service layer between `api/*_routes.py` and infra | architecture | H | L | ⏸ separate PR |
| 7 | Fix `backfill_embeddings` progress log + add ORDER BY | bugs | L | S | ✅ |
| 8 | Use `'\n'.join(...)` in `serialize_index` | perf | L | S | ⏭ false alarm (current code is already O(N)) |
| 9 | Extract `create_skill_zip()` to `dhub_core/ziputil.py` | code-health | M | S | ⏸ separate PR |
| 10 | Add `_enrich_skill_summary()` helper | code-health | M | M | ⏸ separate PR |
| 11 | Honour `X-Forwarded-For` in rate limiter (configurable) | security | M | S | ⏸ needs operator input |
| 12 | Add `test_infra/test_database.py` + `test_storage.py` | testing | H | L | ⏸ separate PR |
| 13 | Add `frontend/src/pages/SearchFlow.test.tsx` | testing | M | M | ⏸ separate PR |
| 14 | Convert `time.sleep`-based TTL cache tests to mocked clock | testing | M | S | ⏸ separate PR |
| 15 | GradeBadge CSS → font scale variables + mobile media query | code-health | L | S | ⏸ separate PR (visual change) |

## Detailed Findings by Category

### Architecture
- `infra/database.py` is a god module (3,465 LOC). Split into `schema.py`, `queries/{users,skills,versions,evals,trackers,search}.py`, `mappers.py`.
- Domain imports infra concretely (no ports). `publish_pipeline.py:32-47` imports 4 infra modules directly. Introduce `StoragePort`, `EmbeddingPort` Protocols and inject.
- No service layer: `registry_routes.py:37-65` imports 25 database functions. Add `SkillService` facade.
- `registry_service.py` is a re-export-only facade that masks coupling rather than reducing it; delete or make it real.

### Bugs / Correctness (3 of 4 fixed in this PR)
- ✅ `rate_limit.py:57-59` — `total % 100 == 0` purge check almost never fires; `_requests` dict grows unbounded.
- ✅ `infra/github.py` — 7 `httpx.AsyncClient()` calls without `timeout=`, hanging the OAuth flow on slow upstream.
- ⏸ `domain/tracker_service.py:833-854` — exception handler that fails to update `last_error` only WARN-logs, leaving the tracker claimed-but-not-advanced.
- ✅ `scripts/backfill_embeddings.py:102` — log format args duplicated; LIMIT without ORDER BY.

### Security
- ⏸ `request.client.host` rate limiting under a proxy lets one attacker burn the whole limit (`rate_limit.py:36`). Needs trusted-proxy config.
- ⏸ Raw `str(exc)` propagated to HTTP responses across 8+ routes; leaks zipfile internals and file paths. Needs UX review.
- ⏸ `decode()` on zip contents in `publish.py:124-128` raises `UnicodeDecodeError` on binary entries → 422 with confusing message.
- ⏸ API keys passed as subprocess env vars in `modal_client.py` — visible via `/proc/<pid>/environ`.
- ⏸ SPA `FileResponse` lacks explicit `media_type="text/html; charset=utf-8"`.

### Performance
- ⏸ N+1 on `GET /skills/{org}/{name}/summary` (3 queries; should be one join).
- ⏸ Missing index on `skill_trackers.repo_url` (called per skill-summary).
- ⏸ No retry-with-jitter on Gemini; thundering herd on 429.
- ⏸ `claim_due_trackers` LIMIT 5000 with no `ORDER BY` tiebreaker — non-deterministic on row ties.

### Code Health / DRY
- ✅ `AskSkillRef` (backend + frontend) drops `github_forks` exposed by `SkillIndexEntry`.
- ⏸ Duplicate `_create_zip` in client and server with asymmetric entry-count limit.
- ⏸ `.lower()` slug normalisation open-coded in `org_routes.py:99-100` and `settings.py:152-155` — extract `normalize_slug()`.
- ⏸ `GradeBadge.module.css` hardcodes `rem` font sizes; CLAUDE.md mandates the fixed scale variables.
- ⏸ `settings.cisco_scanner_policy` is defined but only consumed by tests — dead.

### Testing
- Key gap: `infra/database.py` (3,465 LOC) and `infra/storage.py` (271 LOC) have no test file.
- 82 tests assert only `status_code == 200`; weak coverage.
- ~1,192 mock references in 18 API files — SUT rarely runs in isolation.
- Five `time.sleep`-based TTL tests are timing-flaky on slow CI.

## 3-Phase Test Migration Plan

- **Phase 1 (1–2 sprints):** Plug coverage gaps in infra (database, storage) and pipeline (publish_pipeline, repo_utils). +25% line coverage.
- **Phase 2 (1 sprint):** De-flake — mock clocks, structured errors, parametrise duplicates.
- **Phase 3 (1–2 sprints):** Frontend integration tests, Playwright skeleton, raise coverage floor.

## Non-Obvious Insights

- **Time bomb: `_purge_stale` never fires** (fixed in this PR). In long-lived Modal containers handling many distinct client IPs, `self._requests` was effectively a memory leak with worst-case growth ~one list per unique client IP per container lifetime. Restart on each Modal cold-start currently masks this.
- **Strategic refactor for the next 3–6 months: split `database.py` THEN introduce service layer THEN extract domain ports.** Doing service layer first without splitting `database.py` won't reduce test mocks materially. Doing ports first without a service layer leaves routes still importing infra.
- The `_SKILL_SUMMARY_COLUMNS` chain documented in CLAUDE.md is brittle and already drifted (`github_forks` missing in `AskSkillRef`, both paths — fixed in this PR). A schema-driven approach (single Pydantic model for the wire response, generated from `SkillIndexEntry`) would prevent future drift.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y79UkJJYpp1tiZN8DLJuwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y79UkJJYpp1tiZN8DLJuwU)_