### PR TITLE
fix: correctness, security, and hardening pass across server + CLI

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -1,5 +1,6 @@
 """CLI configuration file management for ~/.dhub/config.{env}.json."""
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -82,14 +83,37 @@ def load_config() -> CliConfig:
 def save_config(config: CliConfig) -> None:
     """Save CLI config to ~/.dhub/config.{env}.json.
 
-    Creates the ~/.dhub directory if it does not already exist.
+    Creates the ~/.dhub directory if it does not already exist. The
+    config file contains a long-lived bearer token, so:
+
+    - The directory is created with mode 0700 (owner-only) so a
+      brand-new install is not readable by other local users.
+    - The file is written atomically via a temp-then-``os.replace``
+      dance: Ctrl-C mid-write no longer leaves the config half-written
+      (which the loader treats as corrupted and asks the user to delete,
+      losing their token).
+    - The file itself is chmod'd to 0600 so an existing ~/.dhub with
+      loose permissions is tightened on next save. On Windows this is a
+      no-op because chmod semantics don't apply — POSIX users benefit,
+      Windows behaviour is unchanged.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # Tighten directory perms best-effort; ignore errors on Windows where
+    # POSIX mode semantics don't apply.
+    with contextlib.suppress(OSError, NotImplementedError):
+        CONFIG_DIR.chmod(0o700)
+
     path = config_file()
-    path.write_text(
-        json.dumps(asdict(config), indent=2) + "\n",
-        encoding="utf-8",
-    )
+    payload = json.dumps(asdict(config), indent=2) + "\n"
+
+    # Write to a sibling temp file first so a mid-write interrupt cannot
+    # leave the real config truncated. ``os.replace`` is atomic on POSIX
+    # and Windows (Python 3.3+).
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    with contextlib.suppress(OSError, NotImplementedError):
+        tmp.chmod(0o600)
+    os.replace(tmp, path)
 
 
 def get_api_url() -> str:

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -1,6 +1,9 @@
 """Tests for dhub.cli.config -- CLI configuration management."""
 
 import json
+import os
+import stat
+import sys
 
 import click
 import pytest
@@ -90,6 +93,64 @@ class TestSaveConfig:
 
         assert loaded.orgs == ("alice", "pymc-labs")
         assert loaded.default_org == "pymc-labs"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX perms not applicable on Windows")
+    def test_saved_file_has_owner_only_perms(self, tmp_path, monkeypatch):
+        """The token is a long-lived bearer; the file must not be world-readable."""
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://example.com", token="secret-token"))
+
+        path = tmp_path / "config.dev.json"
+        mode = stat.S_IMODE(path.stat().st_mode)
+        # Owner-only (0o600). Group and other must not have read bits.
+        assert mode & 0o077 == 0, f"config file must be 0o600, got {oct(mode)}"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX perms not applicable on Windows")
+    def test_save_tightens_existing_loose_directory_perms(self, tmp_path, monkeypatch):
+        """A pre-existing ~/.dhub with loose perms is tightened on next save."""
+        # Create the dir up front with the default umask (typically 0o755).
+        tmp_path.chmod(0o755)
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://example.com", token="secret"))
+
+        mode = stat.S_IMODE(tmp_path.stat().st_mode)
+        assert mode & 0o077 == 0, f"config dir must be 0o700, got {oct(mode)}"
+
+    def test_save_is_atomic_leaves_no_partial_file_on_error(self, tmp_path, monkeypatch):
+        """A crash mid-write must not overwrite the real config with a truncated one.
+
+        Regression: prior implementation used ``path.write_text`` directly,
+        so Ctrl-C mid-write could leave the config half-written; the loader
+        treated that as corruption and prompted the user to delete their
+        config — losing their token.
+        """
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        # Seed with a valid config first.
+        save_config(CliConfig(api_url="https://a.example.com", token="old-tok"))
+        good_content = (tmp_path / "config.dev.json").read_text()
+
+        # Now simulate a crash during os.replace by patching it to raise.
+        real_replace = os.replace
+
+        def failing_replace(src, dst):
+            # The temp file should have been created and written already.
+            assert os.path.exists(src), "atomic write must create a .tmp file first"
+            raise KeyboardInterrupt("simulated Ctrl-C")
+
+        monkeypatch.setattr("dhub.cli.config.os.replace", failing_replace)
+        with pytest.raises(KeyboardInterrupt):
+            save_config(CliConfig(api_url="https://b.example.com", token="new-tok"))
+
+        # The real config must be untouched (still parseable, still holds old-tok).
+        monkeypatch.setattr("dhub.cli.config.os.replace", real_replace)
+        assert (tmp_path / "config.dev.json").read_text() == good_content
+        assert load_config().token == "old-tok"
 
     def test_backward_compat_no_orgs_field(self, tmp_path, monkeypatch):
         """Loading old config without orgs field should use defaults."""

--- a/server/src/decision_hub/api/app.py
+++ b/server/src/decision_hub/api/app.py
@@ -30,6 +30,10 @@ class SecurityHeadersMiddleware:
     - X-Frame-Options: DENY — prevents clickjacking by disallowing iframe embedding
     - X-Content-Type-Options: nosniff — prevents MIME-type sniffing attacks
     - Strict-Transport-Security — enforces HTTPS for 1 year (with subdomains)
+    - Referrer-Policy — strip full URLs from cross-origin referrers so
+      skill / eval URLs don't leak into third-party analytics
+    - Permissions-Policy — deny high-privilege browser features the SPA
+      never needs (camera, mic, geo, payment, USB, MIDI, XR)
 
     Implemented as raw ASGI to avoid the receive-wrapping deadlock with UploadFile.
     """
@@ -38,6 +42,11 @@ class SecurityHeadersMiddleware:
         [b"x-frame-options", b"DENY"],
         [b"x-content-type-options", b"nosniff"],
         [b"strict-transport-security", b"max-age=31536000; includeSubDomains"],
+        [b"referrer-policy", b"strict-origin-when-cross-origin"],
+        [
+            b"permissions-policy",
+            b"camera=(), microphone=(), geolocation=(), payment=(), usb=(), midi=(), xr-spatial-tracking=()",
+        ],
     ]
 
     def __init__(self, app: ASGIApp) -> None:

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,5 +1,7 @@
 """Authentication routes - GitHub Device Flow login."""
 
+import asyncio
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
@@ -7,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -28,14 +30,14 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 def _enforce_auth_rate_limit(request: Request) -> None:
     """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_auth_rate_limiter",
+        settings.auth_rate_limit,
+        settings.auth_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------
@@ -142,11 +144,14 @@ async def exchange_token(
     allowed_orgs = settings.required_github_orgs
     if allowed_orgs:
         username = gh_user["login"]
-        is_member = False
-        for org in allowed_orgs:
-            if await check_org_membership(gh_token, org, username):
-                is_member = True
-                break
+        # Membership checks are independent GitHub REST calls; run them
+        # concurrently. Previously we awaited them sequentially, so a user in
+        # the Nth allowed org paid N * round-trip latency on every login.
+        membership_results = await asyncio.gather(
+            *(check_org_membership(gh_token, org, username) for org in allowed_orgs),
+            return_exceptions=True,
+        )
+        is_member = any(r is True for r in membership_results)
         if not is_member:
             logger.warning("User {} denied access — not in required orgs {}", username, allowed_orgs)
             raise HTTPException(

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -5,6 +5,7 @@ import time
 from collections import defaultdict
 
 from fastapi import HTTPException, Request
+from starlette.datastructures import State
 
 
 class RateLimiter:
@@ -18,6 +19,12 @@ class RateLimiter:
     Thread-safe: FastAPI runs sync dependencies in a threadpool, so
     concurrent access to shared state is guarded by a lock.
 
+    Client-IP resolution honours ``X-Forwarded-For`` when the request is
+    coming from a trusted upstream (Modal terminates TLS and forwards
+    the original IP in this header). Without this, every request looks
+    like it came from the proxy address and one heavy caller starves
+    everyone else on the same container.
+
     Usage as a FastAPI dependency::
 
         limiter = RateLimiter(max_requests=10, window_seconds=60)
@@ -26,23 +33,29 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # Purge stale IP buckets every N accepted requests. Bounded work per
+    # admission; O(unique-ips) at trigger time, not O(total-entries).
+    _PURGE_INTERVAL = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._admissions_since_purge = 0
 
     def __call__(self, request: Request) -> None:
-        key = request.client.host if request.client else "unknown"
+        key = _client_key(request)
         now = time.monotonic()
         cutoff = now - self.window_seconds
 
         with self._lock:
             # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            fresh = [t for t in timestamps if t > cutoff]
+            self._requests[key] = fresh
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(fresh) >= self.max_requests:
                 raise HTTPException(
                     status_code=429,
                     detail=(
@@ -50,12 +63,14 @@ class RateLimiter:
                     ),
                 )
 
-            self._requests[key].append(now)
+            fresh.append(now)
 
             # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            # An accumulator avoids the O(total-entries) sum() the previous
+            # implementation ran on every admission.
+            self._admissions_since_purge += 1
+            if self._admissions_since_purge >= self._PURGE_INTERVAL:
+                self._admissions_since_purge = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:
@@ -63,3 +78,61 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def _client_key(request: Request) -> str:
+    """Return a stable per-client key for rate limiting.
+
+    Prefers the first entry of ``X-Forwarded-For`` (added by Modal /
+    reverse proxies), then falls back to ``request.client.host``.
+    Trusts the header because Modal's edge is the only ingress; behind a
+    different topology this would need an explicit trusted-proxy list.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        # First entry is the original client; subsequent entries are proxy hops.
+        first = xff.split(",", 1)[0].strip()
+        if first:
+            return first
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Lazy limiter registry (thread-safe)
+# ---------------------------------------------------------------------------
+
+# Guards concurrent lazy-init in _get_or_create_limiter. Without this,
+# two concurrent requests to a fresh container both instantiate a new
+# RateLimiter and the second setattr replaces the first — the accounting
+# for whichever bucket lost the race is discarded. Attackers can time
+# bursts against cold-starts to double their effective quota.
+_INIT_LOCK = threading.Lock()
+
+
+def get_or_create_limiter(
+    state: State,
+    name: str,
+    max_requests: int,
+    window_seconds: int,
+) -> RateLimiter:
+    """Return the RateLimiter stored on ``state`` under ``name``, creating it once.
+
+    Thread-safe: guarded by a module-level lock so concurrent first-access
+    doesn't produce two limiter instances (see comment on ``_INIT_LOCK``).
+    """
+    limiter = getattr(state, name, None)
+    if limiter is not None:
+        return limiter
+    with _INIT_LOCK:
+        # Re-check under the lock (double-checked locking) so we don't
+        # replace a limiter another thread already created.
+        limiter = getattr(state, name, None)
+        if limiter is None:
+            limiter = RateLimiter(
+                max_requests=max_requests,
+                window_seconds=window_seconds,
+            )
+            setattr(state, name, limiter)
+        return limiter

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -85,86 +85,86 @@ public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 def _enforce_list_skills_rate_limit(request: Request) -> None:
     """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_list_skills_rate_limiter",
+        settings.list_skills_rate_limit,
+        settings.list_skills_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_resolve_rate_limit(request: Request) -> None:
     """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_resolve_rate_limiter",
+        settings.resolve_rate_limit,
+        settings.resolve_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_similar_skills_rate_limit(request: Request) -> None:
     """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_similar_skills_rate_limiter",
+        settings.similar_skills_rate_limit,
+        settings.similar_skills_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_download_rate_limit(request: Request) -> None:
     """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_download_rate_limiter",
+        settings.download_rate_limit,
+        settings.download_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_audit_log_rate_limit(request: Request) -> None:
     """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_audit_log_rate_limiter",
+        settings.audit_log_rate_limit,
+        settings.audit_log_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_scan_report_rate_limit(request: Request) -> None:
     """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_scan_report_rate_limiter",
+        settings.scan_report_rate_limit,
+        settings.scan_report_rate_window,
+    )
+    limiter(request)
 
 
 def _enforce_publish_rate_limit(request: Request) -> None:
     """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_publish_rate_limiter",
+        settings.publish_rate_limit,
+        settings.publish_rate_window,
+    )
+    limiter(request)
 
 
 _VALID_VISIBILITIES = {"public", "org"}

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import get_or_create_limiter
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -31,14 +31,14 @@ router = APIRouter(prefix="/v1", tags=["search"])
 
 def _enforce_search_rate_limit(request: Request) -> None:
     """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+    settings: Settings = request.app.state.settings
+    limiter = get_or_create_limiter(
+        request.app.state,
+        "_search_rate_limiter",
+        settings.search_rate_limit,
+        settings.search_rate_window,
+    )
+    limiter(request)
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/domain/evals.py
+++ b/server/src/decision_hub/domain/evals.py
@@ -386,8 +386,11 @@ def stream_eval_pipeline(
             duration_ms=duration_ms,
         )
 
-    # Final summary event
-    all_passed = all(r["verdict"] == "pass" for r in case_results)
+    # Final summary event. ``all([])`` is ``True``, so a run with zero
+    # cases would silently be marked ``completed`` — that would let a
+    # skill ship with no eval cases and appear as if it passed evaluation.
+    # Explicitly require at least one case and require every case to pass.
+    all_passed = bool(case_results) and all(r["verdict"] == "pass" for r in case_results)
     status = "completed" if all_passed else "failed"
 
     seq += 1
@@ -509,13 +512,16 @@ def run_streaming_eval(
         # Final flush
         _flush_buffer()
 
-        # Write eval_reports row (same as original pipeline)
+        # Write eval_reports row (same as original pipeline).
+        # Guard against zero-case reports: ``all([])`` is ``True`` and would
+        # mark a zero-case run as ``completed``, which is the same failure
+        # mode as the non-streaming pipeline above.
         if final_report_event:
             case_results = final_report_event["case_results"]
             passed = final_report_event["passed"]
             total = final_report_event["total"]
             total_duration_ms = final_report_event["total_duration_ms"]
-            all_passed = all(r["verdict"] == "pass" for r in case_results)
+            all_passed = bool(case_results) and all(r["verdict"] == "pass" for r in case_results)
             status = "completed" if all_passed else "failed"
 
             with engine.connect() as conn:

--- a/server/src/decision_hub/infra/cache.py
+++ b/server/src/decision_hub/infra/cache.py
@@ -5,6 +5,17 @@ Each entry expires independently after its TTL elapses. Designed for
 slowly-changing data like taxonomy, org profiles, and skill listings
 where a few seconds of staleness is acceptable.
 
+``get`` returns ``None`` on miss for backwards compatibility. Callers
+that need to cache a legitimate ``None`` value should pass the
+``MISS`` sentinel as the ``default`` and check for identity::
+
+    from decision_hub.infra.cache import MISS
+
+    entry = cache.get("my-key", default=MISS)
+    if entry is MISS:
+        entry = expensive_query()  # may legitimately be None
+        cache.set("my-key", entry)
+
 Usage:
     cache = TTLCache(default_ttl=30)
     value = cache.get("my-key")
@@ -16,7 +27,18 @@ Usage:
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Final
+
+
+class _Missing:
+    """Sentinel type for ``MISS``; distinct from ``None`` so ``None``
+    is a legitimate cached value."""
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "<TTLCache.MISS>"
+
+
+MISS: Final = _Missing()
 
 
 @dataclass
@@ -34,8 +56,8 @@ class TTLCache:
     Args:
         default_ttl: Default time-to-live in seconds for cached entries.
         max_size: Maximum number of entries. When exceeded, expired entries
-                  are purged first; if still over limit, the oldest entry
-                  is evicted.
+                  are purged first; if still over limit, the entry expiring
+                  soonest is evicted.
     """
 
     default_ttl: float = 30.0
@@ -43,15 +65,21 @@ class TTLCache:
     _store: dict[str, _CacheEntry] = field(default_factory=dict, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
-    def get(self, key: str) -> Any | None:
-        """Return the cached value if present and not expired, else None."""
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the cached value if present and not expired, else ``default``.
+
+        Returns ``None`` on miss by default (backwards compatible). To
+        cache values that may legitimately be ``None``, pass
+        ``default=MISS`` and compare the result against ``MISS`` with
+        ``is`` — see the module docstring.
+        """
         with self._lock:
             entry = self._store.get(key)
             if entry is None:
-                return None
+                return default
             if time.monotonic() > entry.expires_at:
                 del self._store[key]
-                return None
+                return default
             return entry.value
 
     def set(self, key: str, value: Any, ttl: float | None = None) -> None:

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2788,7 +2788,13 @@ def insert_search_log(
 
 
 def _row_to_skill_tracker(row: sa.Row) -> SkillTracker:
-    """Map a database row to a SkillTracker model."""
+    """Map a database row to a SkillTracker model.
+
+    NB: ``consecutive_permanent_failures`` must be read from the row —
+    the dataclass has a default of 0, so an omitted field silently
+    zeroes the counter on every read, defeating the disable-after-N
+    permanent-failures logic and any downstream backoff.
+    """
     return SkillTracker(
         id=row.id,
         user_id=row.user_id,
@@ -2802,6 +2808,7 @@ def _row_to_skill_tracker(row: sa.Row) -> SkillTracker:
         last_published_at=row.last_published_at,
         last_error=row.last_error,
         next_check_at=row.next_check_at,
+        consecutive_permanent_failures=row.consecutive_permanent_failures,
         created_at=row.created_at,
     )
 

--- a/server/src/decision_hub/infra/github_app_token.py
+++ b/server/src/decision_hub/infra/github_app_token.py
@@ -24,9 +24,14 @@ def mint_installation_token(
     Raises ``httpx.HTTPStatusError`` on API failure.
     """
     now = int(time.time())
+    # GitHub enforces exp <= github_now + 600. Our clock can be ahead of
+    # GitHub's; if it is, ``now + 600`` fails GitHub's check with 401 and
+    # every mint attempt fails until the local clock catches up. Give
+    # ourselves 60s of margin: exp = now + 540 (well inside the cap even
+    # when we're a minute ahead).
     payload = {
         "iat": now - 60,  # issued-at: 60s in the past to account for clock drift
-        "exp": now + (10 * 60),  # expires in 10 minutes (GitHub max)
+        "exp": now + (9 * 60),  # expires in 9 minutes — 60s under GitHub's 10-min max
         "iss": app_id,
     }
     encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")

--- a/server/src/decision_hub/logging.py
+++ b/server/src/decision_hub/logging.py
@@ -249,6 +249,13 @@ def _extract_username_from_jwt(auth_header: str) -> str:
     happens in the dependency layer. We decode the payload segment
     (base64url) to read the ``username`` claim. Returns empty string
     on any failure.
+
+    The returned value is prefixed with ``unverified:`` because the
+    signature is not checked here. Anyone can craft a JWT with an
+    arbitrary ``username`` claim; without the prefix, an attacker
+    could poison logs with e.g. ``admin`` and make log-search results
+    dishonest. Verified identity is available downstream once
+    ``get_current_user`` runs.
     """
     import base64
 
@@ -263,6 +270,9 @@ def _extract_username_from_jwt(auth_header: str) -> str:
         payload_b64 = parts[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        return payload.get("username", "")
+        username = payload.get("username", "")
+        if not username:
+            return ""
+        return f"unverified:{username}"
     except Exception:
         return ""

--- a/server/tests/test_api/test_logging.py
+++ b/server/tests/test_api/test_logging.py
@@ -156,7 +156,13 @@ class TestSensitiveUrlParamRedaction:
 
 class TestExtractUsernameFromJwt:
     def test_extracts_username_from_valid_jwt(self):
-        """Should decode the payload and extract the username claim."""
+        """Should decode the payload and extract the username claim.
+
+        The returned value is prefixed with ``unverified:`` because the
+        JWT signature is not checked here — the prefix keeps forged log
+        entries distinguishable from verified identities established
+        downstream.
+        """
         import base64
 
         header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
@@ -164,7 +170,7 @@ class TestExtractUsernameFromJwt:
         sig = "fakesig"
         token = f"{header}.{payload}.{sig}"
         result = _extract_username_from_jwt(f"Bearer {token}")
-        assert result == "alice"
+        assert result == "unverified:alice"
 
     def test_returns_empty_on_missing_bearer(self):
         assert _extract_username_from_jwt("Basic abc") == ""
@@ -181,3 +187,16 @@ class TestExtractUsernameFromJwt:
         token = f"{header}.{payload}.{sig}"
         result = _extract_username_from_jwt(f"Bearer {token}")
         assert result == ""
+
+    def test_forged_admin_username_is_marked_unverified(self):
+        """A caller-crafted 'admin' token must not appear as verified 'admin' in logs."""
+        import base64
+
+        header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(b'{"username":"admin"}').rstrip(b"=").decode()
+        token = f"{header}.{payload}.aaaa"
+        result = _extract_username_from_jwt(f"Bearer {token}")
+        # Prefix is what makes log-search dishonest attempts detectable.
+        assert result.startswith("unverified:")
+        assert "admin" in result
+        assert result != "admin"

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,17 +1,32 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import State
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import (
+    RateLimiter,
+    _client_key,
+    get_or_create_limiter,
+)
 
 
-def _make_request(host: str = "127.0.0.1") -> MagicMock:
-    """Create a mock Request with a given client IP."""
+def _make_request(host: str = "127.0.0.1", forwarded_for: str | None = None) -> MagicMock:
+    """Create a mock Request with a given client IP.
+
+    Uses a real dict for ``request.headers`` so the ``.get()`` return
+    value is a real Optional[str], not a MagicMock (which would be
+    truthy and defeat the header check).
+    """
     request = MagicMock()
     request.client.host = host
+    headers = {}
+    if forwarded_for is not None:
+        headers["x-forwarded-for"] = forwarded_for
+    request.headers = headers
     return request
 
 
@@ -77,6 +92,7 @@ class TestRateLimiter:
         limiter = RateLimiter(max_requests=2, window_seconds=60)
         request = MagicMock()
         request.client = None
+        request.headers = {}
 
         for _ in range(2):
             limiter(request)
@@ -84,3 +100,86 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestClientKey:
+    """Unit tests for the X-Forwarded-For handling in ``_client_key``."""
+
+    def test_prefers_first_x_forwarded_for_entry(self) -> None:
+        """The first XFF entry (original client) is used as the key."""
+        req = _make_request(host="10.0.0.99", forwarded_for="203.0.113.4, 10.0.0.1")
+        assert _client_key(req) == "203.0.113.4"
+
+    def test_falls_back_to_client_host(self) -> None:
+        """Without XFF, ``request.client.host`` is used."""
+        req = _make_request(host="10.0.0.5")
+        assert _client_key(req) == "10.0.0.5"
+
+    def test_empty_x_forwarded_for_ignored(self) -> None:
+        """An empty XFF value falls back to client.host, not the empty string."""
+        req = _make_request(host="10.0.0.7", forwarded_for="")
+        assert _client_key(req) == "10.0.0.7"
+
+    def test_xff_gives_distinct_limits_behind_proxy(self) -> None:
+        """Two clients behind the same proxy get separate limiter buckets."""
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        # Same proxy IP, different real client IPs.
+        req_a = _make_request(host="10.0.0.99", forwarded_for="203.0.113.4")
+        req_b = _make_request(host="10.0.0.99", forwarded_for="203.0.113.5")
+        limiter(req_a)
+        # Without XFF handling both requests would share one bucket and
+        # this second call would raise; with XFF it must not.
+        limiter(req_b)
+
+
+class TestPurgeAccumulator:
+    """Regression tests for the O(1) purge trigger."""
+
+    def test_purge_runs_after_interval(self) -> None:
+        """After _PURGE_INTERVAL admissions, stale keys are cleared."""
+        limiter = RateLimiter(max_requests=1000, window_seconds=1)
+        # Seed a stale key from an "old" IP.
+        limiter._requests["old-ip"] = [0.0]  # timestamp way in the past
+
+        # Drive PURGE_INTERVAL admissions from a different key.
+        for i in range(limiter._PURGE_INTERVAL):
+            limiter(_make_request(host=f"1.1.1.{i % 250}"))
+
+        # The stale key should have been swept.
+        assert "old-ip" not in limiter._requests
+
+
+class TestGetOrCreateLimiter:
+    """Regression tests for the lazy-init race."""
+
+    def test_returns_same_limiter_across_calls(self) -> None:
+        """A second call must return the previously-stored limiter."""
+        state = State()
+        first = get_or_create_limiter(state, "_test_limiter", 10, 60)
+        second = get_or_create_limiter(state, "_test_limiter", 10, 60)
+        assert first is second
+
+    def test_concurrent_init_produces_one_instance(self) -> None:
+        """Concurrent first-access must not produce two limiter instances.
+
+        Without the init lock, two threads both fail the ``hasattr`` /
+        ``getattr`` check and both instantiate a fresh RateLimiter; one
+        setattr wins and the other's accounting is silently lost.
+        """
+        state = State()
+        results: list[RateLimiter] = []
+        start = threading.Event()
+
+        def race() -> None:
+            start.wait()
+            results.append(get_or_create_limiter(state, "_race_limiter", 10, 60))
+
+        threads = [threading.Thread(target=race) for _ in range(16)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join()
+
+        # All threads must have observed the same instance.
+        assert len({id(r) for r in results}) == 1

--- a/server/tests/test_api/test_security_headers.py
+++ b/server/tests/test_api/test_security_headers.py
@@ -34,6 +34,21 @@ class TestSecurityHeadersMiddleware:
         resp = client.get("/test")
         assert resp.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
 
+    def test_referrer_policy_present(self) -> None:
+        """Skill/eval URLs must not leak into third-party analytics via Referer."""
+        client = TestClient(_make_app())
+        resp = client.get("/test")
+        assert resp.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+
+    def test_permissions_policy_denies_privileged_features(self) -> None:
+        """High-privilege browser features the SPA never needs are disabled."""
+        client = TestClient(_make_app())
+        resp = client.get("/test")
+        policy = resp.headers["permissions-policy"]
+        for feature in ("camera", "microphone", "geolocation", "payment", "usb"):
+            # Each entry looks like ``feature=()`` — an empty allowlist.
+            assert f"{feature}=()" in policy
+
     def test_headers_on_error_responses(self) -> None:
         """Security headers should appear even on 404 responses."""
         client = TestClient(_make_app())
@@ -42,3 +57,5 @@ class TestSecurityHeadersMiddleware:
         assert resp.headers["x-frame-options"] == "DENY"
         assert resp.headers["x-content-type-options"] == "nosniff"
         assert resp.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
+        assert resp.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+        assert "camera=()" in resp.headers["permissions-policy"]

--- a/server/tests/test_domain/test_streaming_evals.py
+++ b/server/tests/test_domain/test_streaming_evals.py
@@ -181,6 +181,28 @@ class TestStreamEvalPipeline:
         assert report["status"] == "completed"
         assert report["total_duration_ms"] == 5000
 
+    def test_zero_cases_marks_report_failed_not_completed(self) -> None:
+        """A skill shipping zero eval cases must NOT be reported as ``completed``.
+
+        Regression: ``all([])`` is ``True``, which previously let a
+        run with no cases silently mark itself green. Guarded by an
+        explicit ``bool(case_results)`` check.
+        """
+        events = list(
+            stream_eval_pipeline(
+                skill_zip=b"fake-zip",
+                eval_config=_make_config(),
+                eval_cases=(),  # no cases
+                agent_env_vars={"ANTHROPIC_API_KEY": "test-key"},
+                org_slug="test-org",
+                skill_name="test-skill",
+            )
+        )
+        report = next(e for e in events if e["type"] == "report")
+        assert report["total"] == 0
+        assert report["passed"] == 0
+        assert report["status"] == "failed"
+
     @patch("decision_hub.domain.evals.judge_eval_output")
     @patch("decision_hub.domain.evals.stream_eval_case_in_sandbox")
     @patch("decision_hub.domain.evals.get_agent_config")

--- a/server/tests/test_infra/test_cache.py
+++ b/server/tests/test_infra/test_cache.py
@@ -2,7 +2,28 @@
 
 import time
 
-from decision_hub.infra.cache import TTLCache
+from decision_hub.infra.cache import MISS, TTLCache
+
+
+class TestMissSentinel:
+    """Regression tests for None-vs-miss disambiguation via the MISS sentinel."""
+
+    def test_default_get_returns_none_for_miss(self) -> None:
+        """Backwards-compatible default: missing keys return None."""
+        cache = TTLCache(default_ttl=10)
+        assert cache.get("nope") is None
+
+    def test_miss_sentinel_distinguishes_none_from_absent(self) -> None:
+        """Callers can cache legitimate None values using default=MISS."""
+        cache = TTLCache(default_ttl=10)
+        # Before set: MISS
+        assert cache.get("key", default=MISS) is MISS
+        # After set to None: cached hit, not MISS
+        cache.set("key", None)
+        assert cache.get("key", default=MISS) is None
+        # After invalidation: MISS again
+        cache.invalidate("key")
+        assert cache.get("key", default=MISS) is MISS
 
 
 class TestTTLCacheBasics:

--- a/server/tests/test_infra/test_github_app_token.py
+++ b/server/tests/test_infra/test_github_app_token.py
@@ -65,8 +65,12 @@ class TestMintInstallationToken:
         assert decoded["iss"] == TEST_APP_ID
         # iat should be ~60s before call time
         assert before - 120 <= decoded["iat"] <= after
-        # exp should be ~10 min after iat
-        assert decoded["exp"] - decoded["iat"] == 11 * 60  # 60s back + 10 min forward
+        # exp - iat now spans 10 minutes total (60s back + 9 min forward).
+        # GitHub enforces exp <= github_now + 600; we pull exp back by 60s
+        # so a locally-fast clock (up to 60s ahead of GitHub) still passes.
+        assert decoded["exp"] - decoded["iat"] == 10 * 60
+        # And exp itself must never exceed now+600 (GitHub's hard cap).
+        assert decoded["exp"] <= after + 9 * 60
 
     @patch("decision_hub.infra.github_app_token.httpx.post")
     def test_calls_correct_url(self, mock_post: MagicMock):

--- a/server/tests/test_infra/test_tracker_db.py
+++ b/server/tests/test_infra/test_tracker_db.py
@@ -36,6 +36,7 @@ def _make_tracker_row(
     enabled: bool = True,
     last_error: str | None = None,
     next_check_at: datetime | None = None,
+    consecutive_permanent_failures: int = 0,
 ) -> MagicMock:
     """Create a mock row that simulates a skill_trackers row."""
     row = MagicMock()
@@ -51,6 +52,7 @@ def _make_tracker_row(
     row.last_published_at = None
     row.last_error = last_error
     row.next_check_at = next_check_at
+    row.consecutive_permanent_failures = consecutive_permanent_failures
     row.created_at = datetime.now(UTC)
     return row
 
@@ -73,6 +75,14 @@ class TestRowToSkillTracker:
         row = _make_tracker_row(next_check_at=now)
         tracker = _row_to_skill_tracker(row)
         assert tracker.next_check_at == now
+
+    def test_maps_consecutive_permanent_failures(self):
+        """Regression: the mapper previously dropped this field, so every
+        tracker read from DB saw ``0`` regardless of the stored value,
+        defeating the disable-after-N-failures logic."""
+        row = _make_tracker_row(consecutive_permanent_failures=7)
+        tracker = _row_to_skill_tracker(row)
+        assert tracker.consecutive_permanent_failures == 7
 
 
 class TestInsertSkillTracker:


### PR DESCRIPTION
## What changed

A deep-review pass across the server, client, shared, and frontend packages surfaced a handful of concrete bugs and hardening opportunities. This PR ships the safest, highest-leverage subset with unit tests for every fix — 19 files touched, +534 / −114, all existing tests still green.

### Correctness bugs

- **`infra/database._row_to_skill_tracker`** was silently dropping `consecutive_permanent_failures`. Because the `SkillTracker` dataclass defaults the field to `0`, every tracker read from the DB reset the counter — the "disable after N permanent failures" backoff never triggered in practice.
- **`domain/evals.stream_eval_pipeline` / `run_streaming_eval`** decided pass/fail with `all(r["verdict"] == "pass" for r in case_results)`. `all([])` is `True`, so a skill shipping zero eval cases silently reported `completed`. Guarded with an explicit `bool(case_results)` check.
- **`infra/github_app_token.mint_installation_token`** set `exp = now + 600`, but GitHub caps `exp ≤ github_now + 600`. If the local clock is even seconds ahead of GitHub's, every mint returned 401 with no retry. Pull `exp` back to `now + 540` so the token has 60 s of clock-drift margin.

### Security

- **`api/rate_limit`** now honours `X-Forwarded-For`. Without it, all requests behind Modal's TLS terminator hashed to the proxy address, so one heavy caller starved everyone else on the same container.
- **`api/rate_limit`** lazy-init race: eight near-identical `_enforce_*_rate_limit` helpers were racing on first-touch. Two concurrent requests both failed the `hasattr` check, both instantiated a limiter, one `setattr` won — the losing bucket's accounting was silently discarded. Extracted `get_or_create_limiter` guarded by a module-level lock; every enforce dependency now goes through it. Same PR also replaces the `O(N-total-entries)` `sum()` on every admission with an `O(1)` accumulator that triggers `_purge_stale` every 100 admissions.
- **`logging._extract_username_from_jwt`** now returns `"unverified:<username>"` instead of the raw claim. The middleware doesn't verify the JWT signature, so anyone could forge a Bearer token with `{"username":"admin"}` and pollute logs with `admin`. The prefix keeps log-search results honest; verified identity is still available downstream via `get_current_user`.
- **`api/app.SecurityHeadersMiddleware`** now emits `Referrer-Policy: strict-origin-when-cross-origin` and a `Permissions-Policy` that denies camera / microphone / geolocation / payment / USB / MIDI / XR — features the SPA never uses. Prevents skill and eval URLs from leaking into third-party analytics via `Referer`.
- **`client/cli/config.save_config`** now writes atomically (temp-file + `os.replace`) and chmods the file to `0600` and the `~/.dhub` directory to `0700` on POSIX. Previous behaviour: a Ctrl-C mid-write left the config truncated; the loader treated that as corruption and asked the user to delete their config, losing their long-lived bearer token. Also plugs the "token file is world-readable" gap on multi-user systems.

### Performance

- **`api/auth_routes`** runs per-org GitHub membership checks concurrently via `asyncio.gather` instead of awaiting them sequentially. A user in the Nth allowed org previously paid `N × round-trip` latency on every login.

### Ergonomics

- **`infra/cache.TTLCache`** adds a `MISS` sentinel and a `default` parameter to `get()` so callers can distinguish "no entry" from "cached `None`" — required for callers that want to memoise a query that legitimately returns `None`. The default remains `None`, so no existing caller changes.

## Why

Standalone code-review pass — not tracking a specific issue. The findings all trace back to concrete failure modes documented in review notes and in the commit body.

## How to test

- `make test-server` — 947 tests pass (34 slow deselected).
- `make test-shared` — 98 tests pass.
- `make test-client` — new config tests pass; 5 pre-existing `docx_integration` failures on `main` are unrelated (fixture drift, verified by running against the base commit).
- `make lint` — clean.
- Targeted new tests:
  - `pytest server/tests/test_api/test_rate_limit.py -v` — concurrent lazy-init produces one instance; X-Forwarded-For splits per-real-client; purge accumulator sweeps stale keys.
  - `pytest server/tests/test_infra/test_cache.py::TestMissSentinel -v` — MISS disambiguates None-vs-absent.
  - `pytest server/tests/test_api/test_logging.py::TestExtractUsernameFromJwt -v` — forged `admin` token surfaces as `unverified:admin`.
  - `pytest server/tests/test_api/test_security_headers.py -v` — Referrer-Policy + Permissions-Policy present on both 200 and 404.
  - `pytest server/tests/test_domain/test_streaming_evals.py::TestReportEvent::test_zero_cases_marks_report_failed_not_completed -v`.
  - `pytest server/tests/test_infra/test_github_app_token.py -v` — `exp - iat == 10min`.
  - `pytest server/tests/test_infra/test_tracker_db.py::TestRowToSkillTracker::test_maps_consecutive_permanent_failures -v`.
  - `pytest client/tests/test_cli/test_config.py -v` — 0600 file perms, 0700 dir perms, atomic-write survival test.

## Checklist

- [x] Tests pass (`make test` for server + shared + client; pre-existing docx failures on main are unrelated)
- [x] No breaking API changes (public APIs unchanged; `TTLCache.get` default is still `None`)
- [x] Database migration included (if schema changed) — n/a, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoPGA764JeRx89dW7PGec5)_