### PR TITLE
refactor: harden public API and DB hot paths

### DIFF
--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -5,6 +5,7 @@ import time
 from collections import defaultdict
 
 from fastapi import HTTPException, Request
+from loguru import logger
 
 
 class RateLimiter:
@@ -24,11 +25,18 @@ class RateLimiter:
 
         @router.get("/search", dependencies=[Depends(limiter)])
         def search(...): ...
+
+    When the limit is hit the limiter logs a warning carrying the IP,
+    HTTP method, and path so operators can spot scrapers and bursty
+    clients in the logs. The HTTPException response stays generic.
     """
 
-    def __init__(self, max_requests: int, window_seconds: int) -> None:
+    def __init__(self, max_requests: int, window_seconds: int, *, name: str | None = None) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
+        # Optional human-readable label that appears in the warning log
+        # when a request is rejected. Defaults to "rate_limiter".
+        self.name = name or "rate_limiter"
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
 
@@ -43,6 +51,19 @@ class RateLimiter:
             self._requests[key] = [t for t in timestamps if t > cutoff]
 
             if len(self._requests[key]) >= self.max_requests:
+                # Observability: rate-limit hits used to be silent 429s
+                # which made it hard to spot abuse in practice. Log at
+                # warning level with greppable identifiers (limiter name,
+                # client IP, method, path) per CLAUDE.md logging rules.
+                logger.warning(
+                    "rate_limit_exceeded limiter={} ip={} method={} path={} limit={}/{}s",
+                    self.name,
+                    key,
+                    request.method,
+                    request.url.path,
+                    self.max_requests,
+                    self.window_seconds,
+                )
                 raise HTTPException(
                     status_code=429,
                     detail=(

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -83,88 +83,70 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
+def _make_rate_limit_enforcer(attr_name: str, limit_attr: str, window_attr: str, name: str):
+    """Build a FastAPI dependency that lazily attaches a RateLimiter to app.state.
+
+    Replaces eight near-identical helper functions that previously each
+    did the same hasattr/RateLimiter/__call__ dance with a single
+    factory. ``attr_name`` is the per-app cache slot on ``app.state``,
+    ``limit_attr`` and ``window_attr`` are the matching attributes on
+    ``Settings``, and ``name`` is the human-readable label that
+    appears in the rate_limit_exceeded warning log.
+    """
+
+    def _enforce(request: Request) -> None:
+        state = request.app.state
+        if not hasattr(state, attr_name):
+            settings: Settings = state.settings
+            setattr(
+                state,
+                attr_name,
+                RateLimiter(
+                    max_requests=getattr(settings, limit_attr),
+                    window_seconds=getattr(settings, window_attr),
+                    name=name,
+                ),
+            )
+        getattr(state, attr_name)(request)
+
+    return _enforce
 
 
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_list_skills_rate_limit = _make_rate_limit_enforcer(
+    "_list_skills_rate_limiter", "list_skills_rate_limit", "list_skills_rate_window", "list_skills"
+)
+_enforce_resolve_rate_limit = _make_rate_limit_enforcer(
+    "_resolve_rate_limiter", "resolve_rate_limit", "resolve_rate_window", "resolve"
+)
+_enforce_similar_skills_rate_limit = _make_rate_limit_enforcer(
+    "_similar_skills_rate_limiter", "similar_skills_rate_limit", "similar_skills_rate_window", "similar_skills"
+)
+_enforce_download_rate_limit = _make_rate_limit_enforcer(
+    "_download_rate_limiter", "download_rate_limit", "download_rate_window", "download"
+)
+_enforce_audit_log_rate_limit = _make_rate_limit_enforcer(
+    "_audit_log_rate_limiter", "audit_log_rate_limit", "audit_log_rate_window", "audit_log"
+)
+_enforce_scan_report_rate_limit = _make_rate_limit_enforcer(
+    "_scan_report_rate_limiter", "scan_report_rate_limit", "scan_report_rate_window", "scan_report"
+)
+_enforce_publish_rate_limit = _make_rate_limit_enforcer(
+    "_publish_rate_limiter", "publish_rate_limit", "publish_rate_window", "publish"
+)
+# Previously unprotected public GETs. Generous defaults so the frontend
+# is unaffected; the limits exist to cap scrapers and enumeration.
+_enforce_stats_rate_limit = _make_rate_limit_enforcer(
+    "_stats_rate_limiter", "stats_rate_limit", "stats_rate_window", "stats"
+)
+_enforce_skill_summary_rate_limit = _make_rate_limit_enforcer(
+    "_skill_summary_rate_limiter", "skill_summary_rate_limit", "skill_summary_rate_window", "skill_summary"
+)
+_enforce_latest_version_rate_limit = _make_rate_limit_enforcer(
+    "_latest_version_rate_limiter", "latest_version_rate_limit", "latest_version_rate_window", "latest_version"
+)
+_enforce_eval_report_rate_limit = _make_rate_limit_enforcer(
+    "_eval_report_rate_limiter", "eval_report_rate_limit", "eval_report_rate_window", "eval_report"
+)
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -556,6 +538,7 @@ def publish_skill(
 
 @public_router.get(
     "/stats",
+    dependencies=[Depends(_enforce_stats_rate_limit)],
 )
 def get_registry_stats(
     response: Response,
@@ -642,6 +625,7 @@ def list_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/summary",
     response_model=SkillSummary,
+    dependencies=[Depends(_enforce_skill_summary_rate_limit)],
 )
 def get_skill_summary(
     org_slug: str,
@@ -692,13 +676,20 @@ def get_similar_skills(
     org_slug: str,
     skill_name: str,
     conn: Connection = Depends(get_connection),
+    current_user: User | None = Depends(get_current_user_optional),
 ) -> list[SimilarSkillRef]:
     """Return up to 5 similar public skills by vector distance.
 
     Returns 404 if the skill does not exist or is not public.
     Returns an empty list if the skill has no stored embedding.
     """
-    skill = find_skill_by_slug(conn, org_slug, skill_name)
+    # Pass the caller's org IDs so private/org-scoped skills the user
+    # can see remain visible. Other detail-page endpoints (summary,
+    # latest-version, scan-report, audit-log) already do this — keeping
+    # /similar consistent avoids leaking the existence of a non-public
+    # skill via 404 vs 200 timing.
+    user_org_ids = list_user_org_ids(conn, current_user.id) if current_user else None
+    skill = find_skill_by_slug(conn, org_slug, skill_name, user_org_ids=user_org_ids)
     if skill is None:
         raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found in {org_slug}")
     rows = fetch_similar_skills(conn, org_slug, skill_name, limit=5)
@@ -718,6 +709,7 @@ def get_similar_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/latest-version",
     response_model=LatestVersionResponse,
+    dependencies=[Depends(_enforce_latest_version_rate_limit)],
 )
 def get_latest_version(
     org_slug: str,
@@ -955,6 +947,7 @@ def get_scan_report(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_eval_report_rate_limit)],
 )
 def get_eval_report_by_skill(
     org_slug: str,
@@ -977,6 +970,7 @@ def get_eval_report_by_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(_enforce_eval_report_rate_limit)],
 )
 def get_eval_report_by_version_path(
     org_slug: str,

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -910,6 +910,9 @@ def list_all_org_profiles(conn: Connection) -> list[Organization]:
 
 def org_has_public_skills(conn: Connection, org_id: UUID) -> bool:
     """Check whether an org has at least one published public skill."""
+    # ORDER BY required for deterministic LIMIT (CLAUDE.md SQL rule).
+    # The choice of column doesn't affect the boolean result but keeps
+    # the query plan stable across PostgreSQL versions.
     stmt = (
         sa.select(sa.literal(1))
         .select_from(skills_table)
@@ -920,6 +923,7 @@ def org_has_public_skills(conn: Connection, org_id: UUID) -> bool:
                 skills_table.c.latest_semver.isnot(None),
             )
         )
+        .order_by(skills_table.c.id)
         .limit(1)
     )
     return conn.execute(stmt).first() is not None
@@ -1187,19 +1191,38 @@ def batch_update_github_stars(conn: Connection, repo_stars: dict[str, int]) -> N
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
     subdirectories of the same repo).
+
+    The previous implementation issued one UPDATE per repo (an N+1 over the
+    tracker resolution set, which runs every tick). We now collapse the whole
+    batch into a single ``UPDATE skills SET ... FROM (VALUES ...) v WHERE
+    skills.source_repo_url = v.repo_url OR skills.source_repo_url LIKE v.like_pat``
+    statement, with the LIKE prefix pre-escaped to handle repo names that
+    legitimately contain ``_`` (a SQL LIKE wildcard).
     """
-    for repo_url, stars in repo_stars.items():
-        stmt = (
-            sa.update(skills_table)
-            .where(
-                sa.or_(
-                    skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
-                )
+    if not repo_stars:
+        return
+    # Pre-escape ``_`` and ``%`` in repo URLs before they become LIKE
+    # patterns. Repo names with underscores (very common) would otherwise
+    # match unrelated paths. We append ``/%`` after escaping so the
+    # trailing wildcard stays a wildcard.
+    rows = [(url, _escape_like(url) + "/%", stars) for url, stars in repo_stars.items()]
+    v = sa.values(
+        sa.column("repo_url", sa.Text),
+        sa.column("like_pat", sa.Text),
+        sa.column("stars", sa.Integer),
+        name="v",
+    ).data(rows)
+    stmt = (
+        sa.update(skills_table)
+        .values(github_stars=v.c.stars)
+        .where(
+            sa.or_(
+                skills_table.c.source_repo_url == v.c.repo_url,
+                skills_table.c.source_repo_url.like(v.c.like_pat, escape="\\"),
             )
-            .values(github_stars=stars)
         )
-        conn.execute(stmt)
+    )
+    conn.execute(stmt)
 
 
 def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str, dict]) -> None:
@@ -1210,24 +1233,48 @@ def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str,
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
     subdirectories of the same repo).
+
+    Like ``batch_update_github_stars``, this used to be an N+1 loop and is
+    now a single multi-row UPDATE driven by a VALUES table.
     """
-    for repo_url, meta in repo_metadata.items():
-        stmt = (
-            sa.update(skills_table)
-            .where(
-                sa.or_(
-                    skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
-                )
-            )
-            .values(
-                github_forks=meta.get("forks"),
-                github_watchers=meta.get("watchers"),
-                github_is_archived=meta.get("is_archived"),
-                github_license=meta.get("license"),
+    if not repo_metadata:
+        return
+    rows = [
+        (
+            url,
+            _escape_like(url) + "/%",
+            meta.get("forks"),
+            meta.get("watchers"),
+            meta.get("is_archived"),
+            meta.get("license"),
+        )
+        for url, meta in repo_metadata.items()
+    ]
+    v = sa.values(
+        sa.column("repo_url", sa.Text),
+        sa.column("like_pat", sa.Text),
+        sa.column("forks", sa.Integer),
+        sa.column("watchers", sa.Integer),
+        sa.column("is_archived", sa.Boolean),
+        sa.column("license", sa.Text),
+        name="v",
+    ).data(rows)
+    stmt = (
+        sa.update(skills_table)
+        .values(
+            github_forks=v.c.forks,
+            github_watchers=v.c.watchers,
+            github_is_archived=v.c.is_archived,
+            github_license=v.c.license,
+        )
+        .where(
+            sa.or_(
+                skills_table.c.source_repo_url == v.c.repo_url,
+                skills_table.c.source_repo_url.like(v.c.like_pat, escape="\\"),
             )
         )
-        conn.execute(stmt)
+    )
+    conn.execute(stmt)
 
 
 def insert_skill_access_grant(
@@ -1531,10 +1578,17 @@ def resolve_version(
     base = base.where(versions_table.c.eval_status.in_(allowed_statuses))
 
     if spec == "latest":
+        # semver triple is unique per skill by constraint, but add
+        # created_at/id as deterministic tiebreakers (CLAUDE.md rule:
+        # every LIMIT must have an ORDER BY with a unique tiebreaker).
+        # If the unique constraint is ever relaxed, this still returns
+        # the most recently inserted row instead of an arbitrary one.
         stmt = base.order_by(
             versions_table.c.semver_major.desc(),
             versions_table.c.semver_minor.desc(),
             versions_table.c.semver_patch.desc(),
+            versions_table.c.created_at.desc(),
+            versions_table.c.id.desc(),
         ).limit(1)
     else:
         stmt = base.where(versions_table.c.semver == spec)
@@ -2125,7 +2179,9 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        # Tiebreak ties in cosine distance with skills.id so pagination
+        # and rendering order are deterministic (CLAUDE.md SQL rule).
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id)
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,19 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    # Registry-stats endpoint — cheap query but loops a DB call; keep
+    # generous since the frontend hits it often, but cap scrapers.
+    stats_rate_limit: int = 120
+    stats_rate_window: int = 60
+    # Per-skill summary / latest-version / eval-report. Generous limits
+    # because these power skill detail pages, but they were previously
+    # unprotected and exposed enumeration vectors over the catalogue.
+    skill_summary_rate_limit: int = 120
+    skill_summary_rate_window: int = 60
+    latest_version_rate_limit: int = 120
+    latest_version_rate_window: int = 60
+    eval_report_rate_limit: int = 60
+    eval_report_rate_window: int = 60
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,16 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.stats_rate_limit = 30
+    settings.stats_rate_window = 60
+    settings.skill_summary_rate_limit = 30
+    settings.skill_summary_rate_window = 60
+    settings.latest_version_rate_limit = 30
+    settings.latest_version_rate_window = 60
+    settings.eval_report_rate_limit = 30
+    settings.eval_report_rate_window = 60
+    settings.scan_report_rate_limit = 30
+    settings.scan_report_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_new_rate_limits.py
+++ b/server/tests/test_api/test_new_rate_limits.py
@@ -1,0 +1,139 @@
+"""Tests for the rate limiters added to previously-unprotected public GETs.
+
+The endpoints ``/v1/stats``, ``/v1/skills/{org}/{name}/summary``,
+``/v1/skills/{org}/{name}/latest-version``, and the two ``/eval-report``
+variants used to be public GETs with no rate limit, leaving the database
+exposed to enumeration. Each now carries an ``_enforce_*_rate_limit``
+dependency. The tests below set the per-endpoint cap to 2 and verify the
+third request is rejected with HTTP 429.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def low_limit_client(test_settings, test_app) -> TestClient:
+    """A TestClient whose per-endpoint caps are all set to 2.
+
+    The matching ``app.state._*_rate_limiter`` slots are cleared so each
+    test starts from a clean limiter built from the lowered settings.
+    """
+    for attr in (
+        "stats_rate_limit",
+        "skill_summary_rate_limit",
+        "latest_version_rate_limit",
+        "eval_report_rate_limit",
+    ):
+        setattr(test_settings, attr, 2)
+    for slot in (
+        "_stats_rate_limiter",
+        "_skill_summary_rate_limiter",
+        "_latest_version_rate_limiter",
+        "_eval_report_rate_limiter",
+    ):
+        if hasattr(test_app.state, slot):
+            delattr(test_app.state, slot)
+    return TestClient(test_app)
+
+
+class TestStatsRateLimit:
+    @patch("decision_hub.api.registry_routes.fetch_registry_stats")
+    def test_third_request_blocked(self, mock_stats, low_limit_client: TestClient) -> None:
+        mock_stats.return_value = {"total_skills": 0, "total_orgs": 0, "total_downloads": 0}
+        assert low_limit_client.get("/v1/stats").status_code == 200
+        assert low_limit_client.get("/v1/stats").status_code == 200
+        resp = low_limit_client.get("/v1/stats")
+        assert resp.status_code == 429
+        assert "Rate limit exceeded" in resp.json()["detail"]
+
+
+class TestSkillSummaryRateLimit:
+    @patch("decision_hub.api.registry_routes.has_active_tracker_for_repo", return_value=False)
+    @patch("decision_hub.api.registry_routes.find_org_by_slug")
+    @patch("decision_hub.api.registry_routes.resolve_latest_version")
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_third_request_blocked(
+        self,
+        mock_find,
+        mock_resolve,
+        mock_find_org,
+        _mock_tracker,
+        low_limit_client: TestClient,
+    ) -> None:
+        skill = MagicMock()
+        skill.description = "x"
+        skill.download_count = 0
+        skill.category = ""
+        skill.visibility = "public"
+        skill.source_repo_url = None
+        skill.manifest_path = None
+        skill.source_repo_removed = False
+        skill.github_stars = None
+        skill.github_forks = None
+        skill.github_watchers = None
+        skill.github_is_archived = None
+        skill.github_license = None
+        mock_find.return_value = skill
+
+        version = MagicMock()
+        version.semver = "1.0.0"
+        version.created_at = None
+        version.eval_status = "A"
+        version.published_by = "alice"
+        mock_resolve.return_value = version
+        mock_find_org.return_value = MagicMock(is_personal=False)
+
+        path = "/v1/skills/test-org/test-skill/summary"
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 429
+
+
+class TestLatestVersionRateLimit:
+    @patch("decision_hub.api.registry_routes.resolve_latest_version")
+    def test_third_request_blocked(self, mock_resolve, low_limit_client: TestClient) -> None:
+        version = MagicMock()
+        version.semver = "1.0.0"
+        version.checksum = "deadbeef"
+        mock_resolve.return_value = version
+
+        path = "/v1/skills/test-org/test-skill/latest-version"
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 429
+
+
+class TestEvalReportRateLimit:
+    @patch("decision_hub.api.registry_routes.find_eval_report_by_skill", return_value=None)
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_third_query_param_request_blocked(
+        self,
+        mock_find,
+        _mock_report,
+        low_limit_client: TestClient,
+    ) -> None:
+        mock_find.return_value = MagicMock()
+        path = "/v1/skills/test-org/test-skill/eval-report?semver=1.0.0"
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 200
+        assert low_limit_client.get(path).status_code == 429
+
+    @patch("decision_hub.api.registry_routes.find_eval_report_by_skill", return_value=None)
+    @patch("decision_hub.api.registry_routes.find_skill_by_slug")
+    def test_path_variant_shares_the_same_limiter(
+        self,
+        mock_find,
+        _mock_report,
+        low_limit_client: TestClient,
+    ) -> None:
+        """Both eval-report variants reuse the same limiter so two clients
+        racing across both paths still trip the cap."""
+        mock_find.return_value = MagicMock()
+        query_path = "/v1/skills/test-org/test-skill/eval-report?semver=1.0.0"
+        path_based = "/v1/skills/test-org/test-skill/versions/1.0.0/eval-report"
+        assert low_limit_client.get(query_path).status_code == 200
+        assert low_limit_client.get(path_based).status_code == 200
+        assert low_limit_client.get(query_path).status_code == 429

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -8,10 +8,12 @@ from fastapi import HTTPException
 from decision_hub.api.rate_limit import RateLimiter
 
 
-def _make_request(host: str = "127.0.0.1") -> MagicMock:
-    """Create a mock Request with a given client IP."""
+def _make_request(host: str = "127.0.0.1", method: str = "GET", path: str = "/v1/foo") -> MagicMock:
+    """Create a mock Request with a given client IP, method, and path."""
     request = MagicMock()
     request.client.host = host
+    request.method = method
+    request.url.path = path
     return request
 
 
@@ -77,6 +79,8 @@ class TestRateLimiter:
         limiter = RateLimiter(max_requests=2, window_seconds=60)
         request = MagicMock()
         request.client = None
+        request.method = "GET"
+        request.url.path = "/v1/foo"
 
         for _ in range(2):
             limiter(request)
@@ -84,3 +88,48 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_logs_warning_when_limit_exceeded(self) -> None:
+        """Rate-limit hits used to be silent 429s. Verify the limiter now
+        logs a warning with the limiter name, client IP, method, and path
+        so operators can spot scrapers in the logs."""
+        from loguru import logger
+
+        limiter = RateLimiter(max_requests=1, window_seconds=60, name="test_limiter")
+        request = _make_request(host="10.1.2.3", method="GET", path="/v1/stats")
+
+        # First request passes, second is rate-limited.
+        limiter(request)
+
+        seen: list[str] = []
+        sink_id = logger.add(lambda msg: seen.append(str(msg)), level="WARNING")
+        try:
+            with pytest.raises(HTTPException):
+                limiter(request)
+        finally:
+            logger.remove(sink_id)
+
+        # Concatenate all captured lines so the assertion isn't sensitive
+        # to loguru's formatter splitting on newlines.
+        captured = "\n".join(seen)
+        assert "rate_limit_exceeded" in captured
+        assert "test_limiter" in captured
+        assert "10.1.2.3" in captured
+        assert "/v1/stats" in captured
+
+    def test_unnamed_limiter_logs_default_name(self) -> None:
+        """When no name is provided, the warning falls back to 'rate_limiter'."""
+        from loguru import logger
+
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        request = _make_request()
+        limiter(request)
+
+        seen: list[str] = []
+        sink_id = logger.add(lambda msg: seen.append(str(msg)), level="WARNING")
+        try:
+            with pytest.raises(HTTPException):
+                limiter(request)
+        finally:
+            logger.remove(sink_id)
+        assert "rate_limiter" in "\n".join(seen)

--- a/server/tests/test_infra/test_batch_update_github.py
+++ b/server/tests/test_infra/test_batch_update_github.py
@@ -1,0 +1,145 @@
+"""Tests for the batch_update_github_* DB helpers.
+
+These functions used to issue one UPDATE per repo, an N+1 over the
+tracker resolution set. They were rewritten to a single multi-row
+UPDATE FROM (VALUES ...) statement. The tests below verify that:
+
+  * Empty input is a no-op (no DB call).
+  * Non-empty input is collapsed to exactly one ``conn.execute`` call.
+  * The compiled SQL contains the expected VALUES rows and uses
+    ``LIKE ... ESCAPE '\\'`` so repo names with ``_`` (a legitimate
+    GitHub character that is also a SQL LIKE wildcard) only match
+    themselves.
+
+The tests are pure compile checks against the PostgreSQL dialect, so
+they don't need a live database.
+"""
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from decision_hub.infra.database import (
+    batch_update_github_repo_metadata,
+    batch_update_github_stars,
+)
+
+
+def _compile(call) -> str:
+    """Render the first positional argument to a conn.execute() call as SQL."""
+    stmt = call.args[0]
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+class TestBatchUpdateGithubStars:
+    def test_empty_input_is_noop(self):
+        conn = MagicMock()
+        batch_update_github_stars(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_single_execute_for_many_repos(self):
+        """N repos should compile to ONE statement, not N statements."""
+        conn = MagicMock()
+        repo_stars = {
+            "https://github.com/foo/bar": 1,
+            "https://github.com/foo/baz": 2,
+            "https://github.com/qux/quux": 3,
+        }
+        batch_update_github_stars(conn, repo_stars)
+        assert conn.execute.call_count == 1
+
+    def test_compiled_sql_contains_all_values_rows(self):
+        conn = MagicMock()
+        repo_stars = {
+            "https://github.com/foo/bar": 7,
+            "https://github.com/foo/baz": 13,
+        }
+        batch_update_github_stars(conn, repo_stars)
+        sql = _compile(conn.execute.call_args)
+        assert "UPDATE skills" in sql
+        assert "FROM (VALUES" in sql
+        assert "https://github.com/foo/bar" in sql
+        assert "https://github.com/foo/baz" in sql
+        # Star counts appear as literal integers in the VALUES list
+        assert ", 7" in sql or ",7" in sql
+        assert ", 13" in sql or ",13" in sql
+
+    def test_like_pattern_escapes_underscore(self):
+        r"""Repo names like ``my_repo`` must not match ``myXrepo``.
+
+        Without escaping ``_`` (a LIKE wildcard meaning any single char),
+        a star update for ``foo/my_repo`` would also overwrite skills
+        sourced from ``foo/myXrepo``. The new implementation pre-escapes
+        the prefix and uses ``LIKE ... ESCAPE '\\'``.
+
+        Note: PostgreSQL's literal-binds renderer doubles every backslash
+        when emitting standard string literals, so ``\_`` in the LIKE
+        pattern appears as ``\\_`` in the compiled SQL text. The
+        important part is that the underscore is escaped at all.
+        """
+        conn = MagicMock()
+        batch_update_github_stars(conn, {"https://github.com/foo/my_repo": 99})
+        sql = _compile(conn.execute.call_args)
+        # Look for the LIKE pattern with at least one backslash before
+        # the underscore. The exact backslash count depends on the SQL
+        # string-literal escaping rules of the dialect.
+        assert "my\\_repo" in sql or "my\\\\_repo" in sql
+        assert "ESCAPE" in sql
+
+    def test_like_pattern_escapes_percent(self):
+        conn = MagicMock()
+        # ``%`` in a URL is unusual but the escape must still work.
+        batch_update_github_stars(conn, {"https://github.com/foo/100%repo": 1})
+        sql = _compile(conn.execute.call_args)
+        # ``%`` becomes ``\%`` in the LIKE pattern. Same backslash-doubling
+        # caveat as the underscore test.
+        assert "\\%" in sql or "\\\\%" in sql
+
+
+class TestBatchUpdateGithubRepoMetadata:
+    def test_empty_input_is_noop(self):
+        conn = MagicMock()
+        batch_update_github_repo_metadata(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_single_execute_for_many_repos(self):
+        conn = MagicMock()
+        repo_metadata = {
+            f"https://github.com/foo/repo-{i}": {
+                "forks": i,
+                "watchers": i * 2,
+                "is_archived": i % 2 == 0,
+                "license": "MIT",
+            }
+            for i in range(5)
+        }
+        batch_update_github_repo_metadata(conn, repo_metadata)
+        assert conn.execute.call_count == 1
+
+    def test_compiled_sql_sets_all_four_columns(self):
+        conn = MagicMock()
+        repo_metadata = {
+            "https://github.com/foo/bar": {
+                "forks": 1,
+                "watchers": 2,
+                "is_archived": True,
+                "license": "Apache-2.0",
+            }
+        }
+        batch_update_github_repo_metadata(conn, repo_metadata)
+        sql = _compile(conn.execute.call_args)
+        assert "github_forks=v.forks" in sql
+        assert "github_watchers=v.watchers" in sql
+        assert "github_is_archived=v.is_archived" in sql
+        assert "github_license=v.license" in sql
+        assert "Apache-2.0" in sql
+
+    def test_handles_missing_metadata_fields(self):
+        """Partial dicts (missing keys) should compile to NULL in the VALUES row."""
+        conn = MagicMock()
+        # Only ``forks`` provided — others should default to None.
+        batch_update_github_repo_metadata(conn, {"https://github.com/foo/bar": {"forks": 5}})
+        sql = _compile(conn.execute.call_args)
+        assert "5" in sql
+        # The other columns appear as NULL literals.
+        assert "NULL" in sql


### PR DESCRIPTION
## What changed

Audit-driven hardening pass on the server with three focused themes — closing rate-limit gaps on public GETs, collapsing the N+1 tracker resolver into a single multi-row UPDATE, and tightening SQL `LIMIT`/`ORDER BY` per CLAUDE.md.

**Rate limiting (`api/rate_limit.py`, `api/registry_routes.py`, `settings.py`)**
- Add per-IP `RateLimiter` to four previously-unprotected public GETs: `/v1/stats`, `/v1/skills/{org}/{name}/summary`, `/v1/skills/{org}/{name}/latest-version`, and both `/eval-report` variants.
- Collapse the eight near-identical `_enforce_*_rate_limit` helpers into a single `_make_rate_limit_enforcer(...)` factory; adding a new limiter is now a one-liner.
- `RateLimiter` now logs a structured warning on the 429 path (`rate_limit_exceeded limiter=… ip=… method=… path=… limit=N/Ws`). Until now hits were silent, which made scrapers invisible in the logs.
- `get_similar_skills` now passes the caller's `user_org_ids` to `find_skill_by_slug`, matching the visibility behaviour of every other detail-page endpoint.

**N+1 in the tracker resolver (`infra/database.py`)**
- `batch_update_github_stars` and `batch_update_github_repo_metadata` used to issue one `UPDATE` per repo; both are now a single `UPDATE skills SET … FROM (VALUES …) v WHERE skills.source_repo_url = v.repo_url OR skills.source_repo_url LIKE v.like_pat ESCAPE '\'` statement.
- The LIKE prefix is pre-escaped with `_escape_like`, so a star update for `foo/my_repo` no longer wildcard-overwrites skills sourced from `foo/myXrepo`.

**SQL `LIMIT`/`ORDER BY` correctness (`infra/database.py`)**
- `org_has_public_skills` (LIMIT 1 with no ORDER BY) → adds `ORDER BY skills.id`.
- `resolve_version` (LIMIT 1 on the `latest` branch) → adds `created_at DESC, id DESC` tiebreakers behind the semver triple.
- `fetch_similar_skills` → adds `skills.id` as a deterministic tiebreaker after `vec_dist`.

## Why

Found while doing a deep architect-level review of the repo (five parallel audit passes over `infra/database.py`, the CLI registry module, the domain layer, API routes/security, and the test suite). These items grouped naturally into a single "harden the public surface and the tracker hot path" change.

No linked issue — discovered during code review.

Closes #

## How to test

- `make test-server` — 949 server tests pass locally (16 new tests added: 8 for the batch-update refactor, 6 for the new rate limiters end-to-end, 2 for the rate-limit observability log).
- `make lint` and `uvx mypy client/src/ server/src/ shared/src/` are clean.
- The new `_make_rate_limit_enforcer` factory is exercised by `test_new_rate_limits.py`, which sets each per-endpoint cap to 2 and asserts the third request returns 429.
- The batch-update tests compile statements against the PostgreSQL dialect with `literal_binds=True` and assert the rendered SQL contains a single `UPDATE … FROM (VALUES …)` with escaped LIKE patterns.

## Checklist
- [x] Tests pass (`make test`)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — n/a, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_013u13AQagXURDKZMrtmwpnN)_