### PR TITLE
fix: correctness bugs and CLAUDE.md-rule violations surfaced by a codebase audit

### DIFF
--- a/client/src/dhub/cli/init.py
+++ b/client/src/dhub/cli/init.py
@@ -38,6 +38,10 @@ def init_command(
         console.print(f"[red]Error: {skill_md} already exists.[/]")
         raise typer.Exit(1)
 
+    # Pin UTF-8 explicitly so a Windows user typing a curly quote or
+    # em-dash in the description does not write cp1252-encoded bytes that
+    # later fail to parse (SKILL.md is read as UTF-8 by both the CLI and
+    # the server).
     skill_md.write_text(
         f"---\n"
         f"name: {name}\n"
@@ -46,7 +50,8 @@ def init_command(
         f"\n"
         f"# {name}\n"
         f"\n"
-        f"Describe what this skill does and how the agent should use it.\n"
+        f"Describe what this skill does and how the agent should use it.\n",
+        encoding="utf-8",
     )
 
     console.print(f"[green]Created skill project at {skill_dir.resolve()}[/]")

--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -155,7 +155,7 @@ def _publish_skill_directory(
 
             _tail_eval_logs(api_url, _bh(token), eval_run_id)
         except KeyboardInterrupt:
-            console.print("\n[dim]Detached. Resume with: dhub logs {eval_run_id} --follow[/]")
+            console.print(f"\n[dim]Detached. Resume with: dhub logs {eval_run_id} --follow[/]")
     elif eval_report_status == "pending":
         console.print("[dim]Agent assessment running in background...[/]")
 
@@ -656,7 +656,11 @@ def _render_skills_table(skills: list[dict], title: str = "Published Skills") ->
     for s in skills:
         rating = s.get("safety_rating", "")
         rating_style = grade_styles.get(rating, "white")
-        updated = s.get("updated_at", "")[:10]
+        # ``dict.get(..., "")`` still returns ``None`` when the key is
+        # present with a null value (e.g. a row backfilled before the
+        # updated_at trigger fired); coerce with ``or ""`` so the slice
+        # cannot crash the entire table render.
+        updated = (s.get("updated_at") or "")[:10]
         table.add_row(
             s["org_slug"],
             s["skill_name"],

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -727,6 +727,47 @@ class TestListCommand:
     @respx.mock
     @patch("dhub.cli.config.get_optional_token", return_value="test-token")
     @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_list_handles_null_updated_at(
+        self,
+        _mock_url,
+        _mock_token,
+    ) -> None:
+        """Regression: rows with ``updated_at: null`` used to crash the
+        table renderer with ``TypeError: 'NoneType' object is not
+        subscriptable`` because ``dict.get(key, "")`` returns ``None`` when
+        the key is present but null."""
+        skills = [
+            {
+                "org_slug": "acme",
+                "skill_name": "fresh-skill",
+                "description": "Just published",
+                "latest_version": "0.1.0",
+                # Explicit JSON null — the failure mode we're guarding against.
+                "updated_at": None,
+                "safety_rating": "A",
+                "author": "bob",
+                "download_count": 0,
+            },
+        ]
+        respx.get("http://test:8000/v1/skills").mock(return_value=httpx.Response(200, json=_paginated_response(skills)))
+        respx.get("http://test:8000/cli/latest-version").mock(
+            return_value=httpx.Response(200, json={"latest_version": ""})
+        )
+
+        result = runner.invoke(app, ["list"])
+
+        # The critical assertion is that the render did NOT crash on the
+        # null value — before the fix, ``None[:10]`` raised TypeError and
+        # exit_code was 1. Rich truncates long column values with an ellipsis,
+        # so we look for a short prefix of the skill name rather than the
+        # full string.
+        assert result.exit_code == 0
+        assert "fresh" in result.output
+        assert "acme" in result.output
+
+    @respx.mock
+    @patch("dhub.cli.config.get_optional_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
     def test_list_filter_by_org(
         self,
         _mock_url,

--- a/server/src/decision_hub/api/org_routes.py
+++ b/server/src/decision_hub/api/org_routes.py
@@ -2,13 +2,14 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from decision_hub.api.deps import get_cache, get_connection, get_current_user, get_settings
+from decision_hub.api.rate_limit import RateLimiter
 from decision_hub.domain.orgs import validate_org_slug
 from decision_hub.infra.cache import TTLCache
 from decision_hub.infra.database import (
@@ -26,6 +27,35 @@ from decision_hub.settings import Settings
 
 org_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
 org_public_router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
+
+
+def _enforce_org_stats_rate_limit(request: Request) -> None:
+    """Rate-limit the public /orgs/stats endpoint.
+
+    Follows the same lazy-init pattern as the other public routes so tests
+    can supply a settings override on ``app.state`` and the limiter picks it
+    up on first request.
+    """
+    state = request.app.state
+    if not hasattr(state, "_org_stats_rate_limiter"):
+        settings: Settings = state.settings
+        state._org_stats_rate_limiter = RateLimiter(
+            max_requests=settings.org_stats_rate_limit,
+            window_seconds=settings.org_stats_rate_window,
+        )
+    state._org_stats_rate_limiter(request)
+
+
+def _enforce_org_profiles_rate_limit(request: Request) -> None:
+    """Rate-limit the public /orgs/profiles endpoint."""
+    state = request.app.state
+    if not hasattr(state, "_org_profiles_rate_limiter"):
+        settings: Settings = state.settings
+        state._org_profiles_rate_limiter = RateLimiter(
+            max_requests=settings.org_profiles_rate_limit,
+            window_seconds=settings.org_profiles_rate_window,
+        )
+    state._org_profiles_rate_limiter(request)
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +181,11 @@ class OrgStatsResponse(BaseModel):
     items: list[OrgStatsEntry]
 
 
-@org_public_router.get("/stats", response_model=OrgStatsResponse)
+@org_public_router.get(
+    "/stats",
+    response_model=OrgStatsResponse,
+    dependencies=[Depends(_enforce_org_stats_rate_limit)],
+)
 def get_org_stats(
     response: Response,
     search: str | None = Query(None, max_length=200),
@@ -190,7 +224,11 @@ def get_org_stats(
     return result
 
 
-@org_public_router.get("/profiles", response_model=list[OrgProfile])
+@org_public_router.get(
+    "/profiles",
+    response_model=list[OrgProfile],
+    dependencies=[Depends(_enforce_org_profiles_rate_limit)],
+)
 def list_org_profiles(
     response: Response,
     conn: Connection = Depends(get_connection),

--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -212,7 +212,10 @@ def run_assessment_background(
             logger.info("Assessment done — {}/{} passed in {}ms", passed, total, total_duration_ms)
 
     except Exception as e:
-        logger.error("Agent assessment failed for version {}: {}", version_id, e)
+        # opt(exception=True) attaches the traceback to stderr — before this
+        # change, on-call had to guess where the failure originated because
+        # only the exception's ``str(e)`` was formatted into the message.
+        logger.opt(exception=True).error("Agent assessment failed for version {}", version_id)
 
         # Update run row if using streaming pipeline
         if run_id is not None:
@@ -232,8 +235,8 @@ def run_assessment_background(
                         completed_at=datetime.now(UTC),
                     )
                     err_conn.commit()
-            except Exception as inner:
-                logger.error("Failed to update run {}: {}", run_id, inner)
+            except Exception:
+                logger.opt(exception=True).error("Failed to update run {}", run_id)
 
         # INSERT an error report
         try:
@@ -255,9 +258,8 @@ def run_assessment_background(
                     error_message=str(e),
                 )
                 err_conn.commit()
-        except Exception as inner:
-            logger.error(
-                "Failed to store error report for version {}: {}",
+        except Exception:
+            logger.opt(exception=True).error(
+                "Failed to store error report for version {}",
                 version_id,
-                inner,
             )

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -387,6 +387,11 @@ def _ask_skills_inner(
     except Exception:
         logger.opt(exception=True).warning("Conversational ask failed, using fallback")
         fallback_latency_ms = int((time.monotonic() - start_time) * 1000)
+        # Keep the fallback answer text as a single constant so the response
+        # body and the analytics record cannot drift out of sync — prior to
+        # this change, analytics silently recorded answer="" whenever the LLM
+        # call failed, hiding the fact that users still saw a valid response.
+        fallback_answer = "Here are the most relevant skills I found:"
         skill_refs = [
             AskSkillRef(
                 org_slug=e.org_slug,
@@ -414,7 +419,7 @@ def _ask_skills_inner(
             s3_bucket=settings.s3_bucket,
             log_id=uuid4(),
             query=q,
-            answer="",
+            answer=fallback_answer,
             results_count=len(result.entries),
             model=settings.gemini_model,
             latency_ms=fallback_latency_ms,
@@ -424,7 +429,7 @@ def _ask_skills_inner(
         )
         return AskResponse(
             query=q,
-            answer="Here are the most relevant skills I found:",
+            answer=fallback_answer,
             skills=skill_refs,
             category=category,
         )

--- a/server/src/decision_hub/domain/evals.py
+++ b/server/src/decision_hub/domain/evals.py
@@ -126,7 +126,9 @@ def run_eval_pipeline(
                 sandbox_cpu=sandbox_cpu,
             )
         except Exception as e:
-            logger.error("Sandbox error for case '{}': {}", case.name, e)
+            # Attach traceback (loguru rule): the exception message alone loses
+            # the origin of sandbox failures, which is what on-call needs.
+            logger.opt(exception=True).error("Sandbox error for case '{}'", case.name)
             case_results.append(
                 {
                     "name": case.name,
@@ -178,7 +180,7 @@ def run_eval_pipeline(
             reasoning = judgment["reasoning"]
             stage = "judge"
         except Exception as e:
-            logger.error("Judge error for case '{}': {}", case.name, e)
+            logger.opt(exception=True).error("Judge error for case '{}'", case.name)
             verdict = "error"
             reasoning = f"Judge error: {e}"
             stage = "judge"
@@ -540,7 +542,7 @@ def run_streaming_eval(
                 conn.commit()
 
     except Exception as e:
-        logger.error("Streaming eval failed for run_id={}: {}", run_id, e)
+        logger.opt(exception=True).error("Streaming eval failed for run_id={}", run_id)
         # Flush any remaining events
         _flush_buffer()
 

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -417,7 +417,10 @@ def check_all_due_trackers(settings: Settings, *, deadline: float | None = None)
             errored=errored,
             processed=0,
             failed=0,
-            trackers_disabled=0,
+            # Preserve the count of trackers disabled in the pre-guardrail phase
+            # so ops metrics still reflect circuit-breaker activity when we
+            # short-circuit on GitHub rate limits.
+            trackers_disabled=disabled_count,
             skipped_rate_limit=len(changed_trackers),
             deadline_deferred=0,
             github_rate_remaining=rate_remaining,
@@ -449,7 +452,10 @@ def check_all_due_trackers(settings: Settings, *, deadline: float | None = None)
                 errored=errored,
                 processed=0,
                 failed=0,
-                trackers_disabled=0,
+                # Same rationale as the rate-limit-low branch above: keep the
+                # count of trackers disabled by the circuit breaker so it is
+                # not lost when we defer the dispatch phase for lack of time.
+                trackers_disabled=disabled_count,
                 skipped_rate_limit=0,
                 deadline_deferred=len(changed_trackers),
                 github_rate_remaining=rate_remaining,

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -166,26 +166,29 @@ def list_eval_log_chunks(
 ) -> list[tuple[int, str]]:
     """List eval log chunk keys with sequence number > after_seq.
 
+    Uses the ``list_objects_v2`` paginator so long-running evals with more
+    than 1000 chunks are not silently truncated to their first page — the
+    tail of the log used to disappear once ``chunk_seq`` crossed 1000.
+
     Returns:
         List of (seq, s3_key) tuples sorted by seq ascending.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-
+    paginator = client.get_paginator("list_objects_v2")
     chunks: list[tuple[int, str]] = []
-    for obj in contents:
-        key = obj["Key"]
-        # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
-        filename = key.rsplit("/", 1)[-1]
-        if not filename.endswith(".jsonl"):
-            continue
-        seq_str = filename.replace(".jsonl", "")
-        try:
-            seq = int(seq_str)
-        except ValueError:
-            continue
-        if seq > after_seq:
-            chunks.append((seq, key))
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        for obj in page.get("Contents", []) or []:
+            key = obj["Key"]
+            # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
+            filename = key.rsplit("/", 1)[-1]
+            if not filename.endswith(".jsonl"):
+                continue
+            seq_str = filename.replace(".jsonl", "")
+            try:
+                seq = int(seq_str)
+            except ValueError:
+                continue
+            if seq > after_seq:
+                chunks.append((seq, key))
 
     chunks.sort(key=lambda x: x[0])
     return chunks
@@ -208,20 +211,27 @@ def delete_eval_logs(
 ) -> int:
     """Delete all eval log chunks under a prefix.
 
+    Paginates over ``list_objects_v2`` so evals with more than 1000 chunks
+    have all their objects removed (previously the tail leaked).  S3's
+    ``delete_objects`` accepts at most 1000 keys per call, so delete in the
+    same page-sized batches as we list.
+
     Returns:
         Number of objects deleted.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-    if not contents:
-        return 0
-
-    objects = [{"Key": obj["Key"]} for obj in contents]
-    client.delete_objects(
-        Bucket=bucket,
-        Delete={"Objects": objects},
-    )
-    return len(objects)
+    paginator = client.get_paginator("list_objects_v2")
+    total = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        contents = page.get("Contents", []) or []
+        if not contents:
+            continue
+        objects = [{"Key": obj["Key"]} for obj in contents]
+        client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": objects},
+        )
+        total += len(objects)
+    return total
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/scripts/backfill_embeddings.py
+++ b/server/src/decision_hub/scripts/backfill_embeddings.py
@@ -36,9 +36,22 @@ def backfill(batch_size: int = 100) -> None:
     total_errors = 0  # cumulative errors for final summary
     consecutive_errors = 0  # circuit breaker: abort if too many in a row
 
+    # Snapshot the total pending count so progress logs are meaningful
+    # ("500/12000") instead of the old "500/500" nonsense — and so an
+    # operator can tell "we're almost done" from "we've barely started".
+    with engine.connect() as conn:
+        total_pending = conn.execute(
+            sa.select(sa.func.count()).select_from(skills_table).where(skills_table.c.embedding.is_(None))
+        ).scalar_one()
+    logger.info("Backfill starting: {} skills pending embeddings", total_pending)
+
     while True:
         with engine.connect() as conn:
-            # Fetch a batch of skills without embeddings
+            # Fetch a batch of skills without embeddings.
+            # ORDER BY id gives a stable ordering so that a persistently
+            # failing batch does not silently starve later batches — required
+            # by the project's SQL correctness rule (LIMIT needs ORDER BY
+            # with a unique tiebreaker; skills.id is the PK).
             stmt = (
                 sa.select(
                     skills_table.c.id,
@@ -54,6 +67,7 @@ def backfill(batch_size: int = 100) -> None:
                     )
                 )
                 .where(skills_table.c.embedding.is_(None))
+                .order_by(skills_table.c.id)
                 .limit(batch_size)
             )
             rows = conn.execute(stmt).all()
@@ -99,7 +113,9 @@ def backfill(batch_size: int = 100) -> None:
             conn.commit()
             total_processed += len(rows)
             consecutive_errors = 0  # reset circuit breaker on success
-            logger.info("Backfilled {}/{} skills", total_processed, total_processed)
+            # Report against the snapshot total so the log reads as real
+            # progress instead of "N/N" every tick.
+            logger.info("Backfilled {}/{} skills", total_processed, total_pending)
 
     logger.info(
         "Backfill complete: {} skills processed, {} errors",

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,13 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    # Public, unauthenticated org endpoints — same shape as list_skills
+    # since they front expensive aggregate queries that would otherwise
+    # accept unbounded traffic.
+    org_stats_rate_limit: int = 120
+    org_stats_rate_window: int = 60
+    org_profiles_rate_limit: int = 120
+    org_profiles_rate_window: int = 60
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,11 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    # Public org endpoints — high default keeps unrelated tests unaffected
+    settings.org_stats_rate_limit = 1000
+    settings.org_stats_rate_window = 60
+    settings.org_profiles_rate_limit = 1000
+    settings.org_profiles_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_org_routes.py
+++ b/server/tests/test_api/test_org_routes.py
@@ -297,3 +297,58 @@ class TestGetOrg:
         """Should return 401 without auth headers."""
         resp = client.get("/v1/orgs/some-org")
         assert resp.status_code == 401
+
+
+class TestPublicOrgEndpointsAreRateLimited:
+    """Regression: /v1/orgs/stats and /v1/orgs/profiles used to be
+    unauthenticated with no rate limiter, so a single attacker could pin
+    the DB with cheap-to-issue but expensive-to-serve aggregate queries.
+
+    These tests lock in the presence of the limiter dependency."""
+
+    @patch("decision_hub.api.org_routes.fetch_org_stats", return_value=[])
+    def test_org_stats_returns_429_after_limit(
+        self,
+        _mock_fetch: MagicMock,
+        client: TestClient,
+        test_app,
+    ) -> None:
+        """Once the per-IP window fills, further /v1/orgs/stats requests get 429."""
+        # Tighten the limiter for this test and drop the cached instance so
+        # the new settings take effect on the next request.
+        test_app.state.settings.org_stats_rate_limit = 2
+        test_app.state.settings.org_stats_rate_window = 60
+        if hasattr(test_app.state, "_org_stats_rate_limiter"):
+            del test_app.state._org_stats_rate_limiter
+
+        # First two requests succeed
+        for _ in range(2):
+            resp = client.get("/v1/orgs/stats")
+            assert resp.status_code == 200
+        # Third is rejected
+        resp = client.get("/v1/orgs/stats")
+        assert resp.status_code == 429
+        assert "Rate limit exceeded" in resp.json()["detail"]
+
+    @patch("decision_hub.api.org_routes.list_all_org_profiles", return_value=[])
+    def test_org_profiles_returns_429_after_limit(
+        self,
+        _mock_list: MagicMock,
+        client: TestClient,
+        test_app,
+    ) -> None:
+        """Once the per-IP window fills, further /v1/orgs/profiles requests get 429."""
+        test_app.state.settings.org_profiles_rate_limit = 2
+        test_app.state.settings.org_profiles_rate_window = 60
+        if hasattr(test_app.state, "_org_profiles_rate_limiter"):
+            del test_app.state._org_profiles_rate_limiter
+
+        # Also purge the cache so requests hit the endpoint (and the limiter)
+        # rather than returning cached responses that would bypass it.
+        test_app.state.cache.clear()
+
+        for _ in range(2):
+            resp = client.get("/v1/orgs/profiles")
+            assert resp.status_code == 200
+        resp = client.get("/v1/orgs/profiles")
+        assert resp.status_code == 429

--- a/server/tests/test_api/test_search_routes.py
+++ b/server/tests/test_api/test_search_routes.py
@@ -224,6 +224,38 @@ class TestAskSkills:
         assert data["skills"][0]["org_slug"] == "acme"
         assert data["skills"][0]["skill_name"] == "weather"
 
+    @patch("decision_hub.api.search_routes._log_ask_analytics")
+    @patch("decision_hub.api.search_routes.parse_query_with_guard", return_value=_GUARD_PASS)
+    @patch("decision_hub.api.search_routes.embed_query", return_value=_FIXED_EMBEDDING)
+    @patch("decision_hub.api.search_routes.search_skills_hybrid")
+    @patch("decision_hub.api.search_routes.ask_conversational", side_effect=Exception("Gemini down"))
+    def test_ask_fallback_analytics_records_actual_answer(
+        self,
+        _mock_llm: MagicMock,
+        mock_hybrid: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_guard: MagicMock,
+        mock_log_analytics: MagicMock,
+        search_client: TestClient,
+    ) -> None:
+        """Regression: the LLM-failure fallback path must record the same
+        ``answer`` text in analytics that it returns to the user. Previously
+        it recorded ``answer=""`` while the response body contained the
+        real fallback message — so search-log dashboards silently reported
+        every fallback conversation as empty."""
+        mock_hybrid.return_value = _SAMPLE_CANDIDATES
+
+        resp = search_client.get("/v1/ask", params={"q": "weather forecast"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert mock_log_analytics.call_count == 1
+        logged_answer = mock_log_analytics.call_args.kwargs["answer"]
+        # Response body and analytics record must agree — and neither may be empty.
+        assert logged_answer != ""
+        assert logged_answer == data["answer"]
+        assert mock_log_analytics.call_args.kwargs["fallback"] is True
+
     @patch("decision_hub.api.search_routes.parse_query_with_guard", return_value=_GUARD_PASS)
     @patch("decision_hub.api.search_routes.embed_query", return_value=_FIXED_EMBEDDING)
     @patch("decision_hub.api.search_routes.search_skills_hybrid")

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -2171,3 +2171,100 @@ class TestCircuitBreaker:
         # The permanent error call should have 1 tracker ID
         perm_ids = mock_increment.call_args[0][1]
         assert len(perm_ids) == 1
+
+
+class TestDisabledCountPreservedOnEarlyReturn:
+    """Regression tests for GH audit finding: ``trackers_disabled`` in the
+    ``TrackerBatchResult`` must reflect trackers actually disabled by the
+    circuit breaker, even when we short-circuit on the rate-limit-low or
+    deadline-deferred guardrails.
+
+    Previously both early-return paths hardcoded ``trackers_disabled=0``,
+    which silently under-reported the metric on any tick where GitHub was
+    also throttling.
+    """
+
+    def _make_tracker(self, idx: int) -> SkillTracker:
+        return SkillTracker(
+            id=uuid4(),
+            user_id=uuid4(),
+            org_slug="myorg",
+            repo_url=f"https://github.com/myorg/deleted-repo-{idx}",
+            branch="main",
+            enabled=True,
+            poll_interval_minutes=60,
+            last_commit_sha="old_sha",
+            last_checked_at=None,
+            last_published_at=None,
+            last_error=None,
+            created_at=datetime.now(UTC),
+        )
+
+    @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
+    @patch("decision_hub.domain.tracker_service._dispatch_changed_trackers")
+    @patch("decision_hub.infra.database.batch_defer_trackers")
+    @patch("decision_hub.infra.database.batch_clear_tracker_errors")
+    @patch("decision_hub.infra.database.batch_set_tracker_errors")
+    @patch("decision_hub.infra.database.batch_disable_trackers")
+    @patch("decision_hub.infra.database.batch_increment_permanent_failures")
+    @patch("decision_hub.infra.database.mark_skills_source_removed")
+    @patch("decision_hub.infra.github_client.batch_fetch_commit_shas")
+    @patch("decision_hub.infra.github_client.GitHubClient")
+    @patch("decision_hub.infra.database.claim_due_trackers")
+    @patch("decision_hub.infra.database.create_engine")
+    def test_disabled_count_survives_rate_limit_early_return(
+        self,
+        mock_create_engine,
+        mock_claim,
+        mock_gh_class,
+        mock_batch_fetch,
+        mock_mark_removed,
+        mock_increment,
+        mock_batch_disable,
+        mock_batch_set_errors,
+        mock_batch_clear_errors,
+        mock_batch_defer,
+        mock_dispatch,
+        _mock_token,
+    ):
+        """When two trackers cross the permanent-failure threshold AND the
+        GitHub rate limit is below the floor, the result must report
+        ``trackers_disabled=2`` — not 0."""
+        trackers = [self._make_tracker(0), self._make_tracker(1)]
+
+        mock_conn = MagicMock()
+        mock_create_engine.return_value.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_create_engine.return_value.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_claim.return_value = trackers
+        # No shas resolved — both trackers get permanent errors
+        mock_batch_fetch.return_value = ({}, set(), {}, {})
+        # Both cross the threshold
+        mock_increment.return_value = [t.id for t in trackers]
+        # Rate limit is BELOW floor → the code takes the short-circuit branch
+        mock_gh_instance = MagicMock()
+        mock_gh_instance.rate_limit_remaining = 100
+        mock_rest_resp = MagicMock()
+        mock_rest_resp.status_code = 404
+        mock_gh_instance.get.return_value = mock_rest_resp
+        mock_gh_class.return_value.__enter__ = MagicMock(return_value=mock_gh_instance)
+        mock_gh_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_settings = MagicMock()
+        mock_settings.tracker_batch_size = 100
+        mock_settings.tracker_jitter_seconds = 0
+        mock_settings.tracker_rate_limit_floor = 500  # 100 < 500 → guardrail trips
+        mock_settings.tracker_permanent_failure_threshold = 10
+        mock_settings.tracker_circuit_breaker_ratio = 1.0  # disable circuit-breaker downgrade
+
+        result = check_all_due_trackers(mock_settings)
+
+        # The regression: previously this was 0. The disabled work happens
+        # *before* the rate-limit check, and the metric must reflect it.
+        assert result.trackers_disabled == 2
+        # Both trackers surfaced permanent errors, so none went to the
+        # "changed" bucket — dispatch was skipped by having nothing to do,
+        # and the errored count is what surfaces the failed trackers.
+        assert result.errored == 2
+        assert result.github_rate_remaining == 100
+        mock_dispatch.assert_not_called()
+        mock_batch_disable.assert_called_once()

--- a/server/tests/test_infra/test_storage_eval_logs.py
+++ b/server/tests/test_infra/test_storage_eval_logs.py
@@ -10,13 +10,24 @@ from decision_hub.infra.storage import (
 )
 
 
-def _make_s3_client() -> MagicMock:
-    return MagicMock()
+def _make_s3_client(pages: list[dict] | None = None) -> MagicMock:
+    """Return an S3 client mock whose ``get_paginator("list_objects_v2")``
+    yields the provided pages.
+
+    ``list_eval_log_chunks`` and ``delete_eval_logs`` iterate the paginator
+    to avoid the 1000-key cap of a single ``list_objects_v2`` call, so all
+    tests exercise the paginator API rather than the flat call.
+    """
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = pages or []
+    client.get_paginator.return_value = paginator
+    return client
 
 
 class TestUploadEvalLogChunk:
     def test_uploads_with_correct_key_and_content(self):
-        client = _make_s3_client()
+        client = MagicMock()
         result = upload_eval_log_chunk(client, "test-bucket", "eval-logs/run123/", 1, '{"seq":1}\n')
         assert result == "eval-logs/run123/0001.jsonl"
         client.put_object.assert_called_once_with(
@@ -27,60 +38,90 @@ class TestUploadEvalLogChunk:
         )
 
     def test_zero_pads_sequence_number(self):
-        client = _make_s3_client()
+        client = MagicMock()
         result = upload_eval_log_chunk(client, "bucket", "prefix/", 42, "data")
         assert result == "prefix/0042.jsonl"
 
 
 class TestListEvalLogChunks:
     def test_returns_chunks_after_cursor(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "eval-logs/run/0001.jsonl"},
-                {"Key": "eval-logs/run/0002.jsonl"},
-                {"Key": "eval-logs/run/0003.jsonl"},
+        client = _make_s3_client(
+            [
+                {
+                    "Contents": [
+                        {"Key": "eval-logs/run/0001.jsonl"},
+                        {"Key": "eval-logs/run/0002.jsonl"},
+                        {"Key": "eval-logs/run/0003.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "eval-logs/run/", after_seq=1)
         assert len(result) == 2
         assert result[0] == (2, "eval-logs/run/0002.jsonl")
         assert result[1] == (3, "eval-logs/run/0003.jsonl")
+        client.get_paginator.assert_called_once_with("list_objects_v2")
 
     def test_returns_empty_for_no_contents(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client([{"Contents": []}])
+        result = list_eval_log_chunks(client, "bucket", "prefix/")
+        assert result == []
+
+    def test_returns_empty_for_missing_contents_key(self):
+        client = _make_s3_client([{}])
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert result == []
 
     def test_skips_non_jsonl_files(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "prefix/0001.jsonl"},
-                {"Key": "prefix/readme.txt"},
+        client = _make_s3_client(
+            [
+                {
+                    "Contents": [
+                        {"Key": "prefix/0001.jsonl"},
+                        {"Key": "prefix/readme.txt"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert len(result) == 1
 
     def test_returns_sorted_by_seq(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0003.jsonl"},
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            [
+                {
+                    "Contents": [
+                        {"Key": "p/0003.jsonl"},
+                        {"Key": "p/0001.jsonl"},
+                        {"Key": "p/0002.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "p/")
         seqs = [s for s, _ in result]
         assert seqs == [1, 2, 3]
 
+    def test_paginates_across_multiple_pages(self):
+        """Regression: an eval that emits more than 1000 chunks must not
+        drop the tail. Previously this used the single ``list_objects_v2``
+        call which caps at 1000 keys; the paginator must walk every page.
+        """
+        page_one = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)]}
+        page_two = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 1500)]}
+        client = _make_s3_client([page_one, page_two])
+
+        result = list_eval_log_chunks(client, "bucket", "p/")
+
+        # Every chunk across both pages is returned and sorted correctly.
+        assert len(result) == 1499
+        assert result[0][0] == 1
+        assert result[-1][0] == 1499
+
 
 class TestReadEvalLogChunk:
     def test_reads_and_decodes_content(self):
-        client = _make_s3_client()
+        client = MagicMock()
         client.get_object.return_value = {"Body": MagicMock(read=lambda: b'{"seq":1}\n{"seq":2}\n')}
         result = read_eval_log_chunk(client, "bucket", "key")
         assert '{"seq":1}' in result
@@ -89,20 +130,41 @@ class TestReadEvalLogChunk:
 
 class TestDeleteEvalLogs:
     def test_deletes_all_objects_under_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            [
+                {
+                    "Contents": [
+                        {"Key": "p/0001.jsonl"},
+                        {"Key": "p/0002.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 2
         client.delete_objects.assert_called_once()
 
     def test_returns_zero_for_empty_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client([{"Contents": []}])
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 0
         client.delete_objects.assert_not_called()
+
+    def test_returns_zero_when_paginator_yields_no_pages(self):
+        client = _make_s3_client([])
+        count = delete_eval_logs(client, "bucket", "p/")
+        assert count == 0
+        client.delete_objects.assert_not_called()
+
+    def test_deletes_across_multiple_pages(self):
+        """Regression: matches the paginated listing fix — long-running
+        evals with more than 1000 chunks previously leaked objects because
+        only the first page of listings was deleted."""
+        page_one = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)]}
+        page_two = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 1300)]}
+        client = _make_s3_client([page_one, page_two])
+
+        count = delete_eval_logs(client, "bucket", "p/")
+
+        assert count == 1299
+        assert client.delete_objects.call_count == 2

--- a/shared/src/dhub_core/manifest.py
+++ b/shared/src/dhub_core/manifest.py
@@ -33,7 +33,12 @@ def parse_skill_md(path: Path) -> SkillManifest:
         ValueError: If the file format is invalid or required fields are missing.
         FileNotFoundError: If the path does not exist.
     """
-    content = path.read_text()
+    # Pin UTF-8 explicitly: without it Python falls back to the platform
+    # locale (cp1252 on Windows), so SKILL.md files containing em-dashes,
+    # curly quotes, or accented characters — extremely common in the
+    # ``description`` field — fail with ``UnicodeDecodeError`` before we
+    # even reach validation.
+    content = path.read_text(encoding="utf-8")
     frontmatter_str, body = split_frontmatter(content)
     data = parse_frontmatter_yaml(frontmatter_str)
 

--- a/shared/tests/test_manifest.py
+++ b/shared/tests/test_manifest.py
@@ -342,3 +342,23 @@ class TestAllowedToolsCoercion:
         path = self._write_skill_md(tmp_path, content)
         with pytest.raises(ValueError, match="allowed_tools must be a string or list"):
             parse_skill_md(path)
+
+
+class TestParseSkillMdEncoding:
+    """Regression: parse_skill_md must pin UTF-8 explicitly so common
+    non-ASCII descriptions (em-dash, curly quote, accented characters) do
+    not blow up on platforms whose locale defaults to cp1252 (Windows)."""
+
+    def test_utf8_content_parses_when_file_is_utf8(self, tmp_path) -> None:
+        """A SKILL.md whose bytes are UTF-8 must parse regardless of the
+        current process locale."""
+        # ``—`` (em-dash, U+2014) is not representable in cp1252/latin-1
+        # roundtrips via read_text() with the wrong encoding — but under
+        # UTF-8 it must round-trip cleanly.
+        content = "---\nname: unicode-skill\ndescription: A skill — with an em-dash and “curly quotes”.\n---\nBody\n"
+        path = tmp_path / "SKILL.md"
+        path.write_bytes(content.encode("utf-8"))
+
+        manifest = parse_skill_md(path)
+        assert "em-dash" in manifest.description
+        assert "curly quotes" in manifest.description


### PR DESCRIPTION
## What changed

A read-only audit of the server, CLI, and shared packages surfaced a small set of concrete correctness bugs and CLAUDE.md-rule violations. This PR fixes them, adds regression tests, and leaves behaviour otherwise unchanged.

## Why

No linked issue — surfaced by a codebase-wide review. Each fix maps to a concrete failing scenario (details below).

Closes #

## How to test

`make test lint typecheck` all pass locally. Suite-by-suite:

- shared: `99 passed`
- client: `292 passed, 29 skipped`
- server: `941 passed` (`-m "not slow"`)
- frontend (`npx vitest run`): `82 passed`
- `uvx ruff@0.15.3 check .` and `format --check .` clean
- `uvx mypy client/src/ server/src/ shared/src/`: `no issues found in 88 source files`

Manually verifiable regressions each new test locks in:

1. **`tracker_service`** — `TestDisabledCountPreservedOnEarlyReturn::test_disabled_count_survives_rate_limit_early_return` fails on `main` (returns `trackers_disabled=0`).
2. **`search_routes`** — `test_ask_fallback_analytics_records_actual_answer` fails on `main` (analytics record `answer=""`).
3. **`storage`** — `test_paginates_across_multiple_pages` / `test_deletes_across_multiple_pages` fail on `main` (only first 1000 keys handled).
4. **`org_routes`** — `test_org_stats_returns_429_after_limit` / `test_org_profiles_returns_429_after_limit` fail on `main` (no rate limiter).
5. **CLI** — `test_list_handles_null_updated_at` fails on `main` (`None[:10]` TypeError crashes `dhub list`).
6. **shared/manifest** — `TestParseSkillMdEncoding::test_utf8_content_parses_when_file_is_utf8` fails on `main` when the process locale is not UTF-8 (Windows cp1252).

## Checklist
- [x] Tests pass (`make test`)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — not applicable, no schema changes

---

### Detailed fixes

**Server**

- `domain/tracker_service.py` — the two guardrail early-return paths in `check_all_due_trackers` (GitHub rate-limit low; dispatch deadline too close) hard-coded `trackers_disabled=0`, silently dropping the count of trackers the permanent-failure circuit breaker had already disabled earlier in the same tick. Both branches now propagate `disabled_count`.
- `api/search_routes.py` — the LLM-failure fallback recorded `answer=""` in analytics while the response body returned "Here are the most relevant skills I found:". Extracted the string into a local `fallback_answer` so response and analytics cannot drift.
- `infra/storage.py` — `list_eval_log_chunks` and `delete_eval_logs` used `list_objects_v2` directly, which caps at 1000 keys. Long streaming evals whose `chunk_seq` crossed 1000 silently lost the tail of their log (and `delete_eval_logs` leaked objects). Switched both to the paginator; the delete path batches deletes per page since `delete_objects` also has a 1000-key cap.
- `scripts/backfill_embeddings.py` — added `.order_by(skills_table.c.id)` on the `LIMIT` query to satisfy the SQL-correctness rule from `CLAUDE.md` (a persistently failing batch could otherwise starve later work), and snapshotted the pending count so progress logs read `500/12000` instead of the nonsensical `500/500`.
- Loguru rule (`CLAUDE.md` requires `logger.opt(exception=True)` rather than formatting exceptions into the message string) — fixed six sites across `api/registry_service.py` and `domain/evals.py`. On-call now sees tracebacks in stderr for background eval failures instead of a bare "sandbox error: <msg>" line.
- `api/org_routes.py` + `settings.py` — the public unauthenticated `/v1/orgs/stats` and `/v1/orgs/profiles` endpoints, both fronting expensive aggregate queries, had no rate limiter. Added `_enforce_org_stats_rate_limit` and `_enforce_org_profiles_rate_limit` mirroring the existing `_enforce_*_rate_limit` pattern, with settings (`org_stats_rate_limit` / `org_profiles_rate_limit`, default 120/60s each).

**CLI / shared**

- `client/src/dhub/cli/registry.py` — the Ctrl-C detach message in `publish_command` was a plain string, so users saw the literal token `{eval_run_id}` instead of a copyable id. Added the `f` prefix.
- `client/src/dhub/cli/registry.py` — `_render_skills_table` did `s.get("updated_at", "")[:10]`, which returns `None` when the key is present with a null value; slicing then blew up the entire `dhub list` render with `TypeError`. Guarded with `(s.get("updated_at") or "")[:10]`.
- `shared/src/dhub_core/manifest.py` and `client/src/dhub/cli/init.py` — pinned `encoding="utf-8"` on the SKILL.md read and write so a Windows user whose locale defaults to cp1252 can round-trip em-dashes, curly quotes, and accented characters in the description. Every other file I/O in the project already sets UTF-8 explicitly; these two were the outliers.

**Tests**

- `server/tests/test_domain/test_tracker_service.py` — regression test for the disabled-count fix.
- `server/tests/test_api/test_search_routes.py` — regression test that the fallback analytics record the same `answer` as the response body.
- `server/tests/test_infra/test_storage_eval_logs.py` — rewrote to mock the paginator API; added `>1000 chunks` list-and-delete regression tests.
- `server/tests/test_api/test_org_routes.py` + `conftest.py` — 429 assertions for both new rate limiters.
- `client/tests/test_cli/test_registry_cli.py` — CLI list test with `updated_at=null`.
- `shared/tests/test_manifest.py` — UTF-8 SKILL.md parse test.

### Not in scope for this PR

The following review findings were surfaced but need behaviour discussion before touching:

- `RateLimiter` keys on `request.client.host`, which collapses to Modal's proxy IP. Fix would prefer `X-Forwarded-For` — but requires validating what Modal actually sets.
- `find_active_eval_runs_for_user` is misnamed (it does not filter by status). Renaming touches an established API surface.
- `get_eval_run` does a double-read after `_check_zombie` on every request — trivial to fix but not a bug, and the polling loop is not currently a bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExQM2wkZaZSayZMmgsHDx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExQM2wkZaZSayZMmgsHDx5)_