### PR TITLE
fix: harden search, evals and external clients (deep-review sweep)

### DIFF
--- a/server/src/decision_hub/api/org_routes.py
+++ b/server/src/decision_hub/api/org_routes.py
@@ -167,10 +167,14 @@ def get_org_stats(
     if ttl:
         response.headers["Cache-Control"] = f"public, max-age={ttl}"
 
-    cache_key = f"org_stats:{search}:{type_filter}:{sort}:{sort_dir}"
-    cached = cache.get(cache_key)
-    if cached is not None:
-        return cached
+    # Only cache the fixed filter matrix. Embedding an arbitrary user
+    # `search` string in the cache key lets an attacker sending random
+    # queries evict genuine hot entries from the bounded TTLCache.
+    cache_key = f"org_stats::{type_filter}:{sort}:{sort_dir}" if not search else None
+    if cache_key is not None:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
 
     rows = fetch_org_stats(conn, search=search, type_filter=type_filter, sort=sort, sort_dir=sort_dir)
     items = [
@@ -185,7 +189,7 @@ def get_org_stats(
         for row in rows
     ]
     result = OrgStatsResponse(items=items)
-    if ttl:
+    if cache_key is not None and ttl:
         cache.set(cache_key, result, ttl=ttl)
     return result
 

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -1194,13 +1194,34 @@ def list_eval_runs(
     conn: Connection = Depends(get_connection),
     current_user: User = Depends(get_current_user),
 ) -> list[EvalRunResponse]:
-    """List eval runs, optionally filtered by version ID."""
+    """List eval runs, optionally filtered by version ID.
+
+    Applies the same zombie-heartbeat detection as the single-run endpoints
+    so a crashed worker's run does not appear "running" indefinitely in the
+    "My Runs" list. Runs whose heartbeat has gone stale are updated in-DB
+    and returned with status="failed".
+    """
     if version_id is not None:
         parsed_vid = _parse_uuid(version_id, "version_id")
         runs = find_eval_runs_for_version(conn, parsed_vid)
         runs = [r for r in runs if r.user_id == current_user.id]
     else:
         runs = find_active_eval_runs_for_user(conn, current_user.id)
+
+    updated_any = False
+    for r in runs:
+        new_status = _check_zombie(conn, r)
+        if new_status != r.status:
+            updated_any = True
+    if updated_any:
+        # Re-read so response reflects the failed status without threading
+        # mutations back through the frozen model.
+        if version_id is not None:
+            runs = find_eval_runs_for_version(conn, parsed_vid)
+            runs = [r for r in runs if r.user_id == current_user.id]
+        else:
+            runs = find_active_eval_runs_for_user(conn, current_user.id)
+
     return [_run_to_response(r) for r in runs]
 
 

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import httpx
+
 if TYPE_CHECKING:
     from decision_hub.infra.github_client import GitHubClient
 
@@ -52,6 +54,10 @@ def _verify_repos_removed(
     GraphQL returning null for a repo does NOT reliably mean the repo is
     deleted — it can also mean renamed, transient outage, or permission gap.
     A REST GET returning 404 is a much stronger signal.
+
+    Transient httpx errors (timeouts, connection resets) fail *safe*: we
+    treat them as "still exists" so a network blip does not silently mark
+    live skills as removed.
     """
     if not candidate_urls:
         return []
@@ -62,7 +68,15 @@ def _verify_repos_removed(
         except ValueError:
             logger.warning("Skipping invalid URL during removal verification: {}", url)
             continue
-        resp = gh.get(f"/repos/{owner}/{repo}")
+        try:
+            resp = gh.get(f"/repos/{owner}/{repo}")
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "REST check for {} failed transiently ({}); treating as still-exists",
+                url,
+                exc.__class__.__name__,
+            )
+            continue
         if resp.status_code == 404:
             verified.append(url)
         else:

--- a/server/src/decision_hub/infra/anthropic_client.py
+++ b/server/src/decision_hub/infra/anthropic_client.py
@@ -5,11 +5,19 @@ avoiding a heavy SDK dependency.
 """
 
 import json
+import random
+import time
 
 import httpx
 from loguru import logger
 
 _ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+
+# Retriable server / rate-limit statuses. A single flaky 429/502 on a
+# gauntlet case used to fail the whole judgement.
+_RETRIABLE_STATUS_CODES = {429, 500, 502, 503, 529}
+_JUDGE_MAX_RETRIES = 3
+_JUDGE_TIMEOUT_SECONDS = 60
 
 _JUDGE_SYSTEM_PROMPT = """You are an evaluation judge for AI agent skill tests.
 
@@ -61,12 +69,7 @@ def judge_eval_output(
     }
 
     logger.debug("Calling Anthropic judge API model={} case={}", model, eval_case_name)
-    response = httpx.post(
-        _ANTHROPIC_API_URL,
-        json=payload,
-        headers=headers,
-        timeout=60,
-    )
+    response = _post_with_retry(payload, headers, eval_case_name)
     response.raise_for_status()
 
     data = response.json()
@@ -75,6 +78,59 @@ def judge_eval_output(
     result = _parse_judge_response(raw_text)
     logger.debug("Judge verdict for '{}': {}", eval_case_name, result["verdict"])
     return result
+
+
+def _post_with_retry(payload: dict, headers: dict, eval_case_name: str) -> httpx.Response:
+    """POST to the Anthropic API with exponential backoff on transient errors.
+
+    Mirrors the behaviour of ``gemini_request_with_retry``: retry on 429/5xx
+    and on ``httpx.TimeoutException`` up to ``_JUDGE_MAX_RETRIES`` times with
+    jittered exponential backoff. Non-retriable errors (4xx auth/validation)
+    return the response immediately so the caller can raise_for_status.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1 + _JUDGE_MAX_RETRIES):
+        try:
+            resp = httpx.post(
+                _ANTHROPIC_API_URL,
+                json=payload,
+                headers=headers,
+                timeout=_JUDGE_TIMEOUT_SECONDS,
+            )
+        except httpx.TimeoutException as exc:
+            last_exc = exc
+            if attempt >= _JUDGE_MAX_RETRIES:
+                raise
+            delay = 2**attempt + random.uniform(0, 0.5)
+            logger.warning(
+                "Anthropic judge timeout for '{}', retrying in {:.1f}s (attempt {}/{})",
+                eval_case_name,
+                delay,
+                attempt + 1,
+                _JUDGE_MAX_RETRIES,
+            )
+            time.sleep(delay)
+            continue
+
+        if resp.status_code < 400 or resp.status_code not in _RETRIABLE_STATUS_CODES:
+            return resp
+
+        if attempt >= _JUDGE_MAX_RETRIES:
+            return resp
+        delay = 2**attempt + random.uniform(0, 0.5)
+        logger.warning(
+            "Anthropic judge returned {} for '{}', retrying in {:.1f}s (attempt {}/{})",
+            resp.status_code,
+            eval_case_name,
+            delay,
+            attempt + 1,
+            _JUDGE_MAX_RETRIES,
+        )
+        time.sleep(delay)
+
+    # The loop always returns or raises before reaching here; this line
+    # exists to satisfy the type checker on unreachable paths.
+    raise last_exc if last_exc else RuntimeError("Anthropic judge retry loop exited unexpectedly")
 
 
 def _parse_judge_response(raw_text: str) -> dict:

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2040,7 +2040,9 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # `id` tiebreaker so LIMIT is deterministic across ties in ts_rank_cd
+        # (zero-rank keyword misses, identical documents).
+        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC"), skills_table.c.id.desc()).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2054,9 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        # `id` tiebreaker so LIMIT is deterministic across identical embeddings
+        # (forks, duplicate content).
+        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC"), skills_table.c.id.desc()).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2091,22 +2095,24 @@ def fetch_similar_skills(
 
     Returns an empty list if the skill has no stored embedding.
     Excludes the queried skill itself from results.
+
+    Runs as a single CTE so the source-embedding lookup and the neighbour
+    search happen in one round-trip.
     """
-    emb_stmt = (
-        sa.select(skills_table.c.embedding)
+    source_cte = (
+        sa.select(skills_table.c.embedding.label("embedding"))
         .select_from(skills_table.join(organizations_table, skills_table.c.org_id == organizations_table.c.id))
         .where(
             organizations_table.c.slug == org_slug,
             skills_table.c.name == skill_name,
             skills_table.c.latest_semver.isnot(None),
             skills_table.c.visibility == "public",
+            skills_table.c.embedding.isnot(None),
         )
+        .limit(1)
+        .cte("source_embedding")
     )
-    row = conn.execute(emb_stmt).first()
-    if row is None or row.embedding is None:
-        return []
-
-    source_embedding = row.embedding
+    source_embedding = sa.select(source_cte.c.embedding).scalar_subquery()
 
     vec_stmt = (
         sa.select(
@@ -2115,6 +2121,7 @@ def fetch_similar_skills(
         )
         .select_from(skills_table.join(organizations_table, skills_table.c.org_id == organizations_table.c.id))
         .where(
+            source_cte.c.embedding.isnot(None),
             skills_table.c.latest_semver.isnot(None),
             skills_table.c.embedding.isnot(None),
             skills_table.c.visibility == "public",
@@ -2125,7 +2132,9 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        # `id` tiebreaker keeps LIMIT deterministic when multiple skills share
+        # the same cosine distance (forks, near-duplicates).
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id.desc())
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2723,8 +2732,10 @@ def find_active_eval_runs_for_user(conn: Connection, user_id: UUID, limit: int =
     """Find recent eval runs for a user, newest first."""
     stmt = (
         sa.select(eval_runs_table)
+        # `id` tiebreaker so parallel `dhub publish` invocations that create
+        # runs in the same millisecond order deterministically across polls.
         .where(eval_runs_table.c.user_id == user_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
         .limit(limit)
     )
     rows = conn.execute(stmt).all()
@@ -3067,18 +3078,21 @@ def batch_increment_permanent_failures(
     """Increment consecutive_permanent_failures and return IDs that reached the threshold.
 
     Trackers already at or above the threshold are included in the returned list
-    but their counter is not incremented further.
+    but their counter is not incremented further — the WHERE clause on the
+    UPDATE enforces this so the counter cannot climb unbounded when a disabled
+    tracker is repeatedly retried.
     """
     if not tracker_ids:
         return []
-    # Increment counter
     stmt = (
         sa.update(skill_trackers_table)
-        .where(skill_trackers_table.c.id.in_(tracker_ids))
+        .where(
+            skill_trackers_table.c.id.in_(tracker_ids),
+            skill_trackers_table.c.consecutive_permanent_failures < threshold,
+        )
         .values(consecutive_permanent_failures=skill_trackers_table.c.consecutive_permanent_failures + 1)
     )
     conn.execute(stmt)
-    # Return IDs that have now crossed the threshold
     stmt = sa.select(skill_trackers_table.c.id).where(
         skill_trackers_table.c.id.in_(tracker_ids),
         skill_trackers_table.c.consecutive_permanent_failures >= threshold,
@@ -3249,7 +3263,13 @@ def insert_tracker_metrics(
 
 def list_tracker_metrics(conn: Connection, *, limit: int = 50) -> list[TrackerMetrics]:
     """Return recent tracker metrics rows, newest first."""
-    stmt = sa.select(tracker_metrics_table).order_by(tracker_metrics_table.c.recorded_at.desc()).limit(limit)
+    stmt = (
+        sa.select(tracker_metrics_table)
+        # `id` tiebreaker so pagination stays stable when multiple metrics
+        # rows share `recorded_at` (possible under high fan-out).
+        .order_by(tracker_metrics_table.c.recorded_at.desc(), tracker_metrics_table.c.id.desc())
+        .limit(limit)
+    )
     rows = conn.execute(stmt).all()
     return [_row_to_tracker_metrics(row) for row in rows]
 

--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -62,7 +62,27 @@ def create_gemini_client(api_key: str, *, http_client: httpx.Client | None = Non
     }
 
 
-_RETRIABLE_STATUS_CODES = {403, 429, 500, 502, 503}
+# 403 is intentionally *not* in this set. Gemini returns 403 for both
+# quota-exceeded and invalid-API-key errors; retrying an auth failure wastes
+# ~7 seconds per gauntlet stage on a misconfigured or rotated key. When 403
+# does mean quota, ``_is_retriable_403`` below adds it back based on the
+# response body.
+_RETRIABLE_STATUS_CODES = {429, 500, 502, 503}
+
+
+def _is_retriable_403(resp: httpx.Response) -> bool:
+    """Return True if a 403 response looks like a quota/rate-limit failure.
+
+    Gemini surfaces quota errors as 403 with the error message mentioning
+    "quota", "rate", or "resource has been exhausted". Authentication and
+    permission failures use the same status code but a different message,
+    and retrying those just wastes wall-clock time.
+    """
+    try:
+        text = resp.text.lower()
+    except Exception:
+        return False
+    return any(marker in text for marker in ("quota", "rate", "resource has been exhausted"))
 
 
 def gemini_request_with_retry(
@@ -123,7 +143,12 @@ def gemini_request_with_retry(
         if resp.status_code < 400:
             return resp.json()
 
-        if resp.status_code not in _RETRIABLE_STATUS_CODES:
+        # 403 is retriable only when the body indicates quota/rate exhaustion;
+        # auth failures should fail fast instead of eating retry budget.
+        is_retriable = resp.status_code in _RETRIABLE_STATUS_CODES or (
+            resp.status_code == 403 and _is_retriable_403(resp)
+        )
+        if not is_retriable:
             resp.raise_for_status()
 
         last_exc = httpx.HTTPStatusError(

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -13,7 +13,17 @@ from uuid import UUID
 
 import boto3
 from botocore.client import BaseClient
+from botocore.config import Config as BotoConfig
 from loguru import logger
+
+# Bounded S3 timeouts + adaptive retry so a slow bucket cannot stall a publish
+# for minutes at a time. boto3's defaults are 60s per attempt with up to 5
+# retries — plenty of time for the whole request pool to run out.
+_S3_CLIENT_CONFIG = BotoConfig(
+    connect_timeout=5,
+    read_timeout=30,
+    retries={"max_attempts": 3, "mode": "adaptive"},
+)
 
 
 def create_s3_client(
@@ -22,7 +32,7 @@ def create_s3_client(
     secret_access_key: str,
     endpoint_url: str = "",
 ) -> BaseClient:
-    """Create an S3 client with explicit credentials.
+    """Create an S3 client with explicit credentials and bounded timeouts.
 
     Args:
         region: AWS region name (e.g. 'us-east-1').
@@ -37,6 +47,7 @@ def create_s3_client(
         "region_name": region,
         "aws_access_key_id": access_key_id,
         "aws_secret_access_key": secret_access_key,
+        "config": _S3_CLIENT_CONFIG,
     }
     if endpoint_url:
         kwargs["endpoint_url"] = endpoint_url

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -492,6 +492,43 @@ class TestListEvalRuns:
         assert len(data) == 1
         assert data[0]["id"] == str(own_run.id)
 
+    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.find_active_eval_runs_for_user")
+    def test_list_runs_applies_zombie_detection(
+        self,
+        mock_find_runs: MagicMock,
+        mock_update_status: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A stale-heartbeat run must be marked failed in the list response.
+
+        Regression: sibling GET /eval-runs/{id} endpoints ran zombie detection
+        but the collection endpoint didn't, so a crashed worker's run
+        appeared "running" indefinitely in the "My Runs" list.
+        """
+        stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
+        stale_run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
+        healthy_run = _make_eval_run(status="running", heartbeat_at=datetime.now(UTC))
+        failed_run = _make_eval_run(
+            id=stale_run.id,
+            status="failed",
+            error_message="Stale heartbeat",
+            heartbeat_at=stale_heartbeat,
+        )
+        # First call: pre-zombie-check. Second: re-read after zombie update.
+        mock_find_runs.side_effect = [[stale_run, healthy_run], [failed_run, healthy_run]]
+
+        resp = client.get("/v1/eval-runs", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert {d["id"] for d in data} == {str(stale_run.id), str(healthy_run.id)}
+        statuses = {d["id"]: d["status"] for d in data}
+        assert statuses[str(stale_run.id)] == "failed"
+        assert statuses[str(healthy_run.id)] == "running"
+        mock_update_status.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # UUID validation tests

--- a/server/tests/test_infra/test_anthropic_client.py
+++ b/server/tests/test_infra/test_anthropic_client.py
@@ -1,6 +1,7 @@
 """Tests for infra/anthropic_client.py -- LLM judge for agent evals."""
 
 import json
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -99,10 +100,12 @@ class TestJudgeEvalOutput:
 
     @respx.mock
     def test_api_error_propagates(self) -> None:
-        """httpx errors should propagate up."""
-        respx.post("https://api.anthropic.com/v1/messages").mock(return_value=httpx.Response(500, text="Server Error"))
+        """httpx errors should propagate up after retries are exhausted."""
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(500, text="Server Error")
+        )
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with patch("decision_hub.infra.anthropic_client.time.sleep"), pytest.raises(httpx.HTTPStatusError):
             judge_eval_output(
                 api_key="test-key",
                 model="test-model",
@@ -110,3 +113,54 @@ class TestJudgeEvalOutput:
                 eval_criteria="criteria",
                 agent_output="output",
             )
+        # Retry attempts: 1 initial + 3 retries = 4 total requests.
+        assert route.call_count == 4
+
+    @respx.mock
+    def test_retries_on_429_then_succeeds(self) -> None:
+        """A transient rate-limit response should not fail the judge case."""
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            side_effect=[
+                httpx.Response(429, text="Rate limited"),
+                httpx.Response(
+                    200,
+                    json={
+                        "content": [{"text": json.dumps({"verdict": "pass", "reasoning": "ok"})}],
+                    },
+                ),
+            ]
+        )
+
+        with patch("decision_hub.infra.anthropic_client.time.sleep") as mock_sleep:
+            result = judge_eval_output(
+                api_key="test-key",
+                model="test-model",
+                eval_case_name="test",
+                eval_criteria="criteria",
+                agent_output="output",
+            )
+
+        assert result["verdict"] == "pass"
+        assert route.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @respx.mock
+    def test_non_retriable_status_returns_immediately(self) -> None:
+        """A 400 must not consume the retry budget — fail fast."""
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(400, text="Bad request")
+        )
+
+        with (
+            patch("decision_hub.infra.anthropic_client.time.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            judge_eval_output(
+                api_key="test-key",
+                model="test-model",
+                eval_case_name="test",
+                eval_criteria="criteria",
+                agent_output="output",
+            )
+        assert route.call_count == 1
+        mock_sleep.assert_not_called()

--- a/server/tests/test_infra/test_gemini.py
+++ b/server/tests/test_infra/test_gemini.py
@@ -32,10 +32,12 @@ class TestGeminiPostRetry:
     """Tests for _gemini_post retry with exponential backoff on transient errors."""
 
     @respx.mock
-    def test_retries_on_403_then_succeeds(self, gemini_client: dict) -> None:
+    def test_retries_on_403_quota_then_succeeds(self, gemini_client: dict) -> None:
+        # 403 is only retried when the body indicates quota / rate-limit
+        # exhaustion. See `_is_retriable_403` in gemini.py.
         route = respx.post(_GEMINI_URL).mock(
             side_effect=[
-                httpx.Response(403, text="Forbidden"),
+                httpx.Response(403, text="Quota exceeded for the day"),
                 httpx.Response(200, json={"candidates": []}),
             ]
         )
@@ -47,6 +49,22 @@ class TestGeminiPostRetry:
         assert result == {"candidates": []}
         assert route.call_count == 2
         mock_sleep.assert_called_once_with(1.25)
+
+    @respx.mock
+    def test_403_auth_error_does_not_retry(self, gemini_client: dict) -> None:
+        # An invalid API key surfaces as 403 with a permission/auth message
+        # rather than a quota marker; retrying just wastes wall-clock time.
+        route = respx.post(_GEMINI_URL).mock(
+            return_value=httpx.Response(403, text="The caller does not have permission")
+        )
+        with (
+            patch("decision_hub.infra.gemini.time.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError) as exc_info,
+        ):
+            _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
+        assert exc_info.value.response.status_code == 403
+        assert route.call_count == 1
+        mock_sleep.assert_not_called()
 
     @respx.mock
     def test_retries_on_429_with_backoff(self, gemini_client: dict) -> None:

--- a/server/tests/test_infra/test_search_db.py
+++ b/server/tests/test_infra/test_search_db.py
@@ -1,0 +1,95 @@
+"""Tests for SQL correctness of the search / similarity DB queries.
+
+These are compile-level tests (no live DB) that verify each `LIMIT` query has
+a unique `ORDER BY` tiebreaker per the project's "SQL query correctness"
+convention. Without the tiebreaker, two rows with identical rank/distance
+produce non-deterministic pagination and can be silently dropped or
+duplicated between calls.
+"""
+
+from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
+
+from decision_hub.infra.database import (
+    fetch_similar_skills,
+    find_active_eval_runs_for_user,
+    search_skills_hybrid,
+)
+
+
+def _compile(stmt) -> str:
+    # Compile against the postgres dialect so pgvector / REGCONFIG-typed
+    # literals render. We only need the SQL text for substring assertions,
+    # not to execute the statement.
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": False})).lower()
+
+
+def _make_conn_returning(rows: list) -> MagicMock:
+    conn = MagicMock()
+    conn.execute.return_value.all.return_value = rows
+    conn.execute.return_value.first.return_value = None
+    return conn
+
+
+class TestSearchSkillsHybridTiebreakers:
+    """Both FTS and vector branches must include a unique tiebreaker."""
+
+    def test_fts_order_by_includes_id_desc(self) -> None:
+        conn = _make_conn_returning([])
+        search_skills_hybrid(
+            conn,
+            fts_queries=["hello world"],
+            query_embedding=None,
+            limit=5,
+        )
+        sql = _compile(conn.execute.call_args_list[0].args[0])
+        assert "order by fts_rank desc" in sql
+        # The `skills.id DESC` tiebreaker prevents ts_rank_cd ties (zero-rank
+        # keyword misses, identical documents) producing unstable pagination.
+        assert "skills.id desc" in sql
+
+    def test_vector_order_by_includes_id_desc(self) -> None:
+        conn = _make_conn_returning([])
+        search_skills_hybrid(
+            conn,
+            fts_queries=[],
+            query_embedding=[0.0] * 768,
+            limit=5,
+        )
+        sql = _compile(conn.execute.call_args_list[0].args[0])
+        assert "order by vec_dist asc" in sql
+        # `skills.id DESC` guards against identical embeddings (forks,
+        # duplicate content) producing unstable top-K.
+        assert "skills.id desc" in sql
+
+
+class TestFetchSimilarSkills:
+    """`fetch_similar_skills` should run one query (CTE) and include a tiebreaker."""
+
+    def test_single_round_trip_and_includes_tiebreaker(self) -> None:
+        # Return a row with an embedding so the CTE path is exercised.
+        conn = MagicMock()
+        conn.execute.return_value.all.return_value = []
+
+        fetch_similar_skills(conn, "acme", "greeter", limit=5)
+
+        # The refactor collapses the previous two-query pattern into one
+        # statement using a CTE. Assert exactly one execute() call.
+        assert conn.execute.call_count == 1
+        sql = _compile(conn.execute.call_args_list[0].args[0])
+        assert "order by vec_dist asc" in sql
+        assert "skills.id desc" in sql
+
+
+class TestFindActiveEvalRunsTiebreaker:
+    def test_order_by_includes_id_desc(self) -> None:
+        from uuid import uuid4
+
+        conn = _make_conn_returning([])
+        find_active_eval_runs_for_user(conn, uuid4(), limit=10)
+        sql = _compile(conn.execute.call_args_list[0].args[0])
+        assert "created_at desc" in sql
+        # Two eval runs created in the same millisecond (parallel `dhub
+        # publish` invocations) must order deterministically.
+        assert "id desc" in sql

--- a/server/tests/test_infra/test_tracker_db.py
+++ b/server/tests/test_infra/test_tracker_db.py
@@ -411,3 +411,41 @@ class TestListTrackerMetrics:
 
         result = list_tracker_metrics(conn)
         assert result == []
+
+    def test_order_by_includes_id_tiebreaker(self):
+        """LIMIT queries must have a unique tiebreaker (project convention)."""
+        conn = MagicMock()
+        conn.execute.return_value.all.return_value = []
+        list_tracker_metrics(conn, limit=10)
+        stmt = conn.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+        # Both `recorded_at DESC` and `id DESC` must appear in the ORDER BY.
+        assert "recorded_at desc" in compiled
+        assert "id desc" in compiled
+
+
+class TestBatchIncrementPermanentFailures:
+    """The counter must not climb above the threshold."""
+
+    def test_update_where_clause_bounds_counter_at_threshold(self):
+        from decision_hub.infra.database import batch_increment_permanent_failures
+
+        conn = MagicMock()
+        conn.execute.return_value = MagicMock()
+        conn.execute.return_value.__iter__ = lambda self: iter([])
+        tracker_ids = [uuid4(), uuid4()]
+
+        batch_increment_permanent_failures(conn, tracker_ids, threshold=3)
+
+        # First call is the UPDATE; inspect its compiled SQL to verify the
+        # counter is only bumped for rows still below the threshold.
+        update_stmt = conn.execute.call_args_list[0].args[0]
+        compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+        assert "consecutive_permanent_failures < 3" in compiled
+
+    def test_empty_input_returns_empty_list_without_execute(self):
+        from decision_hub.infra.database import batch_increment_permanent_failures
+
+        conn = MagicMock()
+        assert batch_increment_permanent_failures(conn, [], threshold=3) == []
+        conn.execute.assert_not_called()


### PR DESCRIPTION
## What changed

Deep-review sweep of the server package. Eleven low-risk, high-confidence fixes across SQL correctness, external-client reliability, cache safety, and eval-run consistency — plus five new regression tests. No public API surface changes; every change is a bug fix or hardening on a stable contract.

## Why

Standalone architectural / correctness review, not a specific issue. Findings that made this cut all met the bar of: concrete failing scenario, small blast radius, clear fix.

## How to test

`make test-server` — all 944 non-slow server tests pass, `make lint` clean, `mypy` clean on the touched modules.

Manual verification is not required for any of these — every fix is covered by an existing or new unit test.

## Checklist

- [x] Tests pass (`make test-server`, 944 passed / 34 slow deselected)
- [x] No breaking API changes (all endpoints/signatures unchanged)
- [x] Database migration included (if schema changed) — n/a, no schema changes

---

## Detailed changes

### SQL correctness — LIMIT queries need a unique tiebreaker

Per the project convention documented in `CLAUDE.md` ("SQL query correctness"), every `LIMIT` query needs an explicit tiebreaker in `ORDER BY`. Without one, two rows with identical rank/distance/timestamp can be silently dropped or duplicated between calls.

- **`search_skills_hybrid`** — `skills.id DESC` added after both `fts_rank DESC` and `vec_dist ASC`. Zero-rank FTS misses and identical embeddings (forks, duplicate content) previously produced non-deterministic top-K across calls.
- **`fetch_similar_skills`** — same tiebreaker, plus a bigger cleanup: the two-query source-embedding lookup + neighbour search collapses into a single CTE. Halves the round-trip on the `/skills/.../similar` hot path.
- **`find_active_eval_runs_for_user`** — parallel `dhub publish` invocations can create runs in the same millisecond; adding `id DESC` keeps `/eval-runs` pagination stable and prevents runs from disappearing/reappearing between polls.
- **`list_tracker_metrics`** — same treatment for the tracker metrics list.

### Correctness — batch counter must not grow unbounded

`batch_increment_permanent_failures`'s docstring says a tracker already at threshold "is not incremented further" — but the UPDATE had no WHERE clause enforcing that. A disabled tracker that got retried would have its counter climb into the thousands. Adds `consecutive_permanent_failures < threshold` to the UPDATE.

### Correctness — zombie detection missing from `list_eval_runs`

`GET /v1/eval-runs/{id}` and `GET /v1/eval-runs/{id}/logs` both call `_check_zombie` before returning, but the collection endpoint `GET /v1/eval-runs` didn't. A crashed worker's run therefore appeared "running" indefinitely in the "My Runs" list. Now applies the same stale-heartbeat check and re-reads the list if any run was updated in-DB.

### Reliability — external clients

- **S3 client timeouts** — `create_s3_client` now uses `botocore.config.Config(connect_timeout=5, read_timeout=30, retries={"max_attempts": 3, "mode": "adaptive"})`. boto3's defaults are 60s per attempt × 5 retries, plenty for the request pool to run out on a slow bucket during a publish or download.
- **Anthropic judge retry** — `judge_eval_output` was a single `httpx.post`; a flaky 429/502 failed the whole gauntlet case. Added exponential-backoff retry that mirrors `gemini_request_with_retry` for 429/500/502/503/529 and `httpx.TimeoutException` (up to 3 retries with jitter).
- **Gemini 403 handling** — 403 was blanket-retriable, but Gemini returns 403 for both quota exhaustion *and* invalid API keys. On a rotated/misconfigured key, every gauntlet call ate ~7s of retry budget before failing (×4 stages ≈ 28s per publish). Now retries 403 only when the response body contains "quota" / "rate" / "resource has been exhausted"; other 403s fail fast.
- **Tracker verification fail-safe** — `_verify_repos_removed` in the tracker service now catches `httpx.HTTPError` per-URL and treats a transient failure as "still exists". A network blip must not silently flip live skills to `source_repo_removed=true`.

### Perf / security — cache-eviction resistance on `/orgs/stats`

`GET /orgs/stats` was caching under `f"org_stats:{search}:{type_filter}:{sort}:{sort_dir}"`, embedding the arbitrary user `search` string in the key. A low-QPS attacker sending random queries could evict genuine hot entries from the bounded 256-entry TTLCache. The route now caches only the fixed `(type_filter, sort, sort_dir)` matrix; requests with a `search=` parameter bypass the cache entirely.

### Tests added

- `test_infra/test_search_db.py` (new file) — asserts compiled SQL for `search_skills_hybrid`, `fetch_similar_skills`, and `find_active_eval_runs_for_user` contains the required tiebreakers, and that `fetch_similar_skills` runs exactly one `execute()` call.
- `test_infra/test_tracker_db.py` — LIMIT tiebreaker on `list_tracker_metrics`; UPDATE bound at threshold for `batch_increment_permanent_failures`.
- `test_infra/test_anthropic_client.py` — retry on 429 then succeed; fast-fail on 400; four total attempts before propagating 5xx.
- `test_infra/test_gemini.py` — 403 with quota body retries; 403 with permission body fails fast (regression for the invalid-key retry-waste behaviour).
- `test_api/test_eval_logs.py` — regression for zombie detection in the `list_eval_runs` endpoint.

---

## What this PR does *not* include (deliberately left out)

The review surfaced several additional candidates that were held back because they were higher-risk or needed a decision I didn't want to make autonomously:

- Auth login handler `async def` refactor (sync SQLAlchemy calls blocking the event loop) — real issue, but semantics change.
- Moving `sync_org_github_metadata` off the login critical path via `BackgroundTasks` — same reason.
- S3 zip download streaming (currently reads the whole zip into memory) — behaviour change on a public endpoint.
- Download counter idempotency / removal from `/resolve` — product decision.
- Rolling back `insert_skill` on late S3 failure in `publish_pipeline` — needs a careful transactional-boundary discussion.
- Modal orphan-labeling correctness under deadline break — needs a broader rework of the fn.map consumer.
- Dead-code removal (`TestingConfig`, `_normalize_repo_url`, various shim re-exports, some frontend feature-flag dead branches) — worth a follow-up PR of its own.

These are documented in the review notes; happy to open follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMuJD2R4E97Fb4veBXGZYN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMuJD2R4E97Fb4veBXGZYN)_