### PR TITLE
refactor: dedupe rate-limiter deps, harden eval-run &amp; version-delete paths

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limiter_dep("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,8 +3,39 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+
+def make_rate_limiter_dep(name: str) -> Callable[[Request], None]:
+    """Return a FastAPI dependency that enforces a named rate limit.
+
+    The limiter is lazily instantiated on ``app.state`` under
+    ``rate_limiters[name]`` on first request and re-used thereafter.
+    The corresponding settings must be present as ``settings.{name}_rate_limit``
+    and ``settings.{name}_rate_window``.
+
+    Replaces the copy-pasted ``_enforce_*_rate_limit`` factories that used
+    to live in every route module.
+    """
+
+    def _dep(request: Request) -> None:
+        state = request.app.state
+        limiters: dict[str, RateLimiter] = getattr(state, "rate_limiters", None) or {}
+        limiter = limiters.get(name)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, f"{name}_rate_limit"),
+                window_seconds=getattr(settings, f"{name}_rate_window"),
+            )
+            limiters[name] = limiter
+            state.rate_limiters = limiters
+        limiter(request)
+
+    _dep.__name__ = f"enforce_{name}_rate_limit"
+    return _dep
 
 
 class RateLimiter:

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -3,10 +3,11 @@
 import json
 import math
 import zipfile
+from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,12 +20,11 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
 from decision_hub.domain.publish import (
-    build_s3_key,
     validate_semver,
     validate_skill_name,
 )
@@ -83,88 +83,13 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_list_skills_rate_limit = make_rate_limiter_dep("list_skills")
+_enforce_resolve_rate_limit = make_rate_limiter_dep("resolve")
+_enforce_similar_skills_rate_limit = make_rate_limiter_dep("similar_skills")
+_enforce_download_rate_limit = make_rate_limiter_dep("download")
+_enforce_audit_log_rate_limit = make_rate_limiter_dep("audit_log")
+_enforce_scan_report_rate_limit = make_rate_limiter_dep("scan_report")
+_enforce_publish_rate_limit = make_rate_limiter_dep("publish")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -1054,15 +979,16 @@ def delete_skill_version(
             detail=f"Skill '{skill_name}' not found in {org_slug}",
         )
 
-    deleted = delete_version(conn, skill.id, version)
-    if not deleted:
+    # Use the DB-returned s3_key rather than reconstructing it from path
+    # params, so a future change to build_s3_key can't leave stale objects
+    # in S3 (or, worse, target the wrong key).
+    s3_key = delete_version(conn, skill.id, version)
+    if s3_key is None:
         raise HTTPException(
             status_code=404,
             detail=f"Version '{version}' not found for {org_slug}/{skill_name}",
         )
 
-    # Remove the zip from S3
-    s3_key = build_s3_key(org_slug, skill_name, version)
     delete_skill_zip(s3_client, settings.s3_bucket, s3_key)
 
     return DeleteResponse(
@@ -1097,27 +1023,40 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
-    """Check if a running eval run has a stale heartbeat (zombie).
+def _check_zombie(conn: Connection, run):
+    """Return the run, promoting it to "failed" if its heartbeat is stale.
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS while the run is in
+    an in-flight state, this marks the run as failed and returns a shallow
+    copy with the updated status/error/completed_at fields. Otherwise the
+    caller's ``run`` is returned unchanged.
+
+    Returning the object (rather than re-reading it) avoids a race where the
+    row is deleted between the update and the re-read; it also removes an
+    extra DB roundtrip per request.
     """
     if run.status not in ("running", "judging", "provisioning"):
-        return run.status
+        return run
     if run.heartbeat_at is None:
-        return run.status
-    elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
-    if elapsed > _STALE_HEARTBEAT_SECONDS:
-        update_eval_run_status(
-            conn,
-            run.id,
-            status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
-            completed_at=datetime.now(UTC),
-        )
-        return "failed"
-    return run.status
+        return run
+    now = datetime.now(UTC)
+    elapsed = (now - run.heartbeat_at).total_seconds()
+    if elapsed <= _STALE_HEARTBEAT_SECONDS:
+        return run
+    error = f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed."
+    update_eval_run_status(
+        conn,
+        run.id,
+        status="failed",
+        error_message=error,
+        completed_at=now,
+    )
+    return replace(
+        run,
+        status="failed",
+        error_message=error,
+        completed_at=now,
+    )
 
 
 @router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
@@ -1131,10 +1070,7 @@ def get_eval_run(
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
-    return _run_to_response(run)
+    return _run_to_response(_check_zombie(conn, run))
 
 
 @router.get("/eval-runs/{run_id}/logs", response_model=EvalRunLogsResponse)
@@ -1152,8 +1088,8 @@ def get_eval_run_logs(
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
 
-    # Zombie detection on read
-    effective_status = _check_zombie(conn, run)
+    # Zombie detection on read (may return an updated shallow copy)
+    run = _check_zombie(conn, run)
 
     # Fetch all S3 chunks for the run. The cursor is an event sequence number
     # (e.g. 50), not a chunk file sequence number (e.g. 3), so we can't use
@@ -1182,7 +1118,7 @@ def get_eval_run_logs(
     return EvalRunLogsResponse(
         events=all_events,
         next_cursor=max_seq,
-        run_status=effective_status,
+        run_status=run.status,
         run_stage=run.stage,
         current_case=run.current_case,
     )

--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -111,7 +111,10 @@ def run_assessment_background(
             encrypted_keys = get_api_keys_for_eval(conn, user_id, required_keys)
             conn.commit()
 
-        logger.info("Got {} API keys: {}", len(encrypted_keys), list(encrypted_keys.keys()))
+        # Log only the count -- key names can leak which third-party services
+        # a user integrates with. required_keys is already known at this scope
+        # so we can report how many of them were found.
+        logger.info("Got {}/{} API keys for eval sandbox", len(encrypted_keys), len(required_keys))
 
         fernet = Fernet(settings.fernet_key.encode())
         agent_env_vars = {name: fernet.decrypt(value).decode() for name, value in encrypted_keys.items()}

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limiter_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limiter_dep("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -262,7 +262,10 @@ def update_tracker(
     )
 
     updated = find_skill_tracker(conn, tid)
-    assert updated is not None
+    if updated is None:
+        # Only possible if another request deleted the tracker between the
+        # update and this re-read. Return 404 (matches delete/get semantics).
+        raise HTTPException(status_code=404, detail="Tracker not found")
     return _tracker_to_response(updated)
 
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1628,29 +1628,31 @@ def delete_skill(conn: Connection, skill_id: UUID) -> None:
     logger.debug("Deleted skill id={}", skill_id)
 
 
-def delete_version(conn: Connection, skill_id: UUID, semver: str) -> bool:
+def delete_version(conn: Connection, skill_id: UUID, semver: str) -> str | None:
     """Delete a specific version of a skill.
 
-    Args:
-        conn: Active database connection.
-        skill_id: UUID of the parent skill.
-        semver: Semantic version string to delete.
-
-    Returns:
-        True if a version was deleted, False if no matching version was found.
+    Returns the deleted row's ``s3_key`` so the caller can clean the S3
+    object using the DB-stored key rather than a reconstructed one (which
+    would drift if the S3 key layout ever changed). Returns ``None`` when
+    no matching version was found.
     """
-    stmt = sa.delete(versions_table).where(
-        sa.and_(
-            versions_table.c.skill_id == skill_id,
-            versions_table.c.semver == semver,
+    stmt = (
+        sa.delete(versions_table)
+        .where(
+            sa.and_(
+                versions_table.c.skill_id == skill_id,
+                versions_table.c.semver == semver,
+            )
         )
+        .returning(versions_table.c.s3_key)
     )
     result = conn.execute(stmt)
-    deleted = result.rowcount > 0
-    if deleted:
-        _refresh_skill_latest_version(conn, skill_id)
-        logger.debug("Deleted version skill={} semver={}", skill_id, semver)
-    return deleted
+    row = result.first()
+    if row is None:
+        return None
+    _refresh_skill_latest_version(conn, skill_id)
+    logger.debug("Deleted version skill={} semver={}", skill_id, semver)
+    return row.s3_key
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -94,23 +94,18 @@ class TestGetEvalRun:
         """A running eval with a heartbeat >5 min stale is marked failed."""
         stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
-
-        # find_eval_run is called twice: once before zombie check, once after
-        failed_run = _make_eval_run(
-            id=run.id,
-            status="failed",
-            error_message="Stale heartbeat",
-            heartbeat_at=stale_heartbeat,
-        )
-        mock_find_run.side_effect = [run, failed_run]
+        mock_find_run.return_value = run
 
         resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
 
+        # The response reflects the zombie-updated status without needing a
+        # second DB read (which could race a delete and return None).
         assert resp.status_code == 200
         assert resp.json()["status"] == "failed"
+        assert resp.json()["error_message"].startswith("Stale heartbeat")
+        assert mock_find_run.call_count == 1
         mock_update_status.assert_called_once()
-        call_kwargs = mock_update_status.call_args
-        assert call_kwargs.kwargs.get("status") == "failed"
+        assert mock_update_status.call_args.kwargs.get("status") == "failed"
 
     @patch("decision_hub.api.registry_routes.update_eval_run_status")
     @patch("decision_hub.api.registry_routes.find_eval_run")

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limiter_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,74 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestMakeRateLimiterDep:
+    """Unit tests for the make_rate_limiter_dep factory."""
+
+    @staticmethod
+    def _request_with_state(settings, host: str = "127.0.0.1") -> MagicMock:
+        request = MagicMock()
+        request.client.host = host
+        request.app.state = SimpleNamespace(settings=settings)
+        return request
+
+    def test_lazily_instantiates_limiter_from_settings(self) -> None:
+        """First call reads settings.{name}_rate_limit / _rate_window."""
+        settings = SimpleNamespace(demo_rate_limit=2, demo_rate_window=60)
+        dep = make_rate_limiter_dep("demo")
+        request = self._request_with_state(settings)
+
+        dep(request)  # should not raise
+        dep(request)
+        with pytest.raises(HTTPException) as exc_info:
+            dep(request)
+        assert exc_info.value.status_code == 429
+
+    def test_reuses_limiter_across_requests_on_same_app(self) -> None:
+        """The limiter is cached on app.state and shared between calls."""
+        settings = SimpleNamespace(demo_rate_limit=1, demo_rate_window=60)
+        dep = make_rate_limiter_dep("demo")
+        state = SimpleNamespace(settings=settings)
+
+        req_a = MagicMock()
+        req_a.client.host = "1.1.1.1"
+        req_a.app.state = state
+
+        req_b = MagicMock()
+        req_b.client.host = "1.1.1.1"
+        req_b.app.state = state
+
+        dep(req_a)
+        with pytest.raises(HTTPException):
+            dep(req_b)  # second call from the same IP is blocked
+
+    def test_different_names_have_isolated_counters(self) -> None:
+        """Two named limiters on the same app do not share counters."""
+        settings = SimpleNamespace(
+            a_rate_limit=1,
+            a_rate_window=60,
+            b_rate_limit=1,
+            b_rate_window=60,
+        )
+        state = SimpleNamespace(settings=settings)
+        request = MagicMock()
+        request.client.host = "127.0.0.1"
+        request.app.state = state
+
+        dep_a = make_rate_limiter_dep("a")
+        dep_b = make_rate_limiter_dep("b")
+
+        dep_a(request)
+        dep_b(request)  # b is independent; must not raise
+
+        with pytest.raises(HTTPException):
+            dep_a(request)
+
+    def test_missing_setting_raises_attribute_error(self) -> None:
+        """Typo in the name surfaces as AttributeError, not a silent no-op."""
+        settings = SimpleNamespace()
+        dep = make_rate_limiter_dep("missing")
+        request = self._request_with_state(settings)
+        with pytest.raises(AttributeError):
+            dep(request)

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -990,7 +990,7 @@ class TestDeleteSkillVersion:
         mock_find_org.return_value = org
         mock_find_member.return_value = _make_member(org, sample_user_id)
         mock_find_skill.return_value = skill
-        mock_delete_version.return_value = True
+        mock_delete_version.return_value = "skills/test-org/my-skill/1.0.0.zip"
 
         resp = client.delete(
             "/v1/skills/test-org/my-skill/1.0.0",
@@ -1003,6 +1003,8 @@ class TestDeleteSkillVersion:
         assert data["skill_name"] == "my-skill"
         assert data["version"] == "1.0.0"
         mock_delete_zip.assert_called_once()
+        # S3 delete must use the DB-returned key, not a reconstructed one.
+        assert mock_delete_zip.call_args.args[-1] == "skills/test-org/my-skill/1.0.0.zip"
 
     def test_delete_no_auth(self, client: TestClient) -> None:
         """Deleting without auth should return 401."""
@@ -1121,7 +1123,7 @@ class TestDeleteSkillVersion:
         mock_find_org.return_value = org
         mock_find_member.return_value = _make_member(org, sample_user_id)
         mock_find_skill.return_value = skill
-        mock_delete_version.return_value = False
+        mock_delete_version.return_value = None
 
         resp = client.delete(
             "/v1/skills/test-org/my-skill/9.9.9",
@@ -1157,7 +1159,7 @@ class TestDeleteSkillVersion:
             role="admin",
         )
         mock_find_skill.return_value = skill
-        mock_delete_version.return_value = True
+        mock_delete_version.return_value = "skills/test-org/my-skill/1.0.0.zip"
 
         resp = client.delete(
             "/v1/skills/test-org/my-skill/1.0.0",


### PR DESCRIPTION
## What changed

A codebase-wide audit surfaced a mix of small correctness bugs, a copy-paste hotspot, one info-leak in logging, and a robustness issue around S3 key reconstruction. Bundling them here because they touch overlapping files (`registry_routes.py`, `rate_limit.py`, `database.py`) and share the theme "tighten existing behaviour without changing external contracts."

Highlights:
- **Rate-limiter dedup** — 9 near-identical `_enforce_*_rate_limit` factories (~80 LOC of copy-paste across `registry_routes.py`, `search_routes.py`, `auth_routes.py`) collapse into a single `make_rate_limiter_dep(name)` helper in `api/rate_limit.py`. Each site becomes one line. Limiters now live in a single `app.state.rate_limiters` dict instead of scattered `_<name>_rate_limiter` attributes.
- **Bug: unsafe re-read after eval-run zombie promotion** — `_check_zombie()` used to `update ... then re-`find_eval_run()`; if the second read returned `None` (row deleted, or transient blip) the result flowed straight into `_run_to_response(None)` and 500'd with `AttributeError`. Now returns a `dataclasses.replace()`d copy of the run with updated status/error/completed_at — no second query, no race.
- **Bug: `assert updated is not None` in tracker update** — fails ungracefully under `-O` and 500s the request when the natural response is 404. Replaced with an explicit `HTTPException(404)`, matching the neighbouring get/delete semantics.
- **Security: don't log user API-key names** — `registry_service.py` logged the list of key names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, …), leaking which third-party services a user integrates with. Now logs only counts.
- **Robustness: delete version by DB-stored s3_key** — the delete-version endpoint reconstructed the S3 key from URL params via `build_s3_key(...)`. If the key layout ever changes, live objects would be orphaned. `delete_version` now uses SQL `RETURNING s3_key`; the endpoint hands that verbatim to `delete_skill_zip`. The two other callers (crawler and publish-pipeline rollback) already ignored the return value, so the signature change is source-compatible.

## Why

Findings from a two-pass codebase review (architecture + code-health, correctness, security, performance/reliability, and testing/observability). Fixes were picked for high leverage (dedup + real bugs + one info-leak) and safety (no external API changes, tests updated in the same commit).

No linked issue — internal audit sweep.

## How to test

- `uv run --package decision-hub-server --extra dev pytest server/tests/ -m "not slow"` — 937 pass (was 933; added 4 in `test_rate_limit.py`).
- `uv run --package dhub-core --extra dev pytest shared/tests/` — 98 pass.
- `uv run --package dhub-cli --extra dev pytest client/tests/` — 291 pass.
- `uvx ruff@0.15.3 check . && uvx ruff@0.15.3 format --check .` — clean.
- `uvx mypy client/src/ server/src/ shared/src/` — no issues (88 source files).

New/updated test cases worth eyeballing:
- `TestMakeRateLimiterDep` in `server/tests/test_api/test_rate_limit.py` — covers lazy init, cross-request reuse, name isolation, and typo detection.
- `test_zombie_detection_marks_stale_run_as_failed` in `server/tests/test_api/test_eval_logs.py` — now asserts a single `find_eval_run` call (proving the racy re-read is gone) and that `error_message` propagates back through the response.
- `test_delete_success` in `server/tests/test_api/test_registry_routes.py` — asserts `delete_skill_zip` receives the DB-returned key rather than a reconstructed one.

## Checklist
- [x] Tests pass (`make test` — server / shared / client)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — n/a, no schema change

## Audit follow-ups deferred to future PRs

The audit surfaced more than fit cleanly in one PR. Batched for later:

1. Split monster files (`infra/database.py` 3.4K LOC, CLI `registry.py` 1.9K LOC, `registry_routes.py` 1.3K LOC).
2. Invert `domain/ -> infra/` imports in `gauntlet.py`, `publish_pipeline.py`, `evals.py`, `tracker_service.py`.
3. Consolidate the 7 `_build_*_fn` factories in `publish_pipeline.py` into one parameterised builder.
4. Extract shared pagination helpers used across audit-log, skills-list, evals-list endpoints.
5. Base `SkillResponse` model to compose the 26 route response classes in `registry_routes.py`.
6. Consider a composite index on `eval_audit_logs (org_slug, skill_name, created_at DESC)` — the current audit-log endpoint scans that table.
7. Add tests for `api/seo_routes.py` (sitemap/robots cache and hostname branching), `infra/cache.py` edge cases, and Modal fan-out timeout fallback in `tracker_service.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_018nEdL44b6VrEb3s5N2xUiC)_