### PR TITLE
fix: harden CLI, server, and frontend against a batch of latent defects

### DIFF
--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -155,7 +155,7 @@ def _publish_skill_directory(
 
             _tail_eval_logs(api_url, _bh(token), eval_run_id)
         except KeyboardInterrupt:
-            console.print("\n[dim]Detached. Resume with: dhub logs {eval_run_id} --follow[/]")
+            console.print(f"\n[dim]Detached. Resume with: dhub logs {eval_run_id} --follow[/]")
     elif eval_report_status == "pending":
         console.print("[dim]Agent assessment running in background...[/]")
 

--- a/client/src/dhub/core/git_repo.py
+++ b/client/src/dhub/core/git_repo.py
@@ -66,32 +66,40 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Path:
     tmp_dir = Path(tempfile.mkdtemp(prefix="dhub-repo-"))
     repo_path = tmp_dir / "repo"
 
-    if ref and _looks_like_sha(ref):
-        # Commit SHAs don't work with --depth 1 --branch; do a full
-        # clone then checkout the specific commit.
-        cmd = ["git", "clone", repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
-        checkout = subprocess.run(
-            ["git", "checkout", ref],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
-        if checkout.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
-    else:
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd += ["--branch", ref]
-        cmd += [repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    # The `--` separator prevents any repo_url that starts with `-` from being
+    # parsed as a git option (which would allow argument injection like
+    # --upload-pack=<attacker binary>). Same reasoning for `ref` on checkout.
+    try:
+        if ref and _looks_like_sha(ref):
+            # Commit SHAs don't work with --depth 1 --branch; do a full
+            # clone then checkout the specific commit.
+            cmd = ["git", "clone", "--", repo_url, str(repo_path)]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+            checkout = subprocess.run(
+                ["git", "checkout", "--", ref],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if checkout.returncode != 0:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
+        else:
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd += ["--branch", ref]
+            cmd += ["--", repo_url, str(repo_path)]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    except subprocess.TimeoutExpired as exc:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise RuntimeError(f"git operation timed out after {exc.timeout}s") from exc
 
     return repo_path
 

--- a/client/tests/test_core/test_git_repo.py
+++ b/client/tests/test_core/test_git_repo.py
@@ -1,8 +1,13 @@
 """Tests for dhub.core.git_repo -- clone and skill discovery."""
 
+import contextlib
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from dhub.core.git_repo import discover_skills
+import pytest
+
+from dhub.core.git_repo import clone_repo, discover_skills
 
 
 class TestDiscoverSkills:
@@ -73,3 +78,53 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         names = [p.name for p in result]
         assert names == sorted(names)
+
+
+class TestCloneRepo:
+    """Ensure clone_repo builds subprocess args that resist injection and hangs."""
+
+    def _fake_run(self, *args, **kwargs) -> MagicMock:
+        return MagicMock(returncode=0, stderr="")
+
+    def test_uses_double_dash_separator_for_default_clone(self) -> None:
+        # A repo URL that starts with `-` would previously be interpreted by
+        # git as an option (e.g. `--upload-pack=<attacker binary>`) and let
+        # a hostile publish invocation execute arbitrary code. The `--`
+        # separator forces git to treat the remainder as positional args.
+        with (
+            patch("dhub.core.git_repo.subprocess.run", side_effect=self._fake_run) as run,
+            contextlib.suppress(Exception),
+        ):
+            clone_repo("--upload-pack=pwn https://x")
+        cmd = run.call_args_list[0].args[0]
+        assert "--" in cmd
+        assert cmd.index("--") < cmd.index("--upload-pack=pwn https://x")
+
+    def test_uses_double_dash_separator_for_sha_clone(self) -> None:
+        with (
+            patch("dhub.core.git_repo.subprocess.run", side_effect=self._fake_run) as run,
+            contextlib.suppress(Exception),
+        ):
+            clone_repo("https://github.com/o/r.git", ref="deadbeef1234567")
+        # First call is `git clone`, second is `git checkout`. Both must
+        # include `--` before user-controlled arguments.
+        assert "--" in run.call_args_list[0].args[0]
+        assert "--" in run.call_args_list[1].args[0]
+
+    def test_passes_timeout(self) -> None:
+        with (
+            patch("dhub.core.git_repo.subprocess.run", side_effect=self._fake_run) as run,
+            contextlib.suppress(Exception),
+        ):
+            clone_repo("https://github.com/o/r.git")
+        assert run.call_args_list[0].kwargs.get("timeout")
+
+    def test_timeout_expired_becomes_runtime_error(self) -> None:
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+        with (
+            patch("dhub.core.git_repo.subprocess.run", side_effect=raise_timeout),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            clone_repo("https://github.com/o/r.git")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,12 @@ import type {
 // For local dev against a remote API, set VITE_API_URL.
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
 
+// URL-encode a path segment. Slugs and version strings can contain characters
+// (`%`, `/`, `#`, `?`) that would otherwise change the request's routing or
+// produce a malformed URL. Query-string values are already handled by the
+// URLSearchParams API elsewhere in this file.
+const enc = encodeURIComponent;
+
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
@@ -66,7 +72,7 @@ export async function getSkill(
   skillName: string
 ): Promise<SkillSummary> {
   return fetchJSON<SkillSummary>(
-    `/v1/skills/${orgSlug}/${skillName}/summary`
+    `/v1/skills/${enc(orgSlug)}/${enc(skillName)}/summary`
   );
 }
 
@@ -91,7 +97,7 @@ export async function listOrgStats(params: {
 }
 
 export async function getOrgProfile(slug: string): Promise<OrgProfile> {
-  return fetchJSON<OrgProfile>(`/v1/orgs/${slug}/profile`);
+  return fetchJSON<OrgProfile>(`/v1/orgs/${enc(slug)}/profile`);
 }
 
 export async function listOrgProfiles(): Promise<OrgProfile[]> {
@@ -109,7 +115,7 @@ export async function resolveSkill(
   allowRisky = false
 ): Promise<ResolveResponse> {
   return fetchJSON<ResolveResponse>(
-    `/v1/resolve/${orgSlug}/${skillName}?spec=${encodeURIComponent(spec)}&allow_risky=${allowRisky}`
+    `/v1/resolve/${enc(orgSlug)}/${enc(skillName)}?spec=${enc(spec)}&allow_risky=${allowRisky}`
   );
 }
 
@@ -119,7 +125,7 @@ export async function getEvalReport(
   semver: string
 ): Promise<EvalReport | null> {
   return fetchJSON<EvalReport | null>(
-    `/v1/skills/${orgSlug}/${skillName}/eval-report?semver=${encodeURIComponent(semver)}`
+    `/v1/skills/${enc(orgSlug)}/${enc(skillName)}/eval-report?semver=${enc(semver)}`
   );
 }
 
@@ -128,9 +134,9 @@ export async function getAuditLog(
   skillName: string,
   semver?: string
 ): Promise<PaginatedAuditLogResponse> {
-  const qs = semver ? `?semver=${encodeURIComponent(semver)}` : "";
+  const qs = semver ? `?semver=${enc(semver)}` : "";
   return fetchJSON<PaginatedAuditLogResponse>(
-    `/v1/skills/${orgSlug}/${skillName}/audit-log${qs}`
+    `/v1/skills/${enc(orgSlug)}/${enc(skillName)}/audit-log${qs}`
   );
 }
 
@@ -139,9 +145,9 @@ export async function getScanReport(
   skillName: string,
   semver?: string
 ): Promise<ScanReport | null> {
-  const qs = semver ? `?semver=${encodeURIComponent(semver)}` : "";
+  const qs = semver ? `?semver=${enc(semver)}` : "";
   return fetchJSON<ScanReport | null>(
-    `/v1/skills/${orgSlug}/${skillName}/scan-report${qs}`
+    `/v1/skills/${enc(orgSlug)}/${enc(skillName)}/scan-report${qs}`
   );
 }
 
@@ -160,7 +166,7 @@ export async function getSimilarSkills(
   skillName: string
 ): Promise<SimilarSkillRef[]> {
   return fetchJSON<SimilarSkillRef[]>(
-    `/v1/skills/${orgSlug}/${skillName}/similar`
+    `/v1/skills/${enc(orgSlug)}/${enc(skillName)}/similar`
   );
 }
 
@@ -171,7 +177,7 @@ export async function downloadSkillZip(
   allowRisky = false
 ): Promise<ArrayBuffer> {
   const res = await fetch(
-    `${API_BASE}/v1/skills/${orgSlug}/${skillName}/download?spec=${encodeURIComponent(spec)}&allow_risky=${allowRisky}`
+    `${API_BASE}/v1/skills/${enc(orgSlug)}/${enc(skillName)}/download?spec=${enc(spec)}&allow_risky=${allowRisky}`
   );
   if (!res.ok) throw new Error(`Download failed: ${res.status}`);
   return res.arrayBuffer();

--- a/frontend/src/components/GradeBadge.test.tsx
+++ b/frontend/src/components/GradeBadge.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import GradeBadge from "./GradeBadge";
+
+describe("GradeBadge", () => {
+  it("renders the grade letter for a known grade", () => {
+    render(<GradeBadge grade="A" />);
+    expect(screen.getByText("A")).toBeDefined();
+  });
+
+  it("renders the pending indicator instead of crashing when grade is null", () => {
+    // Before the guard, `grade.trim()` on a null value from the API would
+    // throw and unmount whatever surrounding SkillCard/detail page was
+    // rendering it. Now null falls back to the pending badge.
+    render(<GradeBadge grade={null} />);
+    expect(screen.getByText("...")).toBeDefined();
+  });
+
+  it("renders the pending indicator when grade is undefined", () => {
+    render(<GradeBadge grade={undefined} />);
+    expect(screen.getByText("...")).toBeDefined();
+  });
+
+  it("renders the pending indicator when grade is an empty string", () => {
+    render(<GradeBadge grade="" />);
+    expect(screen.getByText("...")).toBeDefined();
+  });
+});

--- a/frontend/src/components/GradeBadge.tsx
+++ b/frontend/src/components/GradeBadge.tsx
@@ -1,7 +1,7 @@
 import styles from "./GradeBadge.module.css";
 
 interface GradeBadgeProps {
-  grade: string;
+  grade: string | null | undefined;
   size?: "sm" | "md" | "lg";
 }
 
@@ -14,10 +14,23 @@ const GRADE_CONFIG: Record<string, { label: string; color: string; tooltip: stri
 };
 
 export default function GradeBadge({ grade, size = "md" }: GradeBadgeProps) {
-  // The API returns safety_rating as formatted strings like "A  Safe"
-  const trimmed = grade.trim().toLowerCase();
+  // The API returns safety_rating as formatted strings like "A  Safe", or
+  // null when scanning is still in progress — treat null/undefined as pending.
+  const raw = grade ?? "";
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    const pending = GRADE_CONFIG.pending;
+    return (
+      <span
+        className={`${styles.badge} ${styles[pending.color]} ${styles[size]}`}
+        title={pending.tooltip}
+      >
+        {pending.label}
+      </span>
+    );
+  }
   const gradeKey = trimmed === "pending" ? "pending" : trimmed.charAt(0).toUpperCase();
-  const config = GRADE_CONFIG[gradeKey] ?? { label: grade, color: "muted", tooltip: "Unknown grade" };
+  const config = GRADE_CONFIG[gradeKey] ?? { label: raw, color: "muted", tooltip: "Unknown grade" };
 
   return (
     <span

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -768,13 +768,14 @@ def resolve_skill(
             detail=f"Version '{spec}' not found for {org_slug}/{skill_name}",
         )
 
-    increment_skill_downloads(conn, version.skill_id)
-
+    # Generate the presigned URL first; only bump the download counter after
+    # the S3 op succeeds so a failed presign doesn't corrupt the ranking.
     download_url = generate_presigned_url(
         s3_client,
         settings.s3_bucket,
         version.s3_key,
     )
+    increment_skill_downloads(conn, version.skill_id)
 
     return ResolveResponse(
         version=version.semver,
@@ -806,9 +807,9 @@ def download_skill(
             detail=f"Version '{spec}' not found for {org_slug}/{skill_name}",
         )
 
-    increment_skill_downloads(conn, version.skill_id)
-
+    # Fetch the zip first so a failed S3 download doesn't inflate the count.
     data = download_zip_from_s3(s3_client, settings.s3_bucket, version.s3_key)
+    increment_skill_downloads(conn, version.skill_id)
     filename = f"{org_slug}_{skill_name}_{version.semver}.zip"
     return Response(
         content=data,
@@ -1165,19 +1166,27 @@ def get_eval_run_logs(
         after_seq=0,
     )
 
-    # Read and parse events from each chunk, filtering by cursor
+    # Read and parse events from each chunk, filtering by cursor. A single
+    # malformed line (e.g. from a worker crash mid-write) previously raised
+    # JSONDecodeError and the /logs endpoint would 500 forever for that run
+    # until S3 was hand-patched. Log and skip the bad line instead.
     all_events: list[dict] = []
     max_seq = cursor
     for _chunk_seq, s3_key in chunks:
         content = read_eval_log_chunk(s3_client, settings.s3_bucket, s3_key)
         for line in content.strip().split("\n"):
-            if line.strip():
+            if not line.strip():
+                continue
+            try:
                 event = json.loads(line)
-                event_seq = event.get("seq", 0)
-                if event_seq > cursor:
-                    all_events.append(event)
-                if event_seq > max_seq:
-                    max_seq = event_seq
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping malformed eval-log line in {}: {}", s3_key, exc)
+                continue
+            event_seq = event.get("seq", 0)
+            if event_seq > cursor:
+                all_events.append(event)
+            if event_seq > max_seq:
+                max_seq = event_seq
 
     return EvalRunLogsResponse(
         events=all_events,

--- a/server/src/decision_hub/domain/gauntlet.py
+++ b/server/src/decision_hub/domain/gauntlet.py
@@ -517,7 +517,9 @@ def check_manifest_schema(content: str) -> EvalResult:
     frontmatter_str = "\n".join(lines[start + 1 : end])
     try:
         data = parse_frontmatter_yaml(frontmatter_str)
-    except yaml.YAMLError as exc:
+    except (yaml.YAMLError, ValueError) as exc:
+        # parse_frontmatter_yaml surfaces its fallback-parse failure as a
+        # ValueError; earlier failures still raise yaml.YAMLError directly.
         return EvalResult(
             check_name="manifest_schema",
             severity="fail",

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1189,12 +1189,14 @@ def batch_update_github_stars(conn: Connection, repo_stars: dict[str, int]) -> N
     subdirectories of the same repo).
     """
     for repo_url, stars in repo_stars.items():
+        # Escape LIKE wildcards so repo names containing % or _ don't match
+        # unrelated skills (e.g. `my_repo` would otherwise match `myXrepo/*`).
         stmt = (
             sa.update(skills_table)
             .where(
                 sa.or_(
                     skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
+                    skills_table.c.source_repo_url.like(f"{_escape_like(repo_url)}/%", escape="\\"),
                 )
             )
             .values(github_stars=stars)
@@ -1212,12 +1214,13 @@ def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str,
     subdirectories of the same repo).
     """
     for repo_url, meta in repo_metadata.items():
+        # Escape LIKE wildcards; see batch_update_github_stars for rationale.
         stmt = (
             sa.update(skills_table)
             .where(
                 sa.or_(
                     skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
+                    skills_table.c.source_repo_url.like(f"{_escape_like(repo_url)}/%", escape="\\"),
                 )
             )
             .values(
@@ -2040,7 +2043,8 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # id ASC is a stable tiebreaker so ranked ties don't reorder between calls.
+        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC"), skills_table.c.id.asc()).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2056,7 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC"), skills_table.c.id.asc()).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2125,7 +2129,7 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id.asc())
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2724,7 +2728,7 @@ def find_active_eval_runs_for_user(conn: Connection, user_id: UUID, limit: int =
     stmt = (
         sa.select(eval_runs_table)
         .where(eval_runs_table.c.user_id == user_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.asc())
         .limit(limit)
     )
     rows = conn.execute(stmt).all()
@@ -3249,7 +3253,11 @@ def insert_tracker_metrics(
 
 def list_tracker_metrics(conn: Connection, *, limit: int = 50) -> list[TrackerMetrics]:
     """Return recent tracker metrics rows, newest first."""
-    stmt = sa.select(tracker_metrics_table).order_by(tracker_metrics_table.c.recorded_at.desc()).limit(limit)
+    stmt = (
+        sa.select(tracker_metrics_table)
+        .order_by(tracker_metrics_table.c.recorded_at.desc(), tracker_metrics_table.c.id.asc())
+        .limit(limit)
+    )
     rows = conn.execute(stmt).all()
     return [_row_to_tracker_metrics(row) for row in rows]
 

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -166,26 +166,30 @@ def list_eval_log_chunks(
 ) -> list[tuple[int, str]]:
     """List eval log chunk keys with sequence number > after_seq.
 
+    Uses a paginator so runs with more than 1000 chunks (the S3 ListObjectsV2
+    default page size) still return their full tail — including the "run
+    complete" chunk that tells the UI to stop polling.
+
     Returns:
         List of (seq, s3_key) tuples sorted by seq ascending.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
+    paginator = client.get_paginator("list_objects_v2")
 
     chunks: list[tuple[int, str]] = []
-    for obj in contents:
-        key = obj["Key"]
-        # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
-        filename = key.rsplit("/", 1)[-1]
-        if not filename.endswith(".jsonl"):
-            continue
-        seq_str = filename.replace(".jsonl", "")
-        try:
-            seq = int(seq_str)
-        except ValueError:
-            continue
-        if seq > after_seq:
-            chunks.append((seq, key))
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
+            filename = key.rsplit("/", 1)[-1]
+            if not filename.endswith(".jsonl"):
+                continue
+            seq_str = filename.replace(".jsonl", "")
+            try:
+                seq = int(seq_str)
+            except ValueError:
+                continue
+            if seq > after_seq:
+                chunks.append((seq, key))
 
     chunks.sort(key=lambda x: x[0])
     return chunks
@@ -208,20 +212,39 @@ def delete_eval_logs(
 ) -> int:
     """Delete all eval log chunks under a prefix.
 
+    Paginates the listing and batches deletes in groups of 1000 (the S3
+    DeleteObjects max). Inspects the Errors[] in each response so partial
+    failures are surfaced instead of counted as success.
+
     Returns:
-        Number of objects deleted.
+        Number of objects successfully deleted.
+
+    Raises:
+        RuntimeError: If S3 reports errors while deleting any batch.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-    if not contents:
+    paginator = client.get_paginator("list_objects_v2")
+    keys: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=s3_prefix):
+        keys.extend(obj["Key"] for obj in page.get("Contents", []))
+    if not keys:
         return 0
 
-    objects = [{"Key": obj["Key"]} for obj in contents]
-    client.delete_objects(
-        Bucket=bucket,
-        Delete={"Objects": objects},
-    )
-    return len(objects)
+    total_deleted = 0
+    for i in range(0, len(keys), 1000):
+        batch = keys[i : i + 1000]
+        resp = client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": k} for k in batch]},
+        )
+        errors = resp.get("Errors") or []
+        if errors:
+            first = errors[0]
+            raise RuntimeError(
+                f"delete_objects reported {len(errors)} errors under {s3_prefix}; "
+                f"first: key={first.get('Key')} code={first.get('Code')} message={first.get('Message')}"
+            )
+        total_deleted += len(resp.get("Deleted") or [])
+    return total_deleted
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_infra/test_storage_eval_logs.py
+++ b/server/tests/test_infra/test_storage_eval_logs.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from decision_hub.infra.storage import (
     delete_eval_logs,
     list_eval_log_chunks,
@@ -10,8 +12,19 @@ from decision_hub.infra.storage import (
 )
 
 
-def _make_s3_client() -> MagicMock:
-    return MagicMock()
+def _make_s3_client(pages: list[list[dict]] | None = None) -> MagicMock:
+    """Return a MagicMock S3 client whose `list_objects_v2` paginator yields
+    the given `pages`. Each page is the `Contents` list for that page. This
+    matches how boto3's real `client.get_paginator("list_objects_v2")` yields
+    responses, so tests exercise the same code paths as production.
+    """
+    client = MagicMock()
+    if pages is None:
+        pages = [[]]
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": page} for page in pages]
+    client.get_paginator.return_value = paginator
+    return client
 
 
 class TestUploadEvalLogChunk:
@@ -34,48 +47,65 @@ class TestUploadEvalLogChunk:
 
 class TestListEvalLogChunks:
     def test_returns_chunks_after_cursor(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "eval-logs/run/0001.jsonl"},
-                {"Key": "eval-logs/run/0002.jsonl"},
-                {"Key": "eval-logs/run/0003.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                [
+                    {"Key": "eval-logs/run/0001.jsonl"},
+                    {"Key": "eval-logs/run/0002.jsonl"},
+                    {"Key": "eval-logs/run/0003.jsonl"},
+                ]
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "eval-logs/run/", after_seq=1)
         assert len(result) == 2
         assert result[0] == (2, "eval-logs/run/0002.jsonl")
         assert result[1] == (3, "eval-logs/run/0003.jsonl")
 
     def test_returns_empty_for_no_contents(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client(pages=[[]])
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert result == []
 
     def test_skips_non_jsonl_files(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "prefix/0001.jsonl"},
-                {"Key": "prefix/readme.txt"},
+        client = _make_s3_client(
+            pages=[
+                [
+                    {"Key": "prefix/0001.jsonl"},
+                    {"Key": "prefix/readme.txt"},
+                ]
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert len(result) == 1
 
     def test_returns_sorted_by_seq(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0003.jsonl"},
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                [
+                    {"Key": "p/0003.jsonl"},
+                    {"Key": "p/0001.jsonl"},
+                    {"Key": "p/0002.jsonl"},
+                ]
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "p/")
         seqs = [s for s, _ in result]
         assert seqs == [1, 2, 3]
+
+    def test_paginates_across_multiple_pages(self):
+        """Regression: previously used a single list_objects_v2 call, which
+        truncated at 1000 keys and lost the tail of long-running eval logs
+        (including the final "run complete" chunk)."""
+        client = _make_s3_client(
+            pages=[
+                [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)],
+                [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 1501)],
+            ]
+        )
+        result = list_eval_log_chunks(client, "bucket", "p/")
+        assert len(result) == 1500
+        assert result[0][0] == 1
+        assert result[-1][0] == 1500
 
 
 class TestReadEvalLogChunk:
@@ -89,20 +119,60 @@ class TestReadEvalLogChunk:
 
 class TestDeleteEvalLogs:
     def test_deletes_all_objects_under_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                [
+                    {"Key": "p/0001.jsonl"},
+                    {"Key": "p/0002.jsonl"},
+                ]
             ]
+        )
+        client.delete_objects.return_value = {
+            "Deleted": [{"Key": "p/0001.jsonl"}, {"Key": "p/0002.jsonl"}],
         }
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 2
         client.delete_objects.assert_called_once()
 
     def test_returns_zero_for_empty_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client(pages=[[]])
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 0
         client.delete_objects.assert_not_called()
+
+    def test_batches_deletes_in_groups_of_1000(self):
+        """S3 DeleteObjects caps each request at 1000 keys, so anything
+        larger must be split across multiple requests."""
+        pages = [
+            [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)],
+            [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 2501)],
+        ]
+        client = _make_s3_client(pages=pages)
+        # Each real DeleteObjects call returns per-batch Deleted; simulate
+        # by returning 1000 the first two times then 500 the third.
+        client.delete_objects.side_effect = [
+            {"Deleted": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)]},
+            {"Deleted": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 2001)]},
+            {"Deleted": [{"Key": f"p/{i:04d}.jsonl"} for i in range(2001, 2501)]},
+        ]
+        count = delete_eval_logs(client, "bucket", "p/")
+        assert count == 2500
+        assert client.delete_objects.call_count == 3
+
+    def test_raises_on_partial_failure(self):
+        """Previously the Errors[] array in DeleteObjects responses was
+        ignored, so half-failed deletes were reported as full success."""
+        client = _make_s3_client(
+            pages=[
+                [
+                    {"Key": "p/0001.jsonl"},
+                    {"Key": "p/0002.jsonl"},
+                ]
+            ]
+        )
+        client.delete_objects.return_value = {
+            "Deleted": [{"Key": "p/0001.jsonl"}],
+            "Errors": [{"Key": "p/0002.jsonl", "Code": "AccessDenied", "Message": "no"}],
+        }
+        with pytest.raises(RuntimeError, match="delete_objects reported 1 errors"):
+            delete_eval_logs(client, "bucket", "p/")

--- a/shared/src/dhub_core/manifest.py
+++ b/shared/src/dhub_core/manifest.py
@@ -33,7 +33,7 @@ def parse_skill_md(path: Path) -> SkillManifest:
         ValueError: If the file format is invalid or required fields are missing.
         FileNotFoundError: If the path does not exist.
     """
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     frontmatter_str, body = split_frontmatter(content)
     data = parse_frontmatter_yaml(frontmatter_str)
 
@@ -123,7 +123,12 @@ def parse_frontmatter_yaml(frontmatter_str: str) -> dict:
         patched.append(line)
 
     patched_str = "\n".join(patched)
-    return yaml.safe_load(patched_str)
+    try:
+        return yaml.safe_load(patched_str)
+    except yaml.YAMLError as exc:
+        # Fallback still couldn't parse — surface as ValueError so callers
+        # that catch ValueError see a consistent error type.
+        raise ValueError(f"Frontmatter YAML is invalid: {exc}") from exc
 
 
 def split_frontmatter(content: str) -> tuple[str, str]:

--- a/shared/tests/test_manifest.py
+++ b/shared/tests/test_manifest.py
@@ -81,9 +81,10 @@ class TestParseFrontmatterYaml:
         assert result["metadata"]["version"] == "1.0"
 
     def test_unparseable_yaml(self) -> None:
-        import yaml
-
-        with pytest.raises(yaml.YAMLError):
+        # When even the quoting-fallback can't parse the frontmatter, the
+        # function surfaces a ValueError so callers that already catch
+        # ValueError for other manifest errors get consistent behaviour.
+        with pytest.raises(ValueError, match="Frontmatter YAML is invalid"):
             parse_frontmatter_yaml(":\n  :\n    - [invalid")
 
 


### PR DESCRIPTION
## What changed

A batch of low-risk, high-signal defect fixes across the CLI (`client/`, `shared/`), the server package, and the React frontend. Findings surfaced by a targeted architectural review; higher-effort items (see **Deferred** below) are called out for a follow-up PR rather than landed here.

**Client / shared**
- `git_repo.clone_repo` inserts `--` between `git clone` / `git checkout` and any user-controlled arg, so a `repo_url` that starts with `-` cannot hijack git as an option (`--upload-pack=<binary>` → RCE). Both subprocess calls also pick up an explicit `timeout` and `TimeoutExpired` is translated to `RuntimeError`, so a hung remote or SSH key prompt can't stall the CLI forever.
- Missing f-string in `registry.py:158` — the placeholder in `"Detached. Resume with: dhub logs {eval_run_id} --follow"` was being printed literally, so the resume command couldn't be copy-pasted.
- `shared.dhub_core.manifest.parse_skill_md` now reads `SKILL.md` as UTF-8 explicitly. On Windows the default cp1252 encoding raised on any skill with non-ASCII in its description.
- `parse_frontmatter_yaml` surfaces its fallback-parse failure as a `ValueError` so callers that already catch `ValueError` see a consistent error type (a raw `yaml.YAMLError` previously leaked past the caller's handler). `gauntlet.check_manifest_schema` updated to accept both.

**Server**
- `infra.database.batch_update_github_stars` / `batch_update_github_repo_metadata` now escape LIKE wildcards. A repo containing `_` or `%` previously stamped stars / forks / license / archived state onto unrelated skills (e.g. `my_repo` would match `myXrepo/*`).
- Every `ORDER BY … LIMIT` that previously ordered on a non-unique column (FTS rank, vector cosine distance, similar skills, active eval runs, tracker metrics) gets an `id ASC` tiebreaker so pagination and "similar skills" no longer drift across calls when values tie.
- `infra.storage.list_eval_log_chunks` and `delete_eval_logs` use a boto3 paginator instead of a single `list_objects_v2` call. Long-running eval logs (>1000 chunks) previously lost their tail — including the "run complete" chunk — and cleanup silently orphaned 2000+ S3 objects. `delete_eval_logs` also inspects the response's `Errors[]` and raises so partial failures stop being reported as success.
- `registry_routes.get_eval_run_logs` no longer 500s forever when a single JSONL line is malformed (e.g. from a worker crash mid-write) — the bad line is logged and skipped so the UI keeps making progress.
- Both `/resolve` and `/download` now `increment_skill_downloads` **after** the S3 operation succeeds, so failed presigns / downloads don't inflate the ranking counter.

**Frontend**
- `api/client.ts` wraps every path segment in `encodeURIComponent`. Org slugs or skill names with `%`, `/`, or spaces previously produced malformed URLs that 404'd or hit the wrong route.
- `GradeBadge` tolerates `null` / `undefined` / `""` and renders the pending indicator instead of throwing on `grade.trim()`. The DB column is nullable, so any skill still awaiting a scan was crashing the row.

**Tests**
- `clone_repo`: assert `--` is present in both the default and SHA clone command lines, that `timeout` is passed, and that `TimeoutExpired` becomes a `RuntimeError`.
- `list_eval_log_chunks`: assert pagination across multiple pages returns all 1500 chunks.
- `delete_eval_logs`: assert batching of >1000 keys and that a non-empty `Errors[]` raises.
- `GradeBadge`: `null` / `undefined` / `""` render pending instead of crashing.
- `parse_frontmatter_yaml`: assert the `ValueError` contract on unparseable input.
- Existing `check_manifest_schema` test still passes because the caller now catches both exception types.

## Why

Prevent security, correctness, and UX regressions surfaced by a codebase review:

- The unquoted `git clone` argument is an RCE vector on any host running `dhub publish <url>`.
- LIKE-wildcard bleed silently corrupts GitHub-metadata on unrelated skills — the sort of thing that is very hard to notice after the fact.
- The `/logs` endpoint 500-forever on one bad JSONL line was a real availability bug for any customer whose worker crashed at the wrong moment.
- Path segments not being URL-encoded is a `useParams`-of-doom waiting to happen.
- The nullable `safety_rating` grade crashing a react row is a live "unknown skill on the detail page" outage vector.

## How to test

```
uv run --package dhub-cli --extra dev pytest client/tests/ -q
uv run --package dhub-core --extra dev pytest shared/tests/ -q
cd server && DHUB_ENV=dev uv run --package decision-hub-server --extra dev pytest tests/ -q -m "not slow"
cd frontend && npx vitest run
uvx ruff@0.15.3 check client/ server/ shared/
uvx ruff@0.15.3 format --check client/ server/ shared/
uvx mypy client/src/ server/src/ shared/src/
```

Locally observed on this branch:
- 315 client tests pass. Five failures in `test_docx_integration` (file-count / description assertions) reproduce on `main` at the base commit — pre-existing, unrelated, left alone here.
- 98 shared tests pass.
- 936 server tests pass (`-m "not slow"`).
- 86 frontend vitest tests pass.
- Ruff, ruff-format, and mypy all clean.

## Deferred (call-outs for a follow-up PR)

These surfaced in the same review but are meaningful enough to want their own PR + design conversation rather than sneaking in with a low-risk batch:

- **JWT-baked `github_orgs` is not re-verified** in `create_organisation` (`api/org_routes.py`) — a user removed from a GitHub org can still claim the DB namespace until any real member logs in and the JWT is refreshed. Fix: call `check_org_membership` inside the handler.
- **Lost-update race on `skills.latest_semver` / `latest_version_id`** in `insert_version` / `delete_version` (`infra/database.py`) — concurrent publishes can stamp the wrong "latest". Fix: fold into a single `UPDATE ... SET latest_semver = (SELECT ... LIMIT 1)`.
- **Rate limiter keys off `request.client.host`** (`api/rate_limit.py`) which behind Modal's ingress is the proxy IP; effectively no per-IP limit. Fix: parse `X-Forwarded-For` (with a proxy allowlist).
- **Rate limiter lazy-init race** (`api/*_routes.py`) — `hasattr` check-then-set with no lock in sync deps that run in the threadpool; two cold-start requests each create a fresh `RateLimiter` and lose one's counters. Fix: init eagerly at app startup or guard with a lock.
- **DB pool exhaustion via GH HTTP inside `engine.begin()`** in `tracker_routes.py:187` — `check_repo_accessible` runs inside the transaction; concurrent POSTs during a GH slowdown exhaust the pool. Fix: perform the HTTP before opening the tx.

## Checklist

- [x] Tests pass (`make test`)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_016EYSftjC5byFADmZUM8za2)_