### PR TITLE
refactor: leverage-focused fixes from architect+PE deep review

### DIFF
--- a/client/src/dhub/cli/app.py
+++ b/client/src/dhub/cli/app.py
@@ -96,26 +96,50 @@ from dhub.cli.doctor import doctor_command  # noqa: E402
 app.command("doctor")(doctor_command)
 
 
+_DHUB_CLI = "dhub-cli"
+# Any subprocess we spawn to talk to uv / pipx / pip could hang forever on a
+# broken network or stalled tool — the CLI should fall back rather than block.
+_INSTALLER_TIMEOUT = 30
+
+
+def _first_token_is_dhub_cli(line: str) -> bool:
+    """Return True when the first whitespace token of `line` is exactly `dhub-cli`.
+
+    `str.startswith("dhub-cli")` also matches sibling packages like
+    `dhub-cli-extras`, so match the first token exactly instead.
+    """
+    parts = line.split()
+    return bool(parts) and parts[0] == _DHUB_CLI
+
+
+def _run_installer(cmd: list[str]) -> subprocess.CompletedProcess | None:
+    """Run an installer command with a bounded timeout; return None on failure."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=_INSTALLER_TIMEOUT)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+
 def _detect_installer() -> str:
     """Detect how dhub-cli was installed: 'uv', 'pipx', or 'pip'."""
     uv_bin = shutil.which("uv")
     if uv_bin:
-        result = subprocess.run(
-            [uv_bin, "tool", "list"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0 and any(line.startswith("dhub-cli") for line in result.stdout.splitlines()):
+        result = _run_installer([uv_bin, "tool", "list"])
+        if (
+            result
+            and result.returncode == 0
+            and any(_first_token_is_dhub_cli(line) for line in result.stdout.splitlines())
+        ):
             return "uv"
 
     pipx_bin = shutil.which("pipx")
     if pipx_bin:
-        result = subprocess.run(
-            [pipx_bin, "list", "--short"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0 and any(line.startswith("dhub-cli") for line in result.stdout.splitlines()):
+        result = _run_installer([pipx_bin, "list", "--short"])
+        if (
+            result
+            and result.returncode == 0
+            and any(_first_token_is_dhub_cli(line) for line in result.stdout.splitlines())
+        ):
             return "pipx"
 
     return "pip"
@@ -139,46 +163,40 @@ def _upgrade(installer: str, console: Console) -> int:
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "dhub-cli"]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    # Upgrades can genuinely take a while (PyPI resolution + wheel install),
+    # so allow a much longer window than the light detect/query probes.
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    except subprocess.TimeoutExpired:
+        console.print("[red]Upgrade failed:[/] installer did not finish within 10 minutes.")
+        return 124
     if result.returncode != 0:
         console.print(f"[red]Upgrade failed:[/]\n{result.stderr.strip()}")
     return result.returncode
 
 
 def _query_version(installer: str) -> str | None:
-    """Query the installed dhub-cli version using the same tool that installed it."""
-    if installer == "uv":
-        result = subprocess.run(
-            [_require_bin("uv"), "tool", "list"],
-            capture_output=True,
-            text=True,
-        )
-        for line in result.stdout.splitlines():
-            if line.startswith("dhub-cli"):
-                parts = line.split()
-                if len(parts) >= 2:
-                    return parts[1].lstrip("v")
-        return None
+    """Query the installed dhub-cli version using the same tool that installed it.
 
-    if installer == "pipx":
-        result = subprocess.run(
-            [_require_bin("pipx"), "list", "--short"],
-            capture_output=True,
-            text=True,
-        )
+    Matches the first whitespace token exactly so sibling packages like
+    `dhub-cli-extras` cannot masquerade as `dhub-cli`.
+    """
+    if installer in ("uv", "pipx"):
+        cmd = [_require_bin("uv"), "tool", "list"] if installer == "uv" else [_require_bin("pipx"), "list", "--short"]
+        result = _run_installer(cmd)
+        if result is None:
+            return None
         for line in result.stdout.splitlines():
-            if line.startswith("dhub-cli"):
+            if _first_token_is_dhub_cli(line):
                 parts = line.split()
                 if len(parts) >= 2:
                     return parts[1].lstrip("v")
         return None
 
     # pip — use the same Python that's running this process
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "show", "dhub-cli"],
-        capture_output=True,
-        text=True,
-    )
+    result = _run_installer([sys.executable, "-m", "pip", "show", "dhub-cli"])
+    if result is None:
+        return None
     for line in result.stdout.splitlines():
         if line.startswith("Version:"):
             return line.split(":", 1)[1].strip()

--- a/client/src/dhub/core/install.py
+++ b/client/src/dhub/core/install.py
@@ -262,6 +262,11 @@ def list_linked_agents(org: str, skill_name: str) -> list[str]:
 
     Returns:
         List of agent names that have a symlink pointing to this skill.
+        Multiple agents that share the same on-disk skills directory
+        (e.g. ``amp``, ``kimi-cli``, ``replit``, ``universal`` all resolve
+        to ``~/.config/agents/skills``) will all be reported — the caller
+        is expected to dedupe by physical path when performing side-effects
+        like uninstall (see ``uninstall_skill``).
     """
     canonical = get_dhub_skill_path(org, skill_name)
     linked: list[str] = []

--- a/client/tests/test_cli/test_app_installer.py
+++ b/client/tests/test_cli/test_app_installer.py
@@ -1,0 +1,134 @@
+"""Tests for the installer helpers used by `dhub upgrade`."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from dhub.cli.app import (
+    _detect_installer,
+    _first_token_is_dhub_cli,
+    _query_version,
+    _run_installer,
+)
+
+
+class TestFirstTokenIsDhubCli:
+    """`dhub-cli` must match exactly, not the sibling `dhub-cli-extras`."""
+
+    def test_exact_match(self) -> None:
+        assert _first_token_is_dhub_cli("dhub-cli v0.12.1")
+
+    def test_leading_whitespace(self) -> None:
+        assert _first_token_is_dhub_cli("   dhub-cli v0.12.1")
+
+    def test_sibling_prefix_rejected(self) -> None:
+        # This is the exact bug the fix targets — startswith("dhub-cli") would
+        # have accepted these lines and returned the wrong version.
+        assert not _first_token_is_dhub_cli("dhub-cli-extras 0.1.0")
+        assert not _first_token_is_dhub_cli("dhub-cli-plugin 2.0.0")
+
+    def test_empty_line(self) -> None:
+        assert not _first_token_is_dhub_cli("")
+        assert not _first_token_is_dhub_cli("   ")
+
+
+class TestRunInstaller:
+    """`_run_installer` bounds every subprocess call and swallows exec errors."""
+
+    def test_returns_completed_process(self) -> None:
+        # Use `true` — always available on Linux runners.
+        result = _run_installer(["true"])
+        assert result is not None
+        assert result.returncode == 0
+
+    def test_missing_binary_returns_none(self) -> None:
+        result = _run_installer(["/does/not/exist/for/dhub/tests"])
+        assert result is None
+
+    def test_timeout_returns_none(self) -> None:
+        def _timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=1)
+
+        with patch("dhub.cli.app.subprocess.run", side_effect=_timeout):
+            assert _run_installer(["ignored"]) is None
+
+
+class TestDetectInstaller:
+    """`_detect_installer` distinguishes dhub-cli from sibling packages."""
+
+    def _fake_result(self, stdout: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_uv_detection(self) -> None:
+        with (
+            patch("dhub.cli.app.shutil.which", side_effect=lambda name: f"/usr/bin/{name}" if name == "uv" else None),
+            patch("dhub.cli.app._run_installer", return_value=self._fake_result("dhub-cli v0.12.1\n")),
+        ):
+            assert _detect_installer() == "uv"
+
+    def test_uv_ignores_sibling_dhub_cli_extras(self) -> None:
+        """Regression: sibling packages must not be mistaken for dhub-cli."""
+        with (
+            patch(
+                "dhub.cli.app.shutil.which",
+                side_effect=lambda name: f"/usr/bin/{name}" if name in {"uv", "pipx"} else None,
+            ),
+            patch(
+                "dhub.cli.app._run_installer",
+                side_effect=[
+                    self._fake_result("dhub-cli-extras 0.1.0\n"),  # uv result
+                    self._fake_result("dhub-cli-extras 0.1.0\n"),  # pipx result
+                ],
+            ),
+        ):
+            assert _detect_installer() == "pip"
+
+    def test_pipx_fallback(self) -> None:
+        with (
+            patch("dhub.cli.app.shutil.which", side_effect=lambda name: f"/usr/bin/{name}" if name == "pipx" else None),
+            patch("dhub.cli.app._run_installer", return_value=self._fake_result("dhub-cli 0.12.1\n")),
+        ):
+            assert _detect_installer() == "pipx"
+
+    def test_falls_back_to_pip_when_no_managers(self) -> None:
+        with patch("dhub.cli.app.shutil.which", return_value=None):
+            assert _detect_installer() == "pip"
+
+
+class TestQueryVersion:
+    """`_query_version` returns None cleanly when tooling misbehaves."""
+
+    def _fake_result(self, stdout: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_uv_parses_version(self) -> None:
+        with (
+            patch("dhub.cli.app._require_bin", return_value="/usr/bin/uv"),
+            patch("dhub.cli.app._run_installer", return_value=self._fake_result("dhub-cli v0.12.1\n")),
+        ):
+            assert _query_version("uv") == "0.12.1"
+
+    def test_uv_skips_sibling(self) -> None:
+        stdout = "dhub-cli-extras 0.1.0\ndhub-cli v0.12.1\n"
+        with (
+            patch("dhub.cli.app._require_bin", return_value="/usr/bin/uv"),
+            patch("dhub.cli.app._run_installer", return_value=self._fake_result(stdout)),
+        ):
+            assert _query_version("uv") == "0.12.1"
+
+    def test_returns_none_on_run_failure(self) -> None:
+        with (
+            patch("dhub.cli.app._require_bin", return_value="/usr/bin/uv"),
+            patch("dhub.cli.app._run_installer", return_value=None),
+        ):
+            assert _query_version("uv") is None
+
+    def test_pip_parses_show_output(self) -> None:
+        stdout = "Name: dhub-cli\nVersion: 0.12.1\n"
+        with patch("dhub.cli.app._run_installer", return_value=self._fake_result(stdout)):
+            assert _query_version("pip") == "0.12.1"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -65,7 +65,7 @@ export default function SkillDetailPage() {
   const [skillMdContent, setSkillMdContent] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
   const [copied, setCopied] = useState(false);
-  const zipRetries = useRef(0);
+  const [zipAttempt, setZipAttempt] = useState(0);
   const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const MAX_ZIP_ATTEMPTS = 3;
 
@@ -76,7 +76,7 @@ export default function SkillDetailPage() {
     setZipLoading(false);
     setFiles([]);
     setSkillMdContent(null);
-    zipRetries.current = 0;
+    setZipAttempt(0);
     if (retryTimer.current) {
       clearTimeout(retryTimer.current);
       retryTimer.current = null;
@@ -171,7 +171,9 @@ export default function SkillDetailPage() {
   });
 
   // Download zip once, extract SKILL.md and file list from it.
-  // Retries up to MAX_ZIP_ATTEMPTS total on transient failures with exponential backoff.
+  // On failure we bump `zipAttempt` after a backoff delay; the useEffect below
+  // observes the counter change and calls `loadZip` again, so retries are
+  // explicit state transitions rather than a side effect of clearing loading.
   const loadZip = useCallback(async () => {
     if (!orgSlug || !skillName || !skill || zipData || zipLoading) return;
     setZipLoading(true);
@@ -196,31 +198,30 @@ export default function SkillDetailPage() {
       }
       setFiles(fileList);
       setZipData(buf);
-      zipRetries.current = 0;
+      setZipLoading(false);
     } catch (err) {
-      zipRetries.current += 1;
-      if (zipRetries.current < MAX_ZIP_ATTEMPTS) {
-        const delay = 2000 * zipRetries.current;
+      const nextAttempt = zipAttempt + 1;
+      if (nextAttempt < MAX_ZIP_ATTEMPTS) {
+        const delay = 2000 * nextAttempt;
         retryTimer.current = setTimeout(() => {
           retryTimer.current = null;
           setZipLoading(false);
+          setZipAttempt(nextAttempt);
         }, delay);
         return;
       }
       setZipError(err instanceof Error ? err.message : "Failed to load package");
-    } finally {
-      if (zipRetries.current === 0 || zipRetries.current >= MAX_ZIP_ATTEMPTS) {
-        setZipLoading(false);
-      }
+      setZipLoading(false);
     }
-  }, [orgSlug, skillName, zipData, zipLoading, skill]);
+  }, [orgSlug, skillName, zipData, zipLoading, skill, zipAttempt]);
 
-  // Trigger zip download when overview or files tab is first visited
+  // Trigger zip download when overview or files tab is first visited, and
+  // whenever a scheduled retry bumps `zipAttempt`.
   useEffect(() => {
     if ((activeTab === "overview" || activeTab === "files") && !zipData && !zipLoading && !zipError) {
       loadZip();
     }
-  }, [activeTab, zipData, zipLoading, zipError, loadZip]);
+  }, [activeTab, zipData, zipLoading, zipError, zipAttempt, loadZip]);
 
   const handleDownload = async () => {
     if (!orgSlug || !skillName) return;

--- a/server/src/decision_hub/api/app.py
+++ b/server/src/decision_hub/api/app.py
@@ -158,6 +158,10 @@ def create_app() -> FastAPI:
     app.state.engine = engine
     app.state.settings = settings
     app.state.s3_client = s3_client
+    # Toggle read by the rate limiter's _client_key helper. Kept on state
+    # (not just settings) so tests can flip it per-request without mutating
+    # a shared Settings singleton.
+    app.state._rate_limit_trust_proxy = settings.rate_limit_trust_proxy
 
     # In-memory TTL cache for hot read paths (per-container, not shared
     # across Modal replicas).

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dependency
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = rate_limit_dependency("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/keys_routes.py
+++ b/server/src/decision_hub/api/keys_routes.py
@@ -9,12 +9,17 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from decision_hub.api.deps import get_connection, get_current_user, get_settings
+from decision_hub.api.rate_limit import rate_limit_dependency
 from decision_hub.domain.crypto import encrypt_value
 from decision_hub.infra.database import delete_api_key, insert_api_key, list_api_keys
 from decision_hub.models import User
 from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1/keys", tags=["keys"])
+
+# Throttle key-mgmt endpoints — POST performs Fernet encryption (CPU-bound)
+# and a stolen token should not be able to enumerate encrypted keys rapidly.
+_enforce_keys_rate_limit = rate_limit_dependency("keys")
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +53,7 @@ class KeySummary(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@router.post("", response_model=StoreKeyResponse, status_code=201)
+@router.post("", response_model=StoreKeyResponse, status_code=201, dependencies=[Depends(_enforce_keys_rate_limit)])
 def store_key(
     body: StoreKeyRequest,
     conn: Connection = Depends(get_connection),
@@ -76,7 +81,7 @@ def store_key(
     )
 
 
-@router.get("", response_model=list[KeySummary])
+@router.get("", response_model=list[KeySummary], dependencies=[Depends(_enforce_keys_rate_limit)])
 def get_keys(
     conn: Connection = Depends(get_connection),
     current_user: User = Depends(get_current_user),
@@ -89,7 +94,7 @@ def get_keys(
     return [KeySummary(key_name=r.key_name, created_at=r.created_at) for r in records]
 
 
-@router.delete("/{key_name}", status_code=204)
+@router.delete("/{key_name}", status_code=204, dependencies=[Depends(_enforce_keys_rate_limit)])
 def remove_key(
     key_name: str,
     conn: Connection = Depends(get_connection),

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -3,8 +3,35 @@
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
 
 from fastapi import HTTPException, Request
+
+# Attribute name on `app.state` for the container-wide "trust the first hop of
+# X-Forwarded-For" toggle. Set once at settings load — see `_client_key`.
+_TRUST_PROXY_ATTR = "_rate_limit_trust_proxy"
+
+
+def _client_key(request: Request) -> str:
+    """Return the per-client key used to bucket rate-limit counters.
+
+    Behind Modal / any TLS-terminating proxy, ``request.client.host`` is the
+    proxy IP, so every request would share a single bucket — one attacker
+    could exhaust the limit for the whole world. When ``rate_limit_trust_proxy``
+    is set on ``app.state`` we honour the left-most entry of
+    ``X-Forwarded-For``, which is the closest thing to a real client IP the
+    proxy exposes. The setting is off by default so misconfigured deployments
+    fail closed (spoofable header ignored) rather than open.
+    """
+    app = request.app
+    if getattr(app.state, _TRUST_PROXY_ATTR, False):
+        xff = request.headers.get("x-forwarded-for", "")
+        if xff:
+            first = xff.split(",", 1)[0].strip()
+            if first:
+                return first
+    return request.client.host if request.client else "unknown"
 
 
 class RateLimiter:
@@ -33,7 +60,7 @@ class RateLimiter:
         self._lock = threading.Lock()
 
     def __call__(self, request: Request) -> None:
-        key = request.client.host if request.client else "unknown"
+        key = _client_key(request)
         now = time.monotonic()
         cutoff = now - self.window_seconds
 
@@ -63,3 +90,35 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def rate_limit_dependency(name: str) -> Callable[[Request], None]:
+    """Build a FastAPI dependency that lazily initialises a per-endpoint limiter.
+
+    The returned callable expects the app to carry a ``settings`` attribute on
+    ``app.state`` with ``<name>_rate_limit`` and ``<name>_rate_window`` fields.
+    The limiter is created on first use and cached at ``app.state._<name>_rate_limiter``
+    so all requests to that endpoint share the same sliding window.
+
+    This replaces ~9 near-identical `_enforce_*_rate_limit` helpers that only
+    differed by the settings field they read.
+    """
+    state_attr = f"_{name}_rate_limiter"
+    limit_attr = f"{name}_rate_limit"
+    window_attr = f"{name}_rate_window"
+
+    def _enforce(request: Request) -> None:
+        state = request.app.state
+        limiter: Any = getattr(state, state_attr, None)
+        if limiter is None:
+            settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    _enforce.__name__ = f"_enforce_{name}_rate_limit"
+    _enforce.__doc__ = f"Rate-limit dependency for the '{name}' endpoint group."
+    return _enforce

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dependency
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,16 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate-limit dependencies — one per public endpoint group. Each looks up the
+# `<name>_rate_limit` and `<name>_rate_window` fields on settings on first use
+# and caches a per-container sliding-window limiter on app.state.
+_enforce_list_skills_rate_limit = rate_limit_dependency("list_skills")
+_enforce_resolve_rate_limit = rate_limit_dependency("resolve")
+_enforce_similar_skills_rate_limit = rate_limit_dependency("similar_skills")
+_enforce_download_rate_limit = rate_limit_dependency("download")
+_enforce_audit_log_rate_limit = rate_limit_dependency("audit_log")
+_enforce_scan_report_rate_limit = rate_limit_dependency("scan_report")
+_enforce_publish_rate_limit = rate_limit_dependency("publish")
 
 
 _VALID_VISIBILITIES = {"public", "org"}

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dependency
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = rate_limit_dependency("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -310,9 +310,13 @@ def check_all_due_trackers(settings: Settings, *, deadline: float | None = None)
         with engine.connect() as conn:
             batch_clear_tracker_errors(conn, unchanged_ids)
             batch_set_tracker_errors(conn, errored_ids_permanent, "GraphQL: repo not found or inaccessible")
-            batch_set_tracker_errors(conn, errored_ids_transient, "transient: GraphQL chunk failed, will retry")
+            # Transient / circuit-breaker failures must clear next_check_at, not just
+            # record the error — otherwise claim_due_trackers' bump has already pushed
+            # the retry a full poll interval into the future, making the "will retry"
+            # message misleading. Mirrors the rate-limit / deadline defer paths below.
+            batch_defer_trackers(conn, errored_ids_transient, "transient: GraphQL chunk failed, will retry")
             if circuit_breaker_ids:
-                batch_set_tracker_errors(
+                batch_defer_trackers(
                     conn,
                     circuit_breaker_ids,
                     "transient: circuit breaker tripped, mass permanent errors downgraded",

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1969,6 +1969,11 @@ def fetch_skills_by_repo(
         )
         .order_by(organizations_table.c.slug, skills_table.c.name)
     )
+    # Match the removed/archived filter applied by every other list-shape
+    # query (fetch_all_skills_for_index, search_skills_hybrid). Without this,
+    # /repo lookups leak deleted-source and GitHub-archived skills that the
+    # UI has already hidden elsewhere.
+    base = _exclude_removed_or_archived(base)
 
     # Visibility filter
     granted = list_granted_skill_ids(conn, user_org_ids) if user_org_ids else None
@@ -2040,7 +2045,10 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # skills.id tiebreaker keeps ordering deterministic when ts_rank_cd
+        # ties (common on short queries against many similar skills), so
+        # pagination and dedup below stay stable across requests.
+        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC"), skills_table.c.id).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2060,8 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        # skills.id tiebreaker — cosine distances can tie on rounding.
+        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC"), skills_table.c.id).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2125,7 +2134,7 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id)
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2724,7 +2733,9 @@ def find_active_eval_runs_for_user(conn: Connection, user_id: UUID, limit: int =
     stmt = (
         sa.select(eval_runs_table)
         .where(eval_runs_table.c.user_id == user_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        # id tiebreaker so equal created_at values pick a deterministic
+        # "latest" instead of flipping between the LIMIT and the caller.
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
         .limit(limit)
     )
     rows = conn.execute(stmt).all()

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,15 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    keys_rate_limit: int = 30  # max requests per window
+    keys_rate_window: int = 60  # window in seconds
+
+    # When True, the rate limiter honors the left-most entry of the
+    # X-Forwarded-For header for bucketing counters. Only enable when a
+    # trusted reverse proxy (e.g. Modal) terminates TLS in front of the
+    # container — the header is spoofable when it isn't. Off by default so
+    # deployments without a proxy fail closed.
+    rate_limit_trust_proxy: bool = False
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,8 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.keys_rate_limit = 30
+    settings.keys_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60
@@ -71,6 +73,9 @@ def test_app(test_settings: MagicMock) -> FastAPI:
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
     app.state.cache = TTLCache(default_ttl=60)
+    # Rate limiter reads this to decide whether to trust the XFF header;
+    # keep it off in tests so limiters key off request.client.host as before.
+    app.state._rate_limit_trust_proxy = False
 
     @app.middleware("http")
     async def check_cli_version(request: Request, call_next):

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,17 +1,24 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, rate_limit_dependency
 
 
-def _make_request(host: str = "127.0.0.1") -> MagicMock:
-    """Create a mock Request with a given client IP."""
+def _make_request(
+    host: str = "127.0.0.1", *, headers: dict[str, str] | None = None, trust_proxy: bool = False
+) -> MagicMock:
+    """Create a mock Request with a given client IP and optional headers."""
     request = MagicMock()
     request.client.host = host
+    # Match the FastAPI headers.get(name, "") behaviour used by the code.
+    hmap = {k.lower(): v for k, v in (headers or {}).items()}
+    request.headers.get = lambda name, default="": hmap.get(name.lower(), default)
+    request.app.state = SimpleNamespace(_rate_limit_trust_proxy=trust_proxy)
     return request
 
 
@@ -77,6 +84,8 @@ class TestRateLimiter:
         limiter = RateLimiter(max_requests=2, window_seconds=60)
         request = MagicMock()
         request.client = None
+        request.headers.get = lambda name, default="": default
+        request.app.state = SimpleNamespace(_rate_limit_trust_proxy=False)
 
         for _ in range(2):
             limiter(request)
@@ -84,3 +93,88 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_x_forwarded_for_ignored_by_default(self) -> None:
+        """Without trust_proxy, X-Forwarded-For is not consulted."""
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        # Both requests share the same proxy IP; XFF differs but is ignored.
+        req_a = _make_request("10.0.0.1", headers={"x-forwarded-for": "1.1.1.1"})
+        req_b = _make_request("10.0.0.1", headers={"x-forwarded-for": "2.2.2.2"})
+        limiter(req_a)
+        limiter(req_b)
+        with pytest.raises(HTTPException):
+            limiter(_make_request("10.0.0.1", headers={"x-forwarded-for": "3.3.3.3"}))
+
+    def test_x_forwarded_for_honored_when_trusted(self) -> None:
+        """With trust_proxy, the left-most XFF entry buckets counters per client."""
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        req_a = _make_request(
+            "10.0.0.1",
+            headers={"x-forwarded-for": "1.1.1.1, 10.0.0.5"},
+            trust_proxy=True,
+        )
+        req_b = _make_request(
+            "10.0.0.1",
+            headers={"x-forwarded-for": "2.2.2.2, 10.0.0.5"},
+            trust_proxy=True,
+        )
+        # Two calls each — different XFF clients, so neither should be blocked.
+        limiter(req_a)
+        limiter(req_a)
+        limiter(req_b)
+        limiter(req_b)
+        # But a third call from client A now trips.
+        with pytest.raises(HTTPException):
+            limiter(req_a)
+
+    def test_x_forwarded_for_empty_falls_back_to_client_host(self) -> None:
+        """A blank XFF value must not create an empty bucket."""
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        # No XFF entry present; trust_proxy still on. Should key off client.host.
+        req = _make_request("10.0.0.9", trust_proxy=True)
+        limiter(req)
+        limiter(req)
+        with pytest.raises(HTTPException):
+            limiter(req)
+
+
+class TestRateLimitDependency:
+    """Unit tests for the rate_limit_dependency() factory."""
+
+    def _make_app(self, *, keys_rate_limit: int = 2, keys_rate_window: int = 60) -> MagicMock:
+        settings = SimpleNamespace(
+            keys_rate_limit=keys_rate_limit,
+            keys_rate_window=keys_rate_window,
+        )
+        state = SimpleNamespace(settings=settings, _rate_limit_trust_proxy=False)
+        app = MagicMock()
+        app.state = state
+        return app
+
+    def test_lazy_initialisation_and_reuse(self) -> None:
+        dep = rate_limit_dependency("keys")
+        app = self._make_app(keys_rate_limit=2)
+
+        req_a = _make_request("10.0.0.1")
+        req_a.app = app
+        # First call creates the limiter and cache it on state.
+        dep(req_a)
+        limiter_first = app.state._keys_rate_limiter
+        assert isinstance(limiter_first, RateLimiter)
+        # Second call reuses the same limiter instance.
+        dep(req_a)
+        assert app.state._keys_rate_limiter is limiter_first
+        # Third call trips 429.
+        with pytest.raises(HTTPException) as exc_info:
+            dep(req_a)
+        assert exc_info.value.status_code == 429
+
+    def test_reads_settings_by_name(self) -> None:
+        dep = rate_limit_dependency("keys")
+        app = self._make_app(keys_rate_limit=1, keys_rate_window=30)
+        req = _make_request("10.0.0.1")
+        req.app = app
+        dep(req)
+        limiter = app.state._keys_rate_limiter
+        assert limiter.max_requests == 1
+        assert limiter.window_seconds == 30

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -824,12 +824,13 @@ class TestRateLimitGuardrail:
         assert result.github_rate_remaining == 100
         mock_dispatch.assert_not_called()
 
-        # Rate-limited trackers should be deferred via batch function
-        mock_batch_defer.assert_called_once_with(
-            mock_conn,
-            [tracker.id],
-            "rate_limit: deferred to next tick",
-        )
+        # Rate-limited trackers should be deferred via batch function.
+        # Transient/circuit-breaker branches also fire batch_defer_trackers
+        # (with empty lists in this scenario), so match by message instead of
+        # asserting a single call.
+        rate_limit_calls = [c for c in mock_batch_defer.call_args_list if "rate_limit" in str(c)]
+        assert len(rate_limit_calls) == 1
+        assert rate_limit_calls[0].args == (mock_conn, [tracker.id], "rate_limit: deferred to next tick")
 
     @patch("decision_hub.domain.tracker_service._resolve_github_token", return_value="ghs_test_token")
     @patch("decision_hub.domain.tracker_service._dispatch_changed_trackers", return_value=(1, 0))
@@ -996,14 +997,16 @@ class TestTransientFailureClassification:
         assert result.errored == 2  # transient + permanent both counted
         assert result.changed == 0
 
-        # Verify batch_set_tracker_errors called with both error types
-        calls = mock_batch_set_errors.call_args_list
-        # Find the permanent error call
-        permanent_call = [c for c in calls if "GraphQL: repo not found" in str(c)]
+        # Verify permanent errors go through batch_set_tracker_errors (retry on
+        # next poll interval), transient errors go through batch_defer_trackers
+        # (clears next_check_at so the next tick picks them up promptly).
+        set_error_calls = mock_batch_set_errors.call_args_list
+        permanent_call = [c for c in set_error_calls if "GraphQL: repo not found" in str(c)]
         assert len(permanent_call) == 1
         assert tracker_permanent.id in permanent_call[0][0][1]
-        # Find the transient error call
-        transient_call = [c for c in calls if "transient:" in str(c)]
+
+        defer_calls = mock_batch_defer.call_args_list
+        transient_call = [c for c in defer_calls if "transient:" in str(c) and "circuit breaker" not in str(c)]
         assert len(transient_call) == 1
         assert tracker_transient.id in transient_call[0][0][1]
 
@@ -2087,10 +2090,11 @@ class TestCircuitBreaker:
         mock_batch_disable.assert_not_called()
         mock_mark_removed.assert_not_called()
 
-        # The 3 permanent errors were downgraded to transient, verify via batch_set_tracker_errors calls
-        # There should be a call with the "circuit breaker" message for 3 trackers
-        all_set_error_calls = mock_batch_set_errors.call_args_list
-        circuit_breaker_calls = [c for c in all_set_error_calls if "circuit breaker" in str(c).lower()]
+        # The 3 permanent errors were downgraded to transient — routed through
+        # batch_defer_trackers so next_check_at is cleared and the next tick
+        # picks them up promptly rather than waiting a full poll interval.
+        all_defer_calls = mock_batch_defer.call_args_list
+        circuit_breaker_calls = [c for c in all_defer_calls if "circuit breaker" in str(c).lower()]
         assert len(circuit_breaker_calls) == 1
         # Should contain the 3 tracker IDs that were downgraded
         downgraded_ids = circuit_breaker_calls[0][0][1]

--- a/shared/src/dhub_core/manifest.py
+++ b/shared/src/dhub_core/manifest.py
@@ -93,29 +93,38 @@ def parse_skill_md(path: Path) -> SkillManifest:
 def parse_frontmatter_yaml(frontmatter_str: str) -> dict:
     """Parse YAML frontmatter with a fallback for unquoted special characters.
 
-    When yaml.safe_load fails, falls back to quoting values that contain
-    markdown links [text](url) or unquoted colons, then retries parsing.
+    When yaml.safe_load fails, falls back to quoting scalar values that
+    contain markdown links ``[text](url)`` or unquoted colons, then retries
+    parsing. Values that already look structured — flow mappings (``{...}``),
+    flow sequences (``[...]``), block scalars (``|``, ``>``), or explicit
+    quotes — are left alone so that e.g. ``metadata: {a: b}`` is not
+    mangled into the literal string ``"{a: b}"``.
     """
     try:
         return yaml.safe_load(frontmatter_str)
     except yaml.YAMLError:
         pass
 
-    # Fallback: quote values containing markdown links [text](url) which
-    # YAML misinterprets as flow sequences, then retry parsing.
+    # Fallback: quote scalar values containing markdown links [text](url) or
+    # unquoted colons — both of which YAML misinterprets. The rules:
+    #   * a value with "](" is always a markdown link (looks like [x] to YAML
+    #     but isn't a real flow sequence) — quote it.
+    #   * otherwise, skip anything that already opens a flow container, block
+    #     scalar, or quoted/anchor/alias so we don't corrupt real structured
+    #     values (e.g. `metadata: {a: b}` or `allowed_tools: [a, b]`).
+    #   * finally, quote anything with an unquoted colon in the value.
     lines = frontmatter_str.split("\n")
     patched: list[str] = []
     for line in lines:
         m = re.match(r"^(\s*[\w][\w-]*:\s*)(.+)$", line)
         if m:
             value = m.group(2)
-            needs_quoting = (
-                not value.startswith('"')
-                and not value.startswith("'")
-                and not value.startswith(">")
-                and not value.startswith("|")
-                and ("](" in value or (":" in value and not value.startswith("[")))
-            )
+            first_char = value[:1]
+            if "](" in value:
+                needs_quoting = True
+            else:
+                already_structured = first_char in ('"', "'", ">", "|", "[", "{", "&", "*", "!")
+                needs_quoting = (not already_structured) and (":" in value)
             if needs_quoting:
                 escaped = value.replace('"', '\\"')
                 patched.append(f'{m.group(1)}"{escaped}"')

--- a/shared/tests/test_manifest.py
+++ b/shared/tests/test_manifest.py
@@ -86,6 +86,29 @@ class TestParseFrontmatterYaml:
         with pytest.raises(yaml.YAMLError):
             parse_frontmatter_yaml(":\n  :\n    - [invalid")
 
+    def test_fallback_preserves_flow_mapping(self) -> None:
+        """A flow-mapping value (metadata: {a: b}) must stay a mapping through fallback.
+
+        The fallback path used to blanket-quote every line whose value contained
+        a colon, which turned real structured values into strings — regressed by
+        finding #6 in the deep review.
+        """
+        yaml_str = (
+            "name: my-skill\n"
+            "description: Great: it works\n"  # triggers the fallback
+            "metadata: {author: Alice, version: 1.0}\n"
+        )
+        result = parse_frontmatter_yaml(yaml_str)
+        assert result["name"] == "my-skill"
+        assert isinstance(result["metadata"], dict)
+        assert result["metadata"]["author"] == "Alice"
+
+    def test_fallback_preserves_flow_sequence(self) -> None:
+        """A flow-sequence value (allowed_tools: [a, b]) must stay a list through fallback."""
+        yaml_str = "name: my-skill\ndescription: Great: it works\nallowed_tools: [read, write]\n"
+        result = parse_frontmatter_yaml(yaml_str)
+        assert result["allowed_tools"] == ["read", "write"]
+
 
 # ---------------------------------------------------------------------------
 # parse_runtime


### PR DESCRIPTION
## What changed

Deep architect + principal-engineer review of the whole codebase (server, client, shared, frontend) plus a focused refactor landing the highest-leverage, low-risk fixes it turned up. 18 files, +496 / -201, all quality gates green. Nine distinct fixes in one commit — grouped so the review write-up below stays close to the diff.

## Why

Preventive audit — no single issue, several small ones that compound (SQL non-determinism, DOS gap behind the proxy, transient errors that don't actually retry soon, YAML fallback that corrupts real mappings, subprocess timeouts missing, unclear frontend retry loop, DRY on 9 near-identical helpers).

## How to test

```bash
make lint        # ruff check + format + frontend eslint
make typecheck   # mypy
make test        # client + server + shared + frontend
```

- Server: 938 pass, 34 slow deselected — new `test_rate_limit` XFF cases + `TestRateLimitDependency` factory tests + updated tracker tests.
- Client: 306 pass — new `test_app_installer.py` covers the first-token match, subprocess timeouts, and sibling-package rejection. (The 5 pre-existing `test_docx_integration` failures are local-skill drift on this container — origin fails the same way, unrelated to this diff.)
- Shared: 100 pass — new fallback-preserves-flow-mapping / flow-sequence tests.
- Frontend: 82 pass, `tsc -b` clean, `eslint` reports one pre-existing warning unrelated to this diff.

Manual smoke suggestions if reviewers want to poke:
- `curl -H "X-Forwarded-For: 1.2.3.4" http://.../health` behind a proxy still rate-limits per client once `rate_limit_trust_proxy=True` is set.
- Publishing a skill whose `SKILL.md` frontmatter has `description: Great: it works` and `metadata: {author: Alice}` — metadata now parses as a mapping instead of the literal string `"{author: Alice}"`.

## Checklist
- [x] Tests pass (`make test` — modulo the pre-existing docx integration drift noted above)
- [x] No breaking API changes (the new `keys` rate limiter and `rate_limit_trust_proxy` setting both default to safe values)
- [ ] Database migration included — not needed, no schema changes

---

## Deep-review summary

The review was run as two parallel Explore agents (server; client + shared + frontend), then synthesized. I picked the fixes below by leverage × safety — each is confined to one or two files and comes with tests. The bigger findings that need a design discussion (or a migration) are listed under **Deferred** at the bottom of this PR.

### Landed in this PR

| # | Category | Change | File · line |
|---|---|---|---|
| 1 | DRY / Architecture | Extract `rate_limit_dependency(name)` factory; replaces 9 near-identical `_enforce_*_rate_limit` helpers across `auth`, `search`, `registry`, `keys`. | `server/api/rate_limit.py:96`, `registry_routes.py:86` |
| 2 | Security / DOS | Rate limiter now bucket-keys off the left-most `X-Forwarded-For` when `rate_limit_trust_proxy` is on. Behind Modal every client was previously sharing one bucket because `request.client.host` == proxy IP. | `server/api/rate_limit.py:15` |
| 3 | Security / Throttling | `/v1/keys` (POST + GET + DELETE) now behind `_enforce_keys_rate_limit`. POST does Fernet encryption (CPU-bound) and a stolen token could enumerate at line rate. | `server/api/keys_routes.py:19` |
| 4 | SQL correctness | `search_skills_hybrid` (FTS + vector paths) and `fetch_similar_skills` gain a `skills.id` tiebreaker — LIMIT without a unique ORDER BY was letting pagination flip between requests when ranks tied. | `server/infra/database.py:2043,2055,2131` |
| 5 | SQL correctness | `find_active_eval_runs_for_user` gains an `id.desc()` tiebreaker for the same reason. | `server/infra/database.py:2731` |
| 6 | Bug / consistency | `fetch_skills_by_repo` was the only list-shape query missing `_exclude_removed_or_archived`, so `/repo` lookups leaked deleted-source / archived skills the rest of the UI already hides. | `server/infra/database.py:1971` |
| 7 | Bug / reliability | Transient tracker failures + circuit-breaker downgrades now route through `batch_defer_trackers` instead of `batch_set_tracker_errors`. Because `claim_due_trackers` bumps `next_check_at = now + poll_interval` on claim, the previous "transient — will retry" path had already been pushed a full poll interval into the future, making the log message misleading. Deferring clears `next_check_at` so the next tick picks them up. | `server/domain/tracker_service.py:312` |
| 8 | Bug / reliability | Every uv/pipx/pip subprocess in the CLI now has a bounded timeout (30s probes, 10min upgrade) and swallows `TimeoutExpired` / `FileNotFoundError` cleanly. Also introduces `_first_token_is_dhub_cli` — `line.startswith("dhub-cli")` also accepted `dhub-cli-extras` and returned its version. | `client/cli/app.py:99` |
| 9 | Correctness | `parse_frontmatter_yaml` fallback used to blanket-quote every colon-bearing value, so a real `metadata: {a: b}` YAML mapping got mangled into the string `"{a: b}"`. Now skips values that open a flow container / block scalar / anchor / alias (`{`, `[`, `|`, `>`, `&`, `*`, `!`, quotes). Markdown-link exception (`](`) still forces quoting because those don't close as a real flow sequence. | `shared/dhub_core/manifest.py:93` |
| 10 | UX clarity | `SkillDetailPage` zip-download retries are now driven by an explicit `zipAttempt` counter that `useEffect` observes. Old code relied on `setZipLoading(false)` implicitly re-firing the fetch effect — worked, but only by side-effect ordering. | `frontend/pages/SkillDetailPage.tsx:68` |

### Test additions

- `server/tests/test_api/test_rate_limit.py` — three new XFF cases (ignored by default, honored when trusted, empty XFF falls back to `client.host`) and two `rate_limit_dependency` tests (lazy init reuses the limiter; settings are read by name).
- `client/tests/test_cli/test_app_installer.py` — 15 tests covering `_first_token_is_dhub_cli`, `_run_installer` (missing binary → None, timeout → None), `_detect_installer` (uv, pipx, pip fallbacks + sibling rejection), `_query_version` (uv/pipx/pip parsing + skipped siblings).
- `shared/tests/test_manifest.py` — `test_fallback_preserves_flow_mapping`, `test_fallback_preserves_flow_sequence`.
- `server/tests/test_domain/test_tracker_service.py` — transient / circuit-breaker assertions moved to `batch_defer_trackers` to match the new behavior.
- `server/tests/test_api/conftest.py` — Settings mock advertises the new `keys_rate_limit` / `keys_rate_window` / `rate_limit_trust_proxy` fields so the `keys_routes` tests still exercise their real dependency.

### Full review findings — deferred for follow-up

Called out here so they're on record; happy to open individual issues if you want.

**Server**

- **`infra/database.py` is a 3,465-line god module** mixing users, orgs, skills, versions, api-keys, audit, eval reports, eval runs, trackers, batch-tracker, search-log, scan reports, embeddings, stats. Every route imports the whole thing. Suggested split: `infra/database/{users,orgs,skills,versions,trackers,audit,eval,scans}.py` + shared `_tables.py`. Left out of this PR because a 3k-line module split touches every route, has real merge-conflict cost, and is safer as its own PR with no functional changes.
- **`list_granted_skill_ids` called redundantly** on the same request (`resolve_version`, `resolve_latest_version`, `find_skill_by_slug`, `fetch_skills_by_repo`, `search_skills_hybrid` each re-fetch). Threading a `granted_skill_ids: list[UUID] | None` argument through the affected callers would collapse 4-5 lookups per request to 1. Left out because it touches many signatures at once.
- **`_check_zombie` runs an UPDATE inside GET handlers** (`registry_routes.py:1100`). Two concurrent polls to `/eval-runs/{id}` can both find a stale heartbeat and both run the UPDATE. A background reaper (or an explicit skip when the result is already stale) would be cleaner. Deferred — needs a design discussion about who owns the reaper.
- **Publish race: version row visible before S3 upload** (`publish_pipeline.py:752–768`). Between the `conn.commit()` that publishes the row and the `upload_skill_zip` call, a concurrent `resolve_skill` can hand a client a presigned URL that 404s. Fix is to upload first (staging key), then commit. Deferred because it reorders the pipeline and needs a careful test pass.
- **Long-lived JWT (default 8760h) with `github_orgs` never re-validated**. A removed org member keeps write access until the token expires. Introducing refresh + short-lived tokens + a `jwt_version` claim is a real change with a client-side migration path — clearly out of scope for this PR.
- **Rate-limiter memory-purge trigger uses `total % 100 == 0`**. Fine in practice but fragile; a heap-based sweep on a fixed interval would be cleaner. Very low priority.

**Client / shared**

- **CLI error output goes to stdout**, so `--output json` gets red-ANSI-decorated `"[red]Error: …"` written to stdout alongside the JSON payload. Every module defines its own `console = Console()` (stdout) — only `output.exit_error` writes to stderr. Fix: route all error prints through a shared helper that respects `is_json()` and writes to stderr. Left out because it touches ~15 files and every `console.print("[red]…"`) call site.
- **`_tail_eval_logs` polls forever** (`registry.py:1373`) — `while True: ... sleep(1.5)`. Bound total wall-clock + backoff. Small change, but I want to see how logs currently behave on the retry side before landing.
- **`_ensure_tracker` swallows non-typer exceptions silently** after a tracker GET/PATCH; a `500` from the server yields zero user-visible feedback.

**Frontend**

- **Hard-coded font sizes** in `GradeBadge.module.css:13,19,25`, `SkillDetailPage.module.css:381`, `AskModal.module.css:291` — violates the `--text-*` scale rule in `CLAUDE.md`. Small but noisy — group into its own PR.
- **Several components ship without `@media (max-width: 480px)` rules** despite appearing in card grids: `AnimatedTerminal`, `NeonCard`, `SkillCardStats`, `LoadingSpinner`, `GradeBadge`, `FileBrowser`. Also violates the mobile-first rule in `CLAUDE.md`.
- **`useApi.refetch`** has no staleness guard; a fast retry-click can commit stale results over new ones. Same `cancelled` flag pattern from the auto-fetch branch would fix it.

**Testing / observability**

- `execute_publish` has no direct unit tests — S3 upload failure rollback, `_try_store_scan_result` failure branches, `maybe_trigger_agent_assessment` when Modal is unavailable, and the auto-bump conflict path are all only exercised end-to-end.
- Eval-run zombie / heartbeat logic (`registry_routes.py:1100–1120`) is untested.
- Access-grant endpoints, similar-skills, `_log_ask_analytics` failure paths — no route-level coverage.

I'd suggest a follow-up PR for one of the two big items — either the `database.py` split or the JWT refresh flow. Everything else can be picked up as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xLDXxLB2JPD5a862yRaFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016xLDXxLB2JPD5a862yRaFQ)_