### PR TITLE
fix: correctness + observability fixes from architectural review

### DIFF
--- a/frontend/src/components/AskModal.tsx
+++ b/frontend/src/components/AskModal.tsx
@@ -46,6 +46,16 @@ export default function AskModal({ isOpen, onClose }: AskModalProps) {
     if (isOpen) refreshRecentlyViewed();
   }, [isOpen, refreshRecentlyViewed]);
 
+  // Reset conversation state when the modal closes so a subsequent open
+  // starts fresh instead of resurfacing the previous session's messages/error.
+  useEffect(() => {
+    if (!isOpen) {
+      setMessages([]);
+      setQuery("");
+      setError(null);
+    }
+  }, [isOpen]);
+
   // Scroll to bottom when new messages arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/frontend/src/components/GradeBadge.module.css
+++ b/frontend/src/components/GradeBadge.module.css
@@ -10,19 +10,19 @@
 }
 
 .sm {
-  font-size: 0.65rem;
+  font-size: var(--text-xxs);
   padding: 2px 8px;
   min-width: 28px;
 }
 
 .md {
-  font-size: 0.8rem;
+  font-size: var(--text-xs);
   padding: 4px 12px;
   min-width: 36px;
 }
 
 .lg {
-  font-size: 1.4rem;
+  font-size: var(--text-heading);
   padding: 8px 20px;
   min-width: 56px;
 }

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -8,10 +8,10 @@ export default function NotFoundPage() {
       className="container"
       style={{ textAlign: "center", paddingTop: "4rem", paddingBottom: "4rem" }}
     >
-      <p style={{ fontSize: "4rem", fontWeight: 700, color: "var(--neon-cyan)", margin: 0 }}>
+      <p style={{ fontSize: "var(--text-hero)", fontWeight: 700, color: "var(--neon-cyan)", margin: 0 }}>
         404
       </p>
-      <h1 style={{ fontSize: "1.6rem", margin: "0.75rem 0 0.5rem" }}>Page not found</h1>
+      <h1 style={{ fontSize: "var(--text-heading)", margin: "0.75rem 0 0.5rem" }}>Page not found</h1>
       <p style={{ color: "var(--text-muted)", marginBottom: "2rem" }}>
         The page you&apos;re looking for doesn&apos;t exist.
       </p>

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -143,10 +143,30 @@ async def exchange_token(
     if allowed_orgs:
         username = gh_user["login"]
         is_member = False
-        for org in allowed_orgs:
-            if await check_org_membership(gh_token, org, username):
-                is_member = True
-                break
+        # Transient GitHub errors (429/5xx) inside check_org_membership raise
+        # HTTPStatusError so we can return a 502 (retryable) instead of denying
+        # the user with a 403 during a GitHub incident.
+        try:
+            for org in allowed_orgs:
+                if await check_org_membership(gh_token, org, username):
+                    is_member = True
+                    break
+        except httpx.HTTPStatusError as exc:
+            logger.opt(exception=True).warning(
+                "GitHub returned {} while checking org membership for {}",
+                exc.response.status_code,
+                username,
+            )
+            raise HTTPException(
+                status_code=502,
+                detail="GitHub is unavailable — please try again",
+            ) from exc
+        except httpx.HTTPError as exc:
+            logger.opt(exception=True).warning("Failed to reach GitHub while checking org membership: {}", exc)
+            raise HTTPException(
+                status_code=502,
+                detail="Failed to reach GitHub — please try again",
+            ) from exc
         if not is_member:
             logger.warning("User {} denied access — not in required orgs {}", username, allowed_orgs)
             raise HTTPException(

--- a/server/src/decision_hub/api/deps.py
+++ b/server/src/decision_hub/api/deps.py
@@ -18,6 +18,19 @@ from decision_hub.models import User
 from decision_hub.settings import Settings
 
 
+def parse_uuid(value: str, name: str) -> UUID:
+    """Parse a string as a UUID, raising HTTP 422 with a clear message on invalid input.
+
+    Shared by route handlers that accept UUIDs as path/query parameters and want a
+    422 response instead of the default 500 that a bare ``UUID(value)`` would raise
+    from the ValueError bubbling up.
+    """
+    try:
+        return UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
+
+
 def get_settings(request: Request) -> Settings:
     """Retrieve application settings from app state."""
     return request.app.state.settings

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -1,10 +1,10 @@
 """Skill registry routes -- publish, resolve, and delete."""
 
+import dataclasses
 import json
 import math
 import zipfile
 from datetime import UTC, datetime
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
 from loguru import logger
@@ -18,6 +18,7 @@ from decision_hub.api.deps import (
     get_current_user_optional,
     get_s3_client,
     get_settings,
+    parse_uuid,
 )
 from decision_hub.api.rate_limit import RateLimiter
 from decision_hub.api.registry_service import (
@@ -76,7 +77,7 @@ from decision_hub.infra.storage import (
 from decision_hub.infra.storage import (
     download_skill_zip as download_zip_from_s3,
 )
-from decision_hub.models import User
+from decision_hub.models import EvalRunStatus, User
 from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["registry"])
@@ -168,14 +169,6 @@ def _enforce_publish_rate_limit(request: Request) -> None:
 
 
 _VALID_VISIBILITIES = {"public", "org"}
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a UUID string, raising 422 with a clear message on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
 
 
 # ---------------------------------------------------------------------------
@@ -1097,7 +1090,7 @@ def _run_to_response(run) -> EvalRunResponse:
     )
 
 
-def _check_zombie(conn: Connection, run) -> str:
+def _check_zombie(conn: Connection, run) -> EvalRunStatus:
     """Check if a running eval run has a stale heartbeat (zombie).
 
     If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
@@ -1127,13 +1120,16 @@ def get_eval_run(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunResponse:
     """Get eval run metadata by run ID."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
-    _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
+    # Use the effective status returned by _check_zombie directly instead of
+    # re-reading the row. Saves one SELECT and avoids a rare NoneType crash
+    # if the row was deleted between the two reads.
+    effective_status = _check_zombie(conn, run)
+    if effective_status != run.status:
+        run = dataclasses.replace(run, status=effective_status)
     return _run_to_response(run)
 
 
@@ -1147,7 +1143,7 @@ def get_eval_run_logs(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunLogsResponse:
     """Get eval run log events with cursor-based pagination."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
@@ -1196,9 +1192,8 @@ def list_eval_runs(
 ) -> list[EvalRunResponse]:
     """List eval runs, optionally filtered by version ID."""
     if version_id is not None:
-        parsed_vid = _parse_uuid(version_id, "version_id")
-        runs = find_eval_runs_for_version(conn, parsed_vid)
-        runs = [r for r in runs if r.user_id == current_user.id]
+        parsed_vid = parse_uuid(version_id, "version_id")
+        runs = find_eval_runs_for_version(conn, parsed_vid, user_id=current_user.id)
     else:
         runs = find_active_eval_runs_for_user(conn, current_user.id)
     return [_run_to_response(r) for r in runs]

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -1,7 +1,6 @@
 """CRUD API routes for skill trackers."""
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -9,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from decision_hub.api.deps import get_connection, get_current_user, get_settings
+from decision_hub.api.deps import get_connection, get_current_user, get_settings, parse_uuid
 from decision_hub.domain.tracker import (
     build_canonical_repo_url,
     check_repo_accessible,
@@ -87,14 +86,6 @@ def _tracker_to_response(tracker) -> TrackerResponse:
         last_error=tracker.last_error,
         created_at=tracker.created_at.isoformat() if tracker.created_at else None,
     )
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a string as UUID, raising HTTP 422 on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid {name}: {value}") from None
 
 
 def _resolve_org_slug(conn: Connection, user: User, org_slug: str | None) -> str:
@@ -210,7 +201,7 @@ def get_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Get details of a specific tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -225,7 +216,7 @@ def update_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Update a tracker's settings."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -273,7 +264,7 @@ def delete_tracker(
     user: User = Depends(get_current_user),
 ) -> None:
     """Remove a tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")

--- a/server/src/decision_hub/domain/publish.py
+++ b/server/src/decision_hub/domain/publish.py
@@ -121,11 +121,17 @@ def extract_for_evaluation(
             basename = name.rsplit("/", 1)[-1] if "/" in name else name
 
             if basename == "SKILL.md":
+                # SKILL.md is the manifest — must be valid UTF-8. Strict decode
+                # so we surface a clear error rather than silently mangling.
                 skill_md = zf.read(name).decode()
             elif basename in ("requirements.txt", "uv.lock", "poetry.lock"):
-                lockfile_content = zf.read(name).decode()
+                lockfile_content = zf.read(name).decode(errors="replace")
             elif _is_scannable_file(basename):
-                source_files.append((name, zf.read(name).decode()))
+                # Scannable source files may be Latin-1 / CP1252 / mixed encodings
+                # in the wild. Use ``errors="replace"`` so one weird byte in a
+                # third-party file can't abort the whole publish; the gauntlet
+                # cares about the text content, not the exact bytes.
+                source_files.append((name, zf.read(name).decode(errors="replace")))
             else:
                 unscanned_files.append(name)
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1187,14 +1187,19 @@ def batch_update_github_stars(conn: Connection, repo_stars: dict[str, int]) -> N
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
     subdirectories of the same repo).
+
+    Underscores in repo URLs (e.g. ``pymc_labs``) are common; they must be
+    escaped in the LIKE pattern or they'd be treated as single-char wildcards
+    and clobber unrelated repos' star counts.
     """
     for repo_url, stars in repo_stars.items():
+        prefix = f"{_escape_like(repo_url)}/%"
         stmt = (
             sa.update(skills_table)
             .where(
                 sa.or_(
                     skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
+                    skills_table.c.source_repo_url.like(prefix, escape="\\"),
                 )
             )
             .values(github_stars=stars)
@@ -1209,15 +1214,17 @@ def batch_update_github_repo_metadata(conn: Connection, repo_metadata: dict[str,
     ``forks``, ``watchers``, ``is_archived``, ``license``.
     Updates all skills whose ``source_repo_url`` is either an exact match for
     the repo URL or starts with the repo URL followed by ``/`` (for skills in
-    subdirectories of the same repo).
+    subdirectories of the same repo). See ``batch_update_github_stars`` for the
+    reasoning behind the LIKE-escape.
     """
     for repo_url, meta in repo_metadata.items():
+        prefix = f"{_escape_like(repo_url)}/%"
         stmt = (
             sa.update(skills_table)
             .where(
                 sa.or_(
                     skills_table.c.source_repo_url == repo_url,
-                    skills_table.c.source_repo_url.like(f"{repo_url}/%"),
+                    skills_table.c.source_repo_url.like(prefix, escape="\\"),
                 )
             )
             .values(
@@ -2708,13 +2715,21 @@ def find_eval_run(conn: Connection, run_id: UUID) -> EvalRun | None:
     return _row_to_eval_run(row)
 
 
-def find_eval_runs_for_version(conn: Connection, version_id: UUID) -> list[EvalRun]:
-    """List all eval runs for a version, newest first."""
-    stmt = (
-        sa.select(eval_runs_table)
-        .where(eval_runs_table.c.version_id == version_id)
-        .order_by(eval_runs_table.c.created_at.desc())
-    )
+def find_eval_runs_for_version(
+    conn: Connection,
+    version_id: UUID,
+    user_id: UUID | None = None,
+) -> list[EvalRun]:
+    """List all eval runs for a version, newest first.
+
+    If *user_id* is provided, only returns runs owned by that user — this
+    scopes the filter into the database instead of pulling every row across
+    users and filtering in Python.
+    """
+    stmt = sa.select(eval_runs_table).where(eval_runs_table.c.version_id == version_id)
+    if user_id is not None:
+        stmt = stmt.where(eval_runs_table.c.user_id == user_id)
+    stmt = stmt.order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
     rows = conn.execute(stmt).all()
     return [_row_to_eval_run(row) for row in rows]
 

--- a/server/src/decision_hub/infra/github.py
+++ b/server/src/decision_hub/infra/github.py
@@ -199,7 +199,15 @@ async def check_org_membership(access_token: str, org: str, username: str) -> bo
         username: GitHub username to check.
 
     Returns:
-        True if the user is a member of the organization.
+        True if the user is a member of the organization, False if a
+        definitive negative signal was received (404 not-a-member, 302
+        requester-cannot-see, 403 privacy-restricted).
+
+    Raises:
+        httpx.HTTPStatusError: For any transient GitHub error (429 rate limit,
+            5xx server errors). Silently swallowing these would incorrectly
+            deny access to legitimate members during a GitHub incident;
+            callers should surface a 502 so the client retries login.
     """
     async with httpx.AsyncClient() as client:
         response = await client.get(
@@ -209,16 +217,33 @@ async def check_org_membership(access_token: str, org: str, username: str) -> bo
                 "Accept": _ACCEPT_JSON,
             },
         )
+    # 204 No Content: confirmed member
     if response.status_code == 204:
         return True
+    # 404 Not Found: not a member (or org doesn't exist)
     if response.status_code == 404:
         return False
-
-    # 302 means requester is not an org member — can't see membership list
+    # 302 Found: requester is not an org member and can't see membership
     if response.status_code == 302:
         return False
+    # 403 Forbidden: membership is private and caller lacks permission
+    if response.status_code == 403:
+        logger.info("Org membership check hidden by privacy (403) for org={} user={}", org, username)
+        return False
 
-    return False
+    # 429 rate limit or 5xx: transient error. Do NOT silently map to False —
+    # that would lock legitimate members out of login during a GitHub outage.
+    # Raise so the caller can return a 502 and the client retries.
+    logger.warning(
+        "check_org_membership got unexpected status={} for org={} user={}",
+        response.status_code,
+        org,
+        username,
+    )
+    response.raise_for_status()
+    # raise_for_status only raises on 4xx/5xx; anything else that reaches here
+    # (informational/redirect not handled above) is a protocol-level surprise.
+    raise RuntimeError(f"Unexpected status {response.status_code} from GitHub org membership check")
 
 
 async def fetch_org_metadata(access_token: str, org_login: str) -> dict:

--- a/server/src/decision_hub/infra/storage.py
+++ b/server/src/decision_hub/infra/storage.py
@@ -158,6 +158,18 @@ def upload_eval_log_chunk(
     return s3_key
 
 
+def _iter_bucket_keys(client: BaseClient, bucket: str, prefix: str):
+    """Yield every object under *prefix* in *bucket*, following pagination.
+
+    S3's ``list_objects_v2`` returns at most 1000 keys per page; long-running
+    evals easily blow past that (a 35-min run flushing every 2s produces
+    >1000 chunks) so we must follow ``NextContinuationToken``.
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        yield from page.get("Contents", [])
+
+
 def list_eval_log_chunks(
     client: BaseClient,
     bucket: str,
@@ -169,11 +181,8 @@ def list_eval_log_chunks(
     Returns:
         List of (seq, s3_key) tuples sorted by seq ascending.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-
     chunks: list[tuple[int, str]] = []
-    for obj in contents:
+    for obj in _iter_bucket_keys(client, bucket, s3_prefix):
         key = obj["Key"]
         # Extract seq from filename like 'eval-logs/{run_id}/0001.jsonl'
         filename = key.rsplit("/", 1)[-1]
@@ -211,17 +220,21 @@ def delete_eval_logs(
     Returns:
         Number of objects deleted.
     """
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=s3_prefix)
-    contents = resp.get("Contents", [])
-    if not contents:
-        return 0
-
-    objects = [{"Key": obj["Key"]} for obj in contents]
-    client.delete_objects(
-        Bucket=bucket,
-        Delete={"Objects": objects},
-    )
-    return len(objects)
+    # S3's delete_objects accepts at most 1000 keys per call. Batch to that
+    # limit so a prefix with more than 1000 objects still gets fully cleaned.
+    _DELETE_BATCH = 1000
+    batch: list[dict] = []
+    deleted = 0
+    for obj in _iter_bucket_keys(client, bucket, s3_prefix):
+        batch.append({"Key": obj["Key"]})
+        if len(batch) == _DELETE_BATCH:
+            client.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+            deleted += len(batch)
+            batch = []
+    if batch:
+        client.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+        deleted += len(batch)
+    return deleted
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/logging.py
+++ b/server/src/decision_hub/logging.py
@@ -223,15 +223,25 @@ class RequestLoggingMiddleware:
 
         with logger.contextualize(**ctx):
             logger.info("{} {} {}", method, path, user)
+            unhandled_exc: BaseException | None = None
             try:
                 await self.app(scope, receive, send_wrapper)
-            except Exception:
+            except Exception as exc:
                 status_code = 500
+                unhandled_exc = exc
                 raise
             finally:
                 duration_ms = (time.perf_counter() - start) * 1000
                 lvl = "WARNING" if status_code >= 400 else "INFO"
-                logger.bind(response_size=response_size).log(
+                bound = logger.bind(response_size=response_size)
+                # Attach the traceback on the 500 path so we don't rely on
+                # Starlette's default handler to surface it — otherwise
+                # unhandled exceptions produce a plain "500" line with no
+                # stacktrace and correlation is lost.
+                if unhandled_exc is not None:
+                    bound = bound.opt(exception=unhandled_exc)
+                    lvl = "ERROR"
+                bound.log(
                     lvl,
                     "{} {} → {} ({:.0f}ms, {}B)",
                     method,

--- a/server/src/decision_hub/scripts/backfill_embeddings.py
+++ b/server/src/decision_hub/scripts/backfill_embeddings.py
@@ -54,6 +54,9 @@ def backfill(batch_size: int = 100) -> None:
                     )
                 )
                 .where(skills_table.c.embedding.is_(None))
+                # Deterministic order for reproducible logs / resumability
+                # (CLAUDE.md: every LIMIT query must have an ORDER BY).
+                .order_by(skills_table.c.id)
                 .limit(batch_size)
             )
             rows = conn.execute(stmt).all()

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -476,11 +476,16 @@ class TestListEvalRuns:
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
-        """When filtering by version_id, only the current user's runs are returned."""
+        """When filtering by version_id, only the current user's runs are returned.
+
+        The filter is now pushed into SQL (``find_eval_runs_for_version(user_id=…)``)
+        instead of a post-query Python comprehension, so the test asserts on the
+        kwargs passed to the DB helper and that the response reflects what the
+        helper returned.
+        """
         version_id = uuid4()
         own_run = _make_eval_run(version_id=version_id, user_id=SAMPLE_USER_ID)
-        other_run = _make_eval_run(version_id=version_id, user_id=uuid4())
-        mock_find_runs.return_value = [own_run, other_run]
+        mock_find_runs.return_value = [own_run]
 
         resp = client.get(
             f"/v1/eval-runs?version_id={version_id}",
@@ -491,6 +496,9 @@ class TestListEvalRuns:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["id"] == str(own_run.id)
+        # user_id must be scoped in the DB call, not filtered after the fact.
+        _args, kwargs = mock_find_runs.call_args
+        assert kwargs.get("user_id") == SAMPLE_USER_ID
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_domain/test_publish.py
+++ b/server/tests/test_domain/test_publish.py
@@ -269,3 +269,36 @@ class TestExtractForEvaluation:
         )
         _, _, _, unscanned = extract_for_evaluation(zip_bytes)
         assert unscanned == []
+
+    def test_survives_non_utf8_scannable_file(self) -> None:
+        """Regression: a Latin-1 / CP1252 file in the zip previously raised
+        UnicodeDecodeError and aborted the whole publish. It should now decode
+        with a replacement character and let the gauntlet inspect the file.
+        """
+        # 0xE9 is 'é' in Latin-1, invalid as a stand-alone UTF-8 byte.
+        latin1_bytes = "def greet():\n    return 'café'\n".encode("latin-1")
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md", "---\nname: s\ndescription: d\n---\n")
+            zf.writestr("app.py", latin1_bytes)
+        zip_bytes = buf.getvalue()
+
+        _skill_md, sources, _lockfile, _unscanned = extract_for_evaluation(zip_bytes)
+        source_names = [name for name, _ in sources]
+        assert "app.py" in source_names
+        # Content is still present; the offending byte was replaced.
+        app_content = next(c for n, c in sources if n == "app.py")
+        assert "greet" in app_content
+
+    def test_skill_md_still_strict_on_bad_utf8(self) -> None:
+        """SKILL.md is the manifest and must be valid UTF-8; a broken one still
+        surfaces a decode error so bad manifests fail loudly.
+        """
+        bad_bytes = b"---\nname: s\ndescription: caf\xe9\n---\n"
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("SKILL.md", bad_bytes)
+        zip_bytes = buf.getvalue()
+
+        with pytest.raises(UnicodeDecodeError):
+            extract_for_evaluation(zip_bytes)

--- a/server/tests/test_infra/test_batch_update_github.py
+++ b/server/tests/test_infra/test_batch_update_github.py
@@ -1,0 +1,84 @@
+"""Tests for batch_update_github_stars / batch_update_github_repo_metadata LIKE escaping.
+
+Regression coverage for the bug where an unescaped ``LIKE '<url>/%'`` pattern
+would treat ``_`` characters in repo URLs (e.g. ``pymc_labs``) as single-char
+wildcards and clobber unrelated repos' star/fork/watcher counts.
+"""
+
+from unittest.mock import MagicMock
+
+from decision_hub.infra.database import (
+    _escape_like,
+    batch_update_github_repo_metadata,
+    batch_update_github_stars,
+)
+
+
+def _compile_where(stmt) -> str:
+    """Render a SQLAlchemy statement's WHERE clause with bound literals."""
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+class TestBatchUpdateGithubStars:
+    def test_no_op_on_empty_input(self):
+        conn = MagicMock()
+        batch_update_github_stars(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_underscore_in_repo_url_is_escaped(self):
+        conn = MagicMock()
+        batch_update_github_stars(
+            conn,
+            {"https://github.com/pymc_labs/decision-hub": 42},
+        )
+        assert conn.execute.call_count == 1
+        rendered = _compile_where(conn.execute.call_args.args[0])
+        # The rendered LIKE pattern must contain the escaped underscore
+        # (i.e. the escape character preceding it) so a repo like
+        # ``pymcXlabs`` cannot match by wildcard.
+        assert _escape_like("https://github.com/pymc_labs/decision-hub") + "/%" in rendered
+        # And the ESCAPE clause must be present so Postgres knows to honour it.
+        assert "ESCAPE" in rendered.upper()
+
+    def test_percent_in_repo_url_is_escaped(self):
+        conn = MagicMock()
+        batch_update_github_stars(conn, {"https://github.com/foo/100%bar": 7})
+        rendered = _compile_where(conn.execute.call_args.args[0])
+        # Escaped percent should be present in the LIKE pattern
+        assert "\\%" in rendered
+
+    def test_one_update_per_repo(self):
+        conn = MagicMock()
+        batch_update_github_stars(
+            conn,
+            {
+                "https://github.com/a/one": 1,
+                "https://github.com/b/two": 2,
+                "https://github.com/c/three": 3,
+            },
+        )
+        assert conn.execute.call_count == 3
+
+
+class TestBatchUpdateGithubRepoMetadata:
+    def test_no_op_on_empty_input(self):
+        conn = MagicMock()
+        batch_update_github_repo_metadata(conn, {})
+        conn.execute.assert_not_called()
+
+    def test_underscore_in_repo_url_is_escaped(self):
+        conn = MagicMock()
+        batch_update_github_repo_metadata(
+            conn,
+            {
+                "https://github.com/pymc_labs/decision-hub": {
+                    "forks": 3,
+                    "watchers": 4,
+                    "is_archived": False,
+                    "license": "MIT",
+                }
+            },
+        )
+        rendered = _compile_where(conn.execute.call_args.args[0])
+        assert _escape_like("https://github.com/pymc_labs/decision-hub") + "/%" in rendered
+        assert "ESCAPE" in rendered.upper()

--- a/server/tests/test_infra/test_github.py
+++ b/server/tests/test_infra/test_github.py
@@ -6,6 +6,7 @@ import respx
 
 from decision_hub.infra.github import (
     _parse_next_link,
+    check_org_membership,
     fetch_org_metadata,
     fetch_user_metadata,
     list_user_orgs,
@@ -141,6 +142,71 @@ class TestFetchOrgMetadata:
 
         with pytest.raises(httpx.HTTPStatusError):
             await fetch_org_metadata("gh-token", "bad-org")
+
+
+class TestCheckOrgMembership:
+    """check_org_membership treats transient GitHub errors as retryable, not as denial."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_204_means_member(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs/members/alice").mock(return_value=httpx.Response(204))
+        assert await check_org_membership("gh-token", "pymc-labs", "alice") is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_404_means_not_a_member(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs/members/bob").mock(
+            return_value=httpx.Response(404, json={"message": "Not Found"})
+        )
+        assert await check_org_membership("gh-token", "pymc-labs", "bob") is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_302_means_requester_cannot_see(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs/members/carol").mock(
+            return_value=httpx.Response(302, headers={"Location": "https://api.github.com/whatever"})
+        )
+        assert await check_org_membership("gh-token", "pymc-labs", "carol") is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_403_returns_false_without_raising(self) -> None:
+        # Private membership visible only to org members: definitively cannot see -> False.
+        respx.get("https://api.github.com/orgs/pymc-labs/members/dave").mock(
+            return_value=httpx.Response(403, json={"message": "Forbidden"})
+        )
+        assert await check_org_membership("gh-token", "pymc-labs", "dave") is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_429_raises_instead_of_denying(self) -> None:
+        # Regression: previously we silently returned False on 429, which
+        # locked legitimate members out of login during a GitHub rate-limit
+        # incident. Must now raise so the caller can return a 502.
+        respx.get("https://api.github.com/orgs/pymc-labs/members/erin").mock(
+            return_value=httpx.Response(429, json={"message": "rate limited"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await check_org_membership("gh-token", "pymc-labs", "erin")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_500_raises_instead_of_denying(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs/members/frank").mock(
+            return_value=httpx.Response(500, json={"message": "server error"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await check_org_membership("gh-token", "pymc-labs", "frank")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_502_raises_instead_of_denying(self) -> None:
+        respx.get("https://api.github.com/orgs/pymc-labs/members/gina").mock(
+            return_value=httpx.Response(502, text="Bad Gateway")
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await check_org_membership("gh-token", "pymc-labs", "gina")
 
 
 class TestFetchUserMetadata:

--- a/server/tests/test_infra/test_storage_eval_logs.py
+++ b/server/tests/test_infra/test_storage_eval_logs.py
@@ -10,8 +10,22 @@ from decision_hub.infra.storage import (
 )
 
 
-def _make_s3_client() -> MagicMock:
-    return MagicMock()
+def _make_s3_client(pages: list[dict] | None = None) -> MagicMock:
+    """Build a MagicMock S3 client. If *pages* is given, ``get_paginator`` returns those pages;
+    otherwise ``list_objects_v2`` returns a single-page (empty) result by default.
+    """
+    client = MagicMock()
+    if pages is not None:
+        paginator = MagicMock()
+        paginator.paginate.return_value = iter(pages)
+        client.get_paginator.return_value = paginator
+    else:
+        # Sensible default so tests that only set list_objects_v2 still work
+        # via the paginator abstraction.
+        paginator = MagicMock()
+        paginator.paginate.return_value = iter([{"Contents": []}])
+        client.get_paginator.return_value = paginator
+    return client
 
 
 class TestUploadEvalLogChunk:
@@ -34,48 +48,69 @@ class TestUploadEvalLogChunk:
 
 class TestListEvalLogChunks:
     def test_returns_chunks_after_cursor(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "eval-logs/run/0001.jsonl"},
-                {"Key": "eval-logs/run/0002.jsonl"},
-                {"Key": "eval-logs/run/0003.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                {
+                    "Contents": [
+                        {"Key": "eval-logs/run/0001.jsonl"},
+                        {"Key": "eval-logs/run/0002.jsonl"},
+                        {"Key": "eval-logs/run/0003.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "eval-logs/run/", after_seq=1)
         assert len(result) == 2
         assert result[0] == (2, "eval-logs/run/0002.jsonl")
         assert result[1] == (3, "eval-logs/run/0003.jsonl")
 
     def test_returns_empty_for_no_contents(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client(pages=[{}])
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert result == []
 
     def test_skips_non_jsonl_files(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "prefix/0001.jsonl"},
-                {"Key": "prefix/readme.txt"},
+        client = _make_s3_client(
+            pages=[
+                {
+                    "Contents": [
+                        {"Key": "prefix/0001.jsonl"},
+                        {"Key": "prefix/readme.txt"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "prefix/")
         assert len(result) == 1
 
     def test_returns_sorted_by_seq(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0003.jsonl"},
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                {
+                    "Contents": [
+                        {"Key": "p/0003.jsonl"},
+                        {"Key": "p/0001.jsonl"},
+                        {"Key": "p/0002.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         result = list_eval_log_chunks(client, "bucket", "p/")
         seqs = [s for s, _ in result]
         assert seqs == [1, 2, 3]
+
+    def test_follows_pagination_beyond_1000_keys(self):
+        """Regression: S3's list_objects_v2 truncates at 1000 keys per page.
+        A long eval run flushing every 2s can produce >1000 chunks; the paginator
+        must follow NextContinuationToken so the tail isn't silently dropped.
+        """
+        page_1 = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1, 1001)]}
+        page_2 = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(1001, 1200)]}
+        client = _make_s3_client(pages=[page_1, page_2])
+        result = list_eval_log_chunks(client, "bucket", "p/")
+        assert len(result) == 1199
+        assert result[0] == (1, "p/0001.jsonl")
+        assert result[-1] == (1199, "p/1199.jsonl")
 
 
 class TestReadEvalLogChunk:
@@ -89,20 +124,37 @@ class TestReadEvalLogChunk:
 
 class TestDeleteEvalLogs:
     def test_deletes_all_objects_under_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {
-            "Contents": [
-                {"Key": "p/0001.jsonl"},
-                {"Key": "p/0002.jsonl"},
+        client = _make_s3_client(
+            pages=[
+                {
+                    "Contents": [
+                        {"Key": "p/0001.jsonl"},
+                        {"Key": "p/0002.jsonl"},
+                    ]
+                }
             ]
-        }
+        )
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 2
         client.delete_objects.assert_called_once()
 
     def test_returns_zero_for_empty_prefix(self):
-        client = _make_s3_client()
-        client.list_objects_v2.return_value = {}
+        client = _make_s3_client(pages=[{}])
         count = delete_eval_logs(client, "bucket", "p/")
         assert count == 0
         client.delete_objects.assert_not_called()
+
+    def test_batches_deletes_at_1000_key_limit(self):
+        """S3's delete_objects accepts at most 1000 keys per call. A prefix with
+        2200 objects should trigger 3 delete_objects calls, not one 2200-key call.
+        """
+        page_1 = {"Contents": [{"Key": f"p/{i:04d}.jsonl"} for i in range(2200)]}
+        client = _make_s3_client(pages=[page_1])
+        count = delete_eval_logs(client, "bucket", "p/")
+        assert count == 2200
+        assert client.delete_objects.call_count == 3
+        # First two batches are exactly 1000 keys each
+        for call in client.delete_objects.call_args_list[:2]:
+            assert len(call.kwargs["Delete"]["Objects"]) == 1000
+        # Final batch is the remainder
+        assert len(client.delete_objects.call_args_list[2].kwargs["Delete"]["Objects"]) == 200


### PR DESCRIPTION
## What changed

A first pragmatic pass from a full-repo audit (server + client + shared + frontend). Concrete bug fixes with regression tests, a small dedup, and one observability fix. Every change has a documented failing scenario; nothing here is stylistic.

**Server correctness**
- `database.batch_update_github_stars` / `batch_update_github_repo_metadata` — escape `LIKE` wildcards. A repo URL containing `_` (very common — e.g. `pymc_labs`) was treated as a single-char wildcard and could clobber unrelated repos' star/fork/watcher counts.
- `github.check_org_membership` — raise `HTTPStatusError` on 429/5xx instead of silently returning `False`. Silent `False` meant a GitHub rate-limit or outage locked legitimate members out of login. `auth_routes` now surfaces a `502` (retryable) for transient errors and keeps `403` only for genuine non-membership.
- `storage.list_eval_log_chunks` / `delete_eval_logs` — paginate `list_objects_v2` via boto3's paginator, and batch `delete_objects` at the 1000-key limit. Previously a long eval flushing more than 1000 chunks silently lost its tail.
- `publish.extract_for_evaluation` — decode scannable source files with `errors="replace"` so a Latin-1 / CP1252 file in a third-party repo can't abort the whole publish with `UnicodeDecodeError`. `SKILL.md` (the manifest) stays strict.
- `registry_routes.get_eval_run` — use `_check_zombie` return status directly instead of re-reading the row. Saves one SELECT and avoids a rare `NoneType` crash if the row is deleted between the two reads.
- `registry_routes.list_eval_runs` + `database.find_eval_runs_for_version` — push `user_id` filter into SQL instead of pulling every run for a version across all users and filtering in Python.
- `backfill_embeddings` — add `ORDER BY skills.id` so the `LIMIT` scan is deterministic (per CLAUDE.md invariant).

**Observability**
- `RequestLoggingMiddleware` — on unhandled exceptions attach the traceback via `logger.opt(exception=...)` so the request summary line carries the stack instead of a bare "500" with no correlation.

**Code quality**
- Extract `parse_uuid` into `api/deps.py`; drop the two duplicated `_parse_uuid` copies (`registry_routes.py` and `tracker_routes.py`) and their now-unused `from uuid import UUID` imports.

**Frontend**
- `AskModal` — reset `messages` / `query` / `error` when the modal closes so a subsequent open starts fresh instead of resurfacing the prior session.
- `GradeBadge.module.css` / `NotFoundPage.tsx` — use the `--text-*` CSS custom-property scale instead of hardcoded `rem` sizes.

## Why

Findings surfaced by a scheduled review pass across the codebase. Each fix corresponds to a bug with a specific reproduction case (e.g. GitHub rate-limit → auth denial; underscore in repo URL → wrong repo's stars overwritten; long eval → truncated log tail); each is small enough to review in isolation and covered by a regression test.

## How to test

```
make test-server    # 950 passed
make test-shared    # 98 passed
make test-frontend  # 82 passed
make lint           # ruff + frontend clean (1 pre-existing warning)
make typecheck      # mypy clean
```

New / updated tests:

- `test_batch_update_github` — LIKE-escape regression for `_` / `%` in repo URLs.
- `test_github.TestCheckOrgMembership` — 204/404/302/403 (False) vs 429/500/502 (raises) matrix.
- `test_storage_eval_logs` — pagination beyond 1000 keys; delete batching at the 1000-key API cap.
- `test_publish.test_survives_non_utf8_scannable_file` — Latin-1 regression.
- `test_publish.test_skill_md_still_strict_on_bad_utf8` — guards against loosening `SKILL.md` decoding by accident.
- `test_eval_logs.test_list_by_version_filters_to_current_user` — updated to assert the `user_id` kwarg is passed to the DB helper (filter is now in SQL, not Python).

Manual: unchanged surface for CLI + web UI. No schema changes, no migrations.

## Checklist
- [x] Tests pass (`make test-server`, `make test-shared`, `make test-frontend`)
- [x] No breaking API changes
- [x] Database migration included (if schema changed) — not needed; no schema changes

## Not in this PR (called out in the review)

Larger-blast-radius findings that need a design conversation before landing:

- **Rate limiter reads Modal proxy IP, not client IP**, and lives per-container — per-IP limits are effectively decorative on Modal, and auth brute-force isn't actually rate-limited across replicas. Needs a trust decision on which forwarded-header to honour and a shared backend (Redis / Modal Dict).
- **Batch tracker `UPDATE` uses N per-row round-trips per tick**. At 10k+ trackers this is a real cost; rewrite as one CTE-based UPDATE with `VALUES (...)` unnest.
- **`get_eval_run_logs` reads every S3 chunk on every poll** (comment acknowledges `cursor` is an event-seq, not a chunk-seq). Fix needs min/max-seq metadata baked into the S3 key so early chunks can be skipped.
- **Publish pipeline has no direct tests** — coverage is via 12–15 deep `@patch` stacks in `test_registry_routes.py`, which are refactor-hostile.
- **9 near-identical `_enforce_*_rate_limit` stubs** across route files should collapse into one factory in `api/rate_limit.py`.
- **`crawler.processing._finalize_skill` uploads to S3 before `insert_version`** — on `IntegrityError` from a race the blob is orphaned. `execute_publish` already gets the ordering right; mirror it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rgm9rE4S3GW9xDZwAJ56wR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgm9rE4S3GW9xDZwAJ56wR)_