### PR TITLE
refactor(server): consolidate rate-limiter, gemini callbacks, and eval-run zombie check

### DIFF
--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = make_rate_limit_dep("auth", "auth_rate_limit", "auth_rate_window")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,6 +3,7 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
 
@@ -26,11 +27,18 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # Purge stale IPs every N successful admissions.  Amortises the O(n)
+    # scan across many requests while keeping memory growth bounded.
+    _PURGE_INTERVAL = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        # Count of admissions since the last purge.  Cheap O(1) counter
+        # instead of the previous O(n) sum() over every tracked IP.
+        self._admissions_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -53,13 +61,53 @@ class RateLimiter:
             self._requests[key].append(now)
 
             # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._admissions_since_purge += 1
+            if self._admissions_since_purge >= self._PURGE_INTERVAL:
                 self._purge_stale(cutoff)
+                self._admissions_since_purge = 0
 
     def _purge_stale(self, cutoff: float) -> None:
         """Remove IPs with no recent activity. Caller must hold self._lock."""
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def make_rate_limit_dep(name: str, limit_attr: str, window_attr: str) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that lazily initialises a per-route rate limiter.
+
+    The pattern of "check ``app.state`` for a cached limiter, otherwise
+    construct one from a pair of settings" was previously duplicated in
+    nine ``_enforce_*_rate_limit`` helpers across the routers.  This
+    factory captures the pattern in one place.
+
+    Args:
+        name: Distinguishing suffix for the ``app.state`` cache attribute
+            (e.g. ``"search"``, ``"publish"``, ``"list_skills"``).  Two
+            dependencies with the same *name* share the same limiter
+            instance, so pick a unique value per route family.
+        limit_attr: Name of the ``Settings`` field holding the max-request
+            count for the window (e.g. ``"search_rate_limit"``).
+        window_attr: Name of the ``Settings`` field holding the window in
+            seconds (e.g. ``"search_rate_window"``).
+
+    Returns:
+        A callable suitable for use with ``fastapi.Depends``.
+    """
+    cache_attr = f"_{name}_rate_limiter"
+
+    def dependency(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, cache_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, cache_attr, limiter)
+        limiter(request)
+
+    dependency.__name__ = f"enforce_{name}_rate_limit"
+    dependency.__qualname__ = dependency.__name__
+    return dependency

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,22 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate-limit dependencies for every public endpoint on this router.  Each
+# limiter is lazily instantiated on ``app.state`` the first time its
+# dependency runs; see ``make_rate_limit_dep`` for details.
+_enforce_list_skills_rate_limit = make_rate_limit_dep(
+    "list_skills", "list_skills_rate_limit", "list_skills_rate_window"
+)
+_enforce_resolve_rate_limit = make_rate_limit_dep("resolve", "resolve_rate_limit", "resolve_rate_window")
+_enforce_similar_skills_rate_limit = make_rate_limit_dep(
+    "similar_skills", "similar_skills_rate_limit", "similar_skills_rate_window"
+)
+_enforce_download_rate_limit = make_rate_limit_dep("download", "download_rate_limit", "download_rate_window")
+_enforce_audit_log_rate_limit = make_rate_limit_dep("audit_log", "audit_log_rate_limit", "audit_log_rate_window")
+_enforce_scan_report_rate_limit = make_rate_limit_dep(
+    "scan_report", "scan_report_rate_limit", "scan_report_rate_window"
+)
+_enforce_publish_rate_limit = make_rate_limit_dep("publish", "publish_rate_limit", "publish_rate_window")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -1097,27 +1031,38 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
-    """Check if a running eval run has a stale heartbeat (zombie).
+def _check_zombie(conn: Connection, run):
+    """Fail a stale eval run and return an updated in-memory copy.
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    A run is a "zombie" when its worker last checked in more than
+    ``_STALE_HEARTBEAT_SECONDS`` ago while still in an active status.
+    We flip the row to ``failed`` inline so a stuck run doesn't stay
+    ``running`` in the UI forever.
+
+    Returns the ``EvalRun`` reflecting the current state — the same
+    instance when no transition happened, otherwise a copy with the
+    new status/completed_at/error_message applied.  Returning the
+    updated model lets callers skip a second ``find_eval_run`` round
+    trip when they need the fresh values.
     """
-    if run.status not in ("running", "judging", "provisioning"):
-        return run.status
-    if run.heartbeat_at is None:
-        return run.status
+    if run.status not in ("running", "judging", "provisioning") or run.heartbeat_at is None:
+        return run
     elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
-    if elapsed > _STALE_HEARTBEAT_SECONDS:
-        update_eval_run_status(
-            conn,
-            run.id,
-            status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
-            completed_at=datetime.now(UTC),
-        )
-        return "failed"
-    return run.status
+    if elapsed <= _STALE_HEARTBEAT_SECONDS:
+        return run
+
+    now = datetime.now(UTC)
+    error_message = f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed."
+    update_eval_run_status(
+        conn,
+        run.id,
+        status="failed",
+        error_message=error_message,
+        completed_at=now,
+    )
+    from dataclasses import replace
+
+    return replace(run, status="failed", error_message=error_message, completed_at=now)
 
 
 @router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
@@ -1131,9 +1076,7 @@ def get_eval_run(
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
+    run = _check_zombie(conn, run)
     return _run_to_response(run)
 
 
@@ -1152,8 +1095,10 @@ def get_eval_run_logs(
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
 
-    # Zombie detection on read
-    effective_status = _check_zombie(conn, run)
+    # Zombie detection on read.  ``_check_zombie`` returns a possibly-updated
+    # run so we don't re-fetch the row when the heartbeat was stale.
+    run = _check_zombie(conn, run)
+    effective_status = run.status
 
     # Fetch all S3 chunks for the run. The cursor is an event sequence number
     # (e.g. 50), not a chunk file sequence number (e.g. 3), so we can't use

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import make_rate_limit_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = make_rate_limit_dep("search", "search_rate_limit", "search_rate_window")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/domain/publish_pipeline.py
+++ b/server/src/decision_hub/domain/publish_pipeline.py
@@ -171,110 +171,64 @@ def parse_manifest_from_content(
 # ---------------------------------------------------------------------------
 
 
-def _build_analyze_fn(settings: Settings, gemini: dict | None = None):
-    """Build a Gemini analyze callback if google_api_key is configured."""
+def _build_gemini_callback(gemini_fn, settings: Settings, gemini: dict | None):
+    """Build a fail-open callback that forwards to ``gemini_fn``.
+
+    Returns a closure that calls ``gemini_fn(client, *args, model=settings.gemini_model)``
+    where ``client`` is either the shared ``gemini`` dict (so one HTTP client
+    is reused across every gauntlet stage) or a freshly built one.  Returns
+    ``None`` when no ``google_api_key`` is configured — callers treat ``None``
+    as "LLM stage disabled" and fall back to static checks only.
+
+    All five per-stage factories below (analyze/prompt/review body/review
+    code/credential) previously duplicated this scaffolding.
+    """
     if not settings.google_api_key:
         return None
 
-    from decision_hub.infra.gemini import analyze_code_safety, create_gemini_client
+    from decision_hub.infra.gemini import create_gemini_client
 
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
+    client = gemini or create_gemini_client(settings.google_api_key)
 
-    def analyze_fn(snippets, source_files, skill_name, skill_description):
-        return analyze_code_safety(
-            gemini_client,
-            snippets,
-            source_files,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
+    def callback(*args, **kwargs):
+        return gemini_fn(client, *args, model=settings.gemini_model, **kwargs)
 
-    return analyze_fn
+    return callback
+
+
+def _build_analyze_fn(settings: Settings, gemini: dict | None = None):
+    """Build a Gemini analyze callback if google_api_key is configured."""
+    from decision_hub.infra.gemini import analyze_code_safety
+
+    return _build_gemini_callback(analyze_code_safety, settings, gemini)
 
 
 def _build_analyze_prompt_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini prompt analyze callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
+    from decision_hub.infra.gemini import analyze_prompt_safety
 
-    from decision_hub.infra.gemini import analyze_prompt_safety, create_gemini_client
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def analyze_prompt_fn(prompt_hits, skill_name, skill_description):
-        return analyze_prompt_safety(
-            gemini_client,
-            prompt_hits,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return analyze_prompt_fn
+    return _build_gemini_callback(analyze_prompt_safety, settings, gemini)
 
 
 def _build_review_body_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini holistic body review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
+    from decision_hub.infra.gemini import review_prompt_body_safety
 
-    from decision_hub.infra.gemini import create_gemini_client, review_prompt_body_safety
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def review_body_fn(body, skill_name, skill_description):
-        return review_prompt_body_safety(
-            gemini_client,
-            body,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return review_body_fn
+    return _build_gemini_callback(review_prompt_body_safety, settings, gemini)
 
 
 def _build_review_code_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini holistic code review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
+    from decision_hub.infra.gemini import review_code_body_safety
 
-    from decision_hub.infra.gemini import create_gemini_client, review_code_body_safety
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def review_code_fn(source_files, skill_name, skill_description):
-        return review_code_body_safety(
-            gemini_client,
-            source_files,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return review_code_fn
+    return _build_gemini_callback(review_code_body_safety, settings, gemini)
 
 
 def _build_analyze_credential_fn(settings: Settings, gemini: dict | None = None):
     """Build a Gemini credential entropy review callback if google_api_key is configured."""
-    if not settings.google_api_key:
-        return None
+    from decision_hub.infra.gemini import analyze_credential_entropy
 
-    from decision_hub.infra.gemini import analyze_credential_entropy, create_gemini_client
-
-    gemini_client = gemini or create_gemini_client(settings.google_api_key)
-
-    def analyze_credential_fn(entropy_hits, skill_name, skill_description):
-        return analyze_credential_entropy(
-            gemini_client,
-            entropy_hits,
-            skill_name,
-            skill_description,
-            model=settings.gemini_model,
-        )
-
-    return analyze_credential_fn
+    return _build_gemini_callback(analyze_credential_entropy, settings, gemini)
 
 
 def run_gauntlet_pipeline(

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -95,19 +95,15 @@ class TestGetEvalRun:
         stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
         run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
 
-        # find_eval_run is called twice: once before zombie check, once after
-        failed_run = _make_eval_run(
-            id=run.id,
-            status="failed",
-            error_message="Stale heartbeat",
-            heartbeat_at=stale_heartbeat,
-        )
-        mock_find_run.side_effect = [run, failed_run]
+        # ``_check_zombie`` synthesizes an updated EvalRun from the DB row
+        # after issuing the UPDATE, so ``find_eval_run`` is only called once.
+        mock_find_run.return_value = run
 
         resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "failed"
+        assert mock_find_run.call_count == 1
         mock_update_status.assert_called_once()
         call_kwargs = mock_update_status.call_args
         assert call_kwargs.kwargs.get("status") == "failed"

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, make_rate_limit_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,105 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_purge_stale_runs_periodically(self) -> None:
+        """After PURGE_INTERVAL admissions, stale IPs are dropped.
+
+        We admit ``_PURGE_INTERVAL`` distinct IPs, each two minutes after
+        the previous, so every IP except the current one is stale relative
+        to the 60-second window.  After the interval boundary trips, only
+        the most-recent IP should remain in the tracker.
+        """
+        limiter = RateLimiter(max_requests=1000, window_seconds=60)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            base = 1_000.0
+            for i in range(RateLimiter._PURGE_INTERVAL):
+                mock_time.monotonic.return_value = base + i * 120
+                req = _make_request(f"10.0.0.{i}")
+                limiter(req)
+
+        # Only the most recently admitted IP still has a live timestamp.
+        assert set(limiter._requests) == {f"10.0.0.{RateLimiter._PURGE_INTERVAL - 1}"}
+        assert limiter._admissions_since_purge == 0
+
+    def test_purge_counter_survives_blocks(self) -> None:
+        """Requests that raise 429 should NOT tick the purge counter forward.
+
+        Regression: the old implementation used ``sum(len(v))`` after every
+        admission, and blocked requests still contributed to the counter via
+        the pre-append length.  The current counter increments only on
+        successful admission.
+        """
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        req = _make_request("10.0.0.1")
+
+        limiter(req)  # 1 admission -> counter = 1
+        for _ in range(50):
+            with pytest.raises(HTTPException):
+                limiter(req)  # blocked -> counter stays 1
+
+        assert limiter._admissions_since_purge == 1
+
+
+class TestMakeRateLimitDep:
+    """Unit tests for the make_rate_limit_dep FastAPI-dependency factory."""
+
+    def _make_request_with_settings(self, host: str = "127.0.0.1", **settings_kwargs) -> MagicMock:
+        """Build a mock Request whose ``request.app.state`` mirrors runtime state."""
+        request = MagicMock()
+        request.client.host = host
+        request.app.state = SimpleNamespace(settings=SimpleNamespace(**settings_kwargs))
+        return request
+
+    def test_lazy_initialises_limiter_on_first_call(self) -> None:
+        """The limiter should be constructed only on first invocation."""
+        dep = make_rate_limit_dep("demo", "demo_limit", "demo_window")
+        request = self._make_request_with_settings(demo_limit=5, demo_window=60)
+
+        assert not hasattr(request.app.state, "_demo_rate_limiter")
+        dep(request)
+        limiter = request.app.state._demo_rate_limiter
+        assert isinstance(limiter, RateLimiter)
+        assert limiter.max_requests == 5
+        assert limiter.window_seconds == 60
+
+    def test_reuses_cached_limiter_across_calls(self) -> None:
+        """Subsequent calls must reuse the cached limiter instance."""
+        dep = make_rate_limit_dep("demo", "demo_limit", "demo_window")
+        request = self._make_request_with_settings(demo_limit=5, demo_window=60)
+
+        dep(request)
+        first = request.app.state._demo_rate_limiter
+        dep(request)
+        second = request.app.state._demo_rate_limiter
+        assert first is second
+
+    def test_distinct_names_get_distinct_limiters(self) -> None:
+        """Two dependencies with different ``name`` values do not share state."""
+        dep_a = make_rate_limit_dep("a", "a_limit", "a_window")
+        dep_b = make_rate_limit_dep("b", "b_limit", "b_window")
+        state = SimpleNamespace(
+            settings=SimpleNamespace(a_limit=1, a_window=60, b_limit=100, b_window=60),
+        )
+        req_a = MagicMock()
+        req_a.client.host = "10.0.0.1"
+        req_a.app.state = state
+        req_b = MagicMock()
+        req_b.client.host = "10.0.0.1"
+        req_b.app.state = state
+
+        # Exhaust A's tiny budget; B must still admit because the limiter is
+        # keyed by name, not by settings values.
+        dep_a(req_a)
+        with pytest.raises(HTTPException):
+            dep_a(req_a)
+        dep_b(req_b)  # should not raise
+
+    def test_raises_when_settings_missing_attribute(self) -> None:
+        """A misconfigured attribute name surfaces as an AttributeError, not a silent zero."""
+        dep = make_rate_limit_dep("demo", "does_not_exist", "also_missing")
+        request = self._make_request_with_settings()
+
+        with pytest.raises(AttributeError):
+            dep(request)


### PR DESCRIPTION
## What changed

Four small, self-contained server refactors from a deep codebase review — no behaviour change, ~40 net LOC removed, four correctness/perf smells cleaned up.

- **`api/rate_limit.py`** — new `make_rate_limit_dep(name, limit_attr, window_attr)` factory replaces nine copy-pasted `_enforce_*_rate_limit` helpers across `registry_routes.py`, `search_routes.py`, and `auth_routes.py`.
- **`api/rate_limit.py`** — O(n)-per-request `sum(len(v) for v in self._requests.values())` in `RateLimiter.__call__` replaced with an O(1) admissions counter; purge fires deterministically every `_PURGE_INTERVAL` (100) admissions instead of when the running total modulo happens to hit 100.
- **`domain/publish_pipeline.py`** — five near-identical `_build_*_fn` Gemini-callback factories collapse behind one `_build_gemini_callback` helper (~80 LOC removed). The five factory names are preserved because tests monkey-patch them and `registry_service` re-exports them.
- **`api/registry_routes.py`** — `_check_zombie` now returns the (possibly-updated) `EvalRun` in memory via `dataclasses.replace`, so `get_eval_run` and `get_eval_run_logs` no longer re-issue a `find_eval_run` immediately after the status flip. DB writes are unchanged.

Unused `Request` / `RateLimiter` imports pruned where the extractions left them dangling.

## Why

Follow-up from a codebase review. These are the highest-leverage low-risk items:
- The nine rate-limit helpers were the single largest source of copy-paste in the router layer.
- The rate limiter's per-request O(n) counter is a hot-path smell that scales badly on a serverless container with many transient IPs.
- The five Gemini factories differ only in a function reference; the duplication is pure scaffolding.
- The zombie-check double-read pattern doubles the read pressure on `eval_runs` during CLI log tailing.

No linked issue; no schema change.

Closes #

## How to test

- `uv run --package decision-hub-server --extra dev pytest server/tests -q -m "not slow"` — all 939 non-slow server tests pass locally (232 API + 450 domain + 257 infra/settings/scripts).
- `uv run --package dhub-cli --extra dev pytest client/tests -q` — 291 pass, 29 skipped.
- `uv run --package dhub-core --extra dev pytest shared/tests -q` — 98 pass.
- `uvx ruff@0.15.3 check .` and `uvx ruff@0.15.3 format --check .` — clean.
- `uvx mypy` on touched files — no issues.

New / updated coverage:
- `test_rate_limit.py::TestMakeRateLimitDep` — 4 tests for the new factory (lazy init, cache reuse, name isolation, missing-attribute error).
- `test_rate_limit.py::TestRateLimiter::test_purge_stale_runs_periodically` — asserts the counter triggers a purge at exactly `_PURGE_INTERVAL` admissions.
- `test_rate_limit.py::TestRateLimiter::test_purge_counter_survives_blocks` — regression: 429s must not tick the purge counter (previously they contributed to the O(n) sum).
- `test_eval_logs.py::test_zombie_detection_marks_stale_run_as_failed` — updated to assert exactly one `find_eval_run` call.

## Checklist
- [x] Tests pass (`make test`)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — n/a

---

Also captured while doing this review (not in this PR — flagged for follow-up):
- `database.py` (3,465 LOC) split into `db/tables.py` + per-domain query modules; move `_apply_visibility_filter` to a services layer.
- `registry_routes.py` (1,352 LOC) split into `schemas.py` + `eval_runs_routes.py` + `access_routes.py`.
- False "batch" helpers in `database.py` — `batch_update_github_stars`, `mark_skills_source_removed`, etc. loop and issue one UPDATE per URL.
- `storage.py` `list_objects_v2` calls silently truncate at 1000 keys; `get_eval_run_logs` fetches ALL S3 chunks per poll.
- `test_publish_pipeline.py` doesn't exist — `execute_publish` (848 LOC) has no dedicated test.
- JWT expiry 1 year with no revocation and no per-request DB check (`settings.py:29`).
- Rate limits are per Modal container; bypassable at scale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq2zrnvWgdiMAyGK3QQsGS)_