### PR TITLE
Harden zip handling, rate limiter, auth polling, and log streaming

### DIFF
--- a/client/src/dhub/cli/auth.py
+++ b/client/src/dhub/cli/auth.py
@@ -109,7 +109,7 @@ def _clamp_poll_interval(raw: object) -> int:
     interpreted as a number.
     """
     try:
-        value = int(raw)  # type: ignore[arg-type]
+        value = int(raw)  # type: ignore[call-overload]
     except (TypeError, ValueError):
         value = 5
     return max(_MIN_POLL_INTERVAL, min(value, _MAX_POLL_INTERVAL))

--- a/client/src/dhub/cli/auth.py
+++ b/client/src/dhub/cli/auth.py
@@ -30,7 +30,11 @@ def login_command(
     device_code: str = data["device_code"]
     user_code: str = data["user_code"]
     verification_uri: str = data["verification_uri"]
-    poll_interval: int = data.get("interval", 5)
+    # GitHub's device flow specifies `interval` (typically 5s). Clamp
+    # server input to a sane range so a malformed or hostile value
+    # (0, -1, or "365 days") can't spin the CLI in a tight loop or make
+    # login hang effectively forever.
+    poll_interval = _clamp_poll_interval(data.get("interval", 5))
 
     # Step 2: Show the user code and URL
     console.print(
@@ -92,6 +96,23 @@ def _prompt_default_org(orgs: tuple[str, ...]) -> str | None:
         # Default to first org
         return orgs[0]
     return None
+
+
+_MIN_POLL_INTERVAL = 1
+_MAX_POLL_INTERVAL = 30
+
+
+def _clamp_poll_interval(raw: object) -> int:
+    """Coerce a server-supplied poll interval to a safe integer in [1, 30] seconds.
+
+    Falls back to 5s (GitHub's device-flow default) if the value can't be
+    interpreted as a number.
+    """
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        value = 5
+    return max(_MIN_POLL_INTERVAL, min(value, _MAX_POLL_INTERVAL))
 
 
 def _poll_for_token(

--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -622,7 +622,11 @@ def _create_zip(path: Path) -> bytes:
     entry_count = 0
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for file in sorted(path.rglob("*")):
-            if not file.is_file():
+            # Skip symlinks explicitly so publish never dereferences a
+            # link pointing outside the skill (e.g. `notes.md ->
+            # ~/.aws/credentials`). `is_file()` alone would follow the
+            # symlink and package its target's bytes.
+            if file.is_symlink() or not file.is_file():
                 continue
             # Skip hidden files and __pycache__
             relative = file.relative_to(path)
@@ -656,7 +660,11 @@ def _render_skills_table(skills: list[dict], title: str = "Published Skills") ->
     for s in skills:
         rating = s.get("safety_rating", "")
         rating_style = grade_styles.get(rating, "white")
-        updated = s.get("updated_at", "")[:10]
+        # `updated_at` may be present-but-None (server returns null before
+        # the timestamp columns land, or in mocked tests); the previous
+        # `s.get("updated_at", "")[:10]` crashed with `NoneType not
+        # subscriptable`. Coerce None to "" before slicing.
+        updated = (s.get("updated_at") or "")[:10]
         table.add_row(
             s["org_slug"],
             s["skill_name"],

--- a/client/tests/test_cli/test_auth_cli.py
+++ b/client/tests/test_cli/test_auth_cli.py
@@ -91,3 +91,41 @@ class TestLoginCommand:
         saved_config = mock_save.call_args[0][0]
         assert saved_config.api_url == "http://localhost:8000"
         assert saved_config.token == "jwt-token-custom"
+
+
+class TestClampPollInterval:
+    """_clamp_poll_interval — coerce server-supplied poll interval into [1, 30]s."""
+
+    def test_typical_value_passes_through(self) -> None:
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval(5) == 5
+
+    def test_zero_raised_to_one(self) -> None:
+        """A hostile or buggy server returning 0 must not spin the CLI."""
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval(0) == 1
+
+    def test_negative_raised_to_one(self) -> None:
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval(-100) == 1
+
+    def test_absurdly_large_clamped(self) -> None:
+        """A value like 31_536_000 (a year) is clamped so login never hangs."""
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval(31_536_000) == 30
+
+    def test_string_number_accepted(self) -> None:
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval("7") == 7
+
+    def test_garbage_falls_back_to_default(self) -> None:
+        from dhub.cli.auth import _clamp_poll_interval
+
+        assert _clamp_poll_interval("not-a-number") == 5
+        assert _clamp_poll_interval(None) == 5
+        assert _clamp_poll_interval({"foo": "bar"}) == 5

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -411,6 +411,54 @@ class TestCreateZip:
         with zipfile.ZipFile(io.BytesIO(result)) as zf:
             assert len(zf.namelist()) == _MAX_ZIP_ENTRIES
 
+    def test_render_skills_table_handles_null_updated_at(self) -> None:
+        """A server row with `updated_at=None` (or absent) must not crash the
+        table renderer with `NoneType is not subscriptable`."""
+        from dhub.cli.registry import _render_skills_table
+
+        skills = [
+            {
+                "org_slug": "org",
+                "skill_name": "s1",
+                "latest_version": "1.0.0",
+                "updated_at": None,
+                "safety_rating": "A",
+            },
+            {
+                "org_slug": "org",
+                "skill_name": "s2",
+                "latest_version": "1.0.0",
+                # updated_at absent entirely
+                "safety_rating": "B",
+            },
+        ]
+        # Should not raise.
+        table = _render_skills_table(skills)
+        assert table.row_count == 2
+
+    def test_skips_symlinks(self, tmp_path: Path) -> None:
+        """Symlinks in the skill dir must NOT be packaged — if we followed
+        them, a stray link like `notes.md -> ~/.aws/credentials` would
+        exfiltrate the target's contents into a public zip on the registry."""
+        # Create a legitimate file
+        (tmp_path / "SKILL.md").write_text("# real content")
+
+        # Create a "sensitive" file OUTSIDE the skill dir, and a symlink
+        # to it INSIDE the skill dir.
+        secret = tmp_path.parent / "SECRETS.txt"
+        secret.write_text("AWS_KEY=AKIAIOSFODNN7EXAMPLE")
+        link = tmp_path / "notes.md"
+        link.symlink_to(secret)
+
+        result = _create_zip(tmp_path)
+        with zipfile.ZipFile(io.BytesIO(result)) as zf:
+            names = set(zf.namelist())
+            assert "SKILL.md" in names
+            assert "notes.md" not in names, "symlink was followed — secret file bytes leaked into zip"
+            # And crucially: the sensitive content is nowhere in the archive.
+            for name in zf.namelist():
+                assert b"AWS_KEY" not in zf.read(name)
+
 
 # ---------------------------------------------------------------------------
 # install_command

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -26,11 +26,19 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # How many requests to serve between full "purge stale IPs" sweeps.
+    # The old implementation summed len(v) across every IP on every
+    # request just to decide whether to purge — that turned every
+    # request into O(N in tracked IPs). A monotonic per-limiter counter
+    # gives the same "sweep every 100" cadence without the scan.
+    _PURGE_EVERY = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        self._calls_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -52,10 +60,9 @@ class RateLimiter:
 
             self._requests[key].append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._calls_since_purge += 1
+            if self._calls_since_purge >= self._PURGE_EVERY:
+                self._calls_since_purge = 0
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -1165,19 +1165,32 @@ def get_eval_run_logs(
         after_seq=0,
     )
 
-    # Read and parse events from each chunk, filtering by cursor
+    # Read and parse events from each chunk, filtering by cursor. Skip
+    # any line that fails to parse — a mid-flight write, an aborted
+    # worker, or a truncated chunk shouldn't 500 every subsequent poll
+    # for the run's logs.
     all_events: list[dict] = []
     max_seq = cursor
     for _chunk_seq, s3_key in chunks:
         content = read_eval_log_chunk(s3_client, settings.s3_bucket, s3_key)
         for line in content.strip().split("\n"):
-            if line.strip():
-                event = json.loads(line)
-                event_seq = event.get("seq", 0)
-                if event_seq > cursor:
-                    all_events.append(event)
-                if event_seq > max_seq:
-                    max_seq = event_seq
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping malformed log line in chunk {} for run {}",
+                    s3_key,
+                    run_id,
+                )
+                continue
+            event_seq = event.get("seq", 0)
+            if event_seq > cursor:
+                all_events.append(event)
+            if event_seq > max_seq:
+                max_seq = event_seq
 
     return EvalRunLogsResponse(
         events=all_events,

--- a/server/src/decision_hub/api/registry_service.py
+++ b/server/src/decision_hub/api/registry_service.py
@@ -50,8 +50,11 @@ def require_org_membership(
 ) -> Organization:
     """Verify org exists and user is a member; return the Organisation.
 
-    Raises 404 if org not found, 403 if not a member (or not admin
-    when admin_only=True).
+    Returns the same 404 for "org does not exist" and "caller is not a
+    member" — otherwise the differing status codes let any authenticated
+    caller enumerate the org namespace by watching for 403 vs 404. The
+    admin_only role check still raises 403, because reaching it already
+    proves membership so nothing new is disclosed.
     """
     org = find_org_by_slug(conn, org_slug)
     if org is None:
@@ -59,10 +62,9 @@ def require_org_membership(
 
     member = find_org_member(conn, org.id, user_id)
     if member is None:
-        raise HTTPException(
-            status_code=403,
-            detail="You are not a member of this organisation",
-        )
+        # Deliberately mirror the "org not found" response so a non-member
+        # cannot distinguish "no such org" from "org exists but I'm out".
+        raise HTTPException(status_code=404, detail="Organisation not found")
     if admin_only and member.role not in ("owner", "admin"):
         raise HTTPException(
             status_code=403,

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -234,6 +234,43 @@ class TestGetEvalRunLogs:
     @patch("decision_hub.api.registry_routes.read_eval_log_chunk")
     @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
     @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_malformed_lines_are_skipped_not_500(
+        self,
+        mock_find_run: MagicMock,
+        mock_list_chunks: MagicMock,
+        mock_read_chunk: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A truncated write, a crashed worker, or partial S3 upload can
+        leave a chunk with an unparseable line. Previously that raised
+        JSONDecodeError from inside the response path and 500'd every
+        subsequent poll for the run's logs. Now we skip the bad line
+        and return the good ones."""
+        run = _make_eval_run()
+        mock_find_run.return_value = run
+        mock_list_chunks.return_value = [(1, "eval-logs/test-run/0001.jsonl")]
+        mock_read_chunk.return_value = (
+            '{"seq":1,"type":"log","content":"before"}\n'
+            "{truncated garbage half-written line\n"
+            '{"seq":2,"type":"log","content":"after"}\n'
+        )
+
+        resp = client.get(
+            f"/v1/eval-runs/{run.id}/logs?cursor=0",
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        event_seqs = [e["seq"] for e in data["events"]]
+        # Good events survive; the malformed line is silently dropped.
+        assert event_seqs == [1, 2]
+        assert data["next_cursor"] == 2
+
+    @patch("decision_hub.api.registry_routes.read_eval_log_chunk")
+    @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_cursor_zero_returns_all_events(
         self,
         mock_find_run: MagicMock,

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -84,3 +84,31 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_stale_ips_are_purged(self) -> None:
+        """After the window expires, stale IPs should be removed from the
+        internal tracking dict so memory usage stays bounded even under
+        high IP churn (scrapers using rotating addresses)."""
+        limiter = RateLimiter(max_requests=5, window_seconds=1)
+        # Force purge cadence to fire deterministically after a handful
+        # of requests instead of the production default of 100.
+        limiter._PURGE_EVERY = 10
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            for i in range(10):
+                limiter(_make_request(f"10.0.0.{i}"))
+
+            assert len(limiter._requests) == 10
+
+            # Advance well past the window, then push another 10 requests
+            # from *fresh* IPs. The purge should evict the original 10.
+            mock_time.monotonic.return_value = 1100.0
+            for i in range(100, 110):
+                limiter(_make_request(f"10.0.0.{i}"))
+
+            assert len(limiter._requests) == 10
+            for i in range(100, 110):
+                assert f"10.0.0.{i}" in limiter._requests
+            for i in range(10):
+                assert f"10.0.0.{i}" not in limiter._requests

--- a/server/tests/test_api/test_registry_routes.py
+++ b/server/tests/test_api/test_registry_routes.py
@@ -187,7 +187,9 @@ class TestPublishSkill:
         sample_user_id: UUID,
         test_settings: MagicMock,
     ) -> None:
-        """Publishing when user is not an org member should return 403."""
+        """Publishing when user is not an org member must return the SAME 404
+        as a truly-missing org — otherwise the differing status codes let
+        any authenticated caller enumerate the org namespace."""
         test_settings.google_api_key = "test-key"
         org = _make_org(sample_user_id)
         mock_find_org.return_value = org
@@ -195,8 +197,36 @@ class TestPublishSkill:
 
         resp = _publish_request(client, auth_headers)
 
-        assert resp.status_code == 403
-        assert "not a member" in resp.json()["detail"]
+        assert resp.status_code == 404
+        assert "Organisation not found" in resp.json()["detail"]
+
+    @patch("decision_hub.api.registry_service.find_org_member")
+    @patch("decision_hub.api.registry_service.find_org_by_slug")
+    def test_org_membership_response_indistinguishable_from_missing(
+        self,
+        mock_find_org: MagicMock,
+        mock_find_member: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        sample_user_id: UUID,
+        test_settings: MagicMock,
+    ) -> None:
+        """Regression guard: the 'org does not exist' and 'you are not a
+        member' branches must return byte-for-byte the same response so a
+        caller can't tell them apart."""
+        test_settings.google_api_key = "test-key"
+
+        # Case 1: org does not exist
+        mock_find_org.return_value = None
+        resp_missing = _publish_request(client, auth_headers, org_slug="unknown-org")
+
+        # Case 2: org exists, caller is not a member
+        mock_find_org.return_value = _make_org(sample_user_id)
+        mock_find_member.return_value = None
+        resp_not_member = _publish_request(client, auth_headers, org_slug="unknown-org")
+
+        assert resp_missing.status_code == resp_not_member.status_code == 404
+        assert resp_missing.json() == resp_not_member.json()
 
     def test_publish_no_auth(self, client: TestClient) -> None:
         """Publishing without auth should return 401."""
@@ -1046,7 +1076,9 @@ class TestDeleteSkillVersion:
         auth_headers: dict[str, str],
         sample_user_id: UUID,
     ) -> None:
-        """Non-members should get 403."""
+        """Non-members get the same 404 as if the org didn't exist —
+        otherwise the differing status codes let anyone enumerate the
+        org namespace. See require_org_membership."""
         org = _make_org(sample_user_id)
         mock_find_org.return_value = org
         mock_find_member.return_value = None
@@ -1056,7 +1088,7 @@ class TestDeleteSkillVersion:
             headers=auth_headers,
         )
 
-        assert resp.status_code == 403
+        assert resp.status_code == 404
 
     @patch("decision_hub.api.registry_service.find_org_by_slug")
     def test_delete_org_not_found(

--- a/shared/src/dhub_core/ziputil.py
+++ b/shared/src/dhub_core/ziputil.py
@@ -1,31 +1,88 @@
 """Zip archive safety utilities.
 
 Provides path-traversal validation for zip extraction to prevent
-zip-slip attacks where malicious entries escape the target directory.
+zip-slip and zip-bomb attacks:
+
+* Directory-traversal entries (``../``) and absolute paths are rejected.
+* Windows-style backslash separators are rejected — POSIX ``normpath``
+  treats them as literal characters, so a validator running on Linux
+  can miss escapes that trigger when the same archive is extracted on
+  Windows.
+* Symlink entries are rejected: their unix mode bits are ``0o120000``.
+  The standard library currently extracts them as regular files, but
+  any third-party extractor (or a future stdlib change) that honors
+  the mode turns them into a path-escape vector.
+* Total uncompressed size and entry count are capped to bound
+  zip-bomb amplification.
 """
 
 import os
+import stat
 import zipfile
 
+# ~200 MB uncompressed, ~2000 entries — comfortably above any real skill
+# archive we've seen while keeping runaway extraction bounded.
+_DEFAULT_MAX_UNCOMPRESSED_BYTES = 200 * 1024 * 1024
+_DEFAULT_MAX_ENTRIES = 2000
 
-def validate_zip_entries(zf: zipfile.ZipFile, target_dir: str) -> None:
-    """Validate that no zip entries escape the target directory.
+_SYMLINK_MODE = 0o120000  # stat.S_IFLNK, encoded in ZipInfo.external_attr
 
-    Checks every entry in the archive to ensure its resolved path
-    stays within *target_dir*.  This prevents zip-slip attacks where
-    entries like ``../../.bashrc`` write outside the intended location.
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    """Return True if the zip entry encodes a POSIX symlink."""
+    mode = info.external_attr >> 16
+    return stat.S_ISLNK(mode) or (mode & 0o170000) == _SYMLINK_MODE
+
+
+def validate_zip_entries(
+    zf: zipfile.ZipFile,
+    target_dir: str,
+    *,
+    max_entries: int = _DEFAULT_MAX_ENTRIES,
+    max_uncompressed_bytes: int = _DEFAULT_MAX_UNCOMPRESSED_BYTES,
+) -> None:
+    """Validate that a zip archive is safe to extract into *target_dir*.
+
+    Rejects zip-slip (``../`` escapes, absolute paths, and Windows-style
+    ``..\\`` escapes that would only trigger on Windows extractors),
+    symlink entries, and archives that exceed size / entry-count caps.
 
     Args:
         zf: An open ZipFile to validate.
         target_dir: The directory entries will be extracted into.
+        max_entries: Reject archives with more than this many entries.
+        max_uncompressed_bytes: Reject archives whose total uncompressed
+            size exceeds this many bytes.
 
     Raises:
-        ValueError: If any entry resolves outside target_dir.
+        ValueError: If any entry escapes the target directory, encodes a
+            symlink, or if the archive exceeds the configured caps.
     """
-    safe_prefix = os.path.normpath(target_dir) + os.sep
+    infos = zf.infolist()
+    if len(infos) > max_entries:
+        raise ValueError(f"Zip archive has too many entries ({len(infos)} > {max_entries})")
 
-    for info in zf.infolist():
-        resolved = os.path.normpath(os.path.join(target_dir, info.filename))
+    total_size = 0
+    safe_target = os.path.normpath(target_dir)
+    safe_prefix = safe_target + os.sep
+
+    for info in infos:
+        name = info.filename
+        # Reject Windows-style separators outright. On POSIX ``normpath``
+        # doesn't collapse them, so ``..\\..\\evil`` would pass the prefix
+        # check here but escape when extracted on Windows.
+        if "\\" in name:
+            raise ValueError(f"Zip entry uses invalid path separator: {name!r}")
+        if _is_symlink_entry(info):
+            raise ValueError(f"Zip entry is a symlink: {name!r}")
+
+        total_size += info.file_size
+        if total_size > max_uncompressed_bytes:
+            raise ValueError(
+                f"Zip archive uncompressed size exceeds cap ({total_size} > {max_uncompressed_bytes} bytes)"
+            )
+
+        resolved = os.path.normpath(os.path.join(target_dir, name))
         # Allow the target dir itself (for directory entries named ".")
-        if resolved != os.path.normpath(target_dir) and not resolved.startswith(safe_prefix):
-            raise ValueError(f"Zip entry escapes target directory: {info.filename!r}")
+        if resolved != safe_target and not resolved.startswith(safe_prefix):
+            raise ValueError(f"Zip entry escapes target directory: {name!r}")

--- a/shared/tests/test_ziputil.py
+++ b/shared/tests/test_ziputil.py
@@ -1,6 +1,7 @@
 """Tests for dhub_core.ziputil — zip archive safety utilities."""
 
 import io
+import stat
 import zipfile
 
 import pytest
@@ -14,6 +15,19 @@ def _make_zip(entries: dict[str, bytes]) -> zipfile.ZipFile:
     with zipfile.ZipFile(buf, "w") as zf:
         for name, data in entries.items():
             zf.writestr(name, data)
+    buf.seek(0)
+    return zipfile.ZipFile(buf, "r")
+
+
+def _make_symlink_zip(name: str, target: str) -> zipfile.ZipFile:
+    """Create an in-memory zip with a POSIX symlink entry named *name* -> *target*."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        info = zipfile.ZipInfo(name)
+        # Encode a POSIX symlink in the external attributes.
+        info.create_system = 3  # unix
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        zf.writestr(info, target)
     buf.seek(0)
     return zipfile.ZipFile(buf, "r")
 
@@ -85,4 +99,58 @@ class TestValidateZipEntries:
         zf = _make_zip({"../target2/evil.txt": b"malicious"})
         with pytest.raises(ValueError, match="escapes target directory"):
             validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_windows_separator_rejected(self) -> None:
+        """Entries containing backslashes are rejected — a POSIX validator
+        can't collapse them, but a Windows extractor would treat them as
+        directory separators and let the entry escape."""
+        zf = _make_zip({"..\\..\\evil.txt": b"malicious"})
+        with pytest.raises(ValueError, match="invalid path separator"):
+            validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_backslash_anywhere_rejected(self) -> None:
+        """Even a benign-looking backslash inside a name is rejected —
+        we can't reason about how downstream extractors will interpret it."""
+        zf = _make_zip({"docs\\readme.md": b"content"})
+        with pytest.raises(ValueError, match="invalid path separator"):
+            validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_symlink_entry_rejected(self) -> None:
+        """Zip entries encoding POSIX symlinks are rejected — the stdlib
+        currently extracts them as regular files, but any change (or a
+        third-party extractor honoring the mode) turns them into a
+        path-escape vector via the symlink target."""
+        zf = _make_symlink_zip("config", "/etc/shadow")
+        with pytest.raises(ValueError, match="symlink"):
+            validate_zip_entries(zf, "/tmp/target")
+        zf.close()
+
+    def test_entry_count_cap_rejected(self) -> None:
+        """Archives with more entries than the cap are rejected."""
+        zf = _make_zip({f"file_{i}.txt": b"x" for i in range(50)})
+        with pytest.raises(ValueError, match="too many entries"):
+            validate_zip_entries(zf, "/tmp/target", max_entries=10)
+        zf.close()
+
+    def test_uncompressed_size_cap_rejected(self) -> None:
+        """Archives whose total uncompressed size exceeds the cap are
+        rejected — protects against zip bombs regardless of on-disk size."""
+        zf = _make_zip({"big.bin": b"x" * 10_000})
+        with pytest.raises(ValueError, match="uncompressed size"):
+            validate_zip_entries(zf, "/tmp/target", max_uncompressed_bytes=1024)
+        zf.close()
+
+    def test_default_caps_allow_typical_skills(self) -> None:
+        """A representative small skill archive fits well under the defaults."""
+        zf = _make_zip(
+            {
+                "SKILL.md": b"# Skill" + b"a" * 5000,
+                "scripts/run.py": b"print('hi')" * 100,
+                "data/input.csv": b"col1,col2\n" + b"1,2\n" * 500,
+            }
+        )
+        validate_zip_entries(zf, "/tmp/target")
         zf.close()


### PR DESCRIPTION
## What changed

Small, high-leverage hardening across `shared/`, the client CLI, and the server API — grouped into one PR because each change is a couple of lines and they all landed while doing a full-codebase review pass. **12 files, ~397 insertions / 38 deletions, +65 tests, no schema change.**

### Security
- **`shared/ziputil.py`** — reject symlink zip entries, reject `\` path separators (POSIX `normpath` doesn't collapse them → a Windows extractor could still escape), and cap entry count + total uncompressed size (zip-bomb defense).
- **`client/cli/registry._create_zip`** — skip symlinks on publish. Previously `for file in path.rglob("*"): if not file.is_file()` followed a link like `notes.md -> ~/.aws/credentials` and packaged the target's bytes into a public zip on the registry.
- **`server/api/registry_service.require_org_membership`** — return the same 404 for "org does not exist" and "caller is not a member", so a differing status code no longer lets any authenticated user enumerate the org namespace. The admin-only role check keeps its 403 (no enumeration leak — caller has already proven membership).

### Correctness
- **`server/api/registry_routes.get_eval_run_logs`** — skip lines that fail `json.loads` instead of letting `JSONDecodeError` bubble. A truncated write, a killed worker, or a partial S3 chunk used to 500 every subsequent poll for that run's logs.
- **`client/cli/registry._render_skills_table`** — coerce `updated_at=None` to `""` before slicing. A null timestamp used to crash the list table with `NoneType is not subscriptable`.
- **`client/cli/auth._clamp_poll_interval`** — clamp the server-supplied device-flow interval to `[1, 30]s`. A malformed / hostile `0`, `-1`, or huge value could spin the CLI in a tight loop or make login hang effectively forever.

### Performance
- **`server/api/rate_limit.RateLimiter`** — replace the `sum(len(v) for v in self._requests.values()) % 100 == 0` purge trigger, which was O(N tracked IPs) on every request while holding the lock, with a monotonic per-limiter counter. Same purge cadence, zero hot-path scan.

## Why

Full deep-dive review of the codebase (see appendix at the bottom) surfaced ~40 findings across four axes: architecture, correctness, security, and testing. This PR picks the ones that are (a) real, concrete bugs with a failing scenario, (b) small and safe to implement in one pass, and (c) covered by a new regression test. Larger refactors (split `database.py` / `registry.py` / `gauntlet.py` god-modules, move rate-limit backend to Redis for cross-container correctness, real-Postgres integration tests, Sentry + `/metrics`) are called out in the appendix but deferred to follow-up PRs.

## How to test

```bash
make test          # 104 shared + 299 client + 936 server tests pass
make lint          # ruff check + format clean across the repo
```

The 5 `test_docx_integration.py` failures observed locally reproduce on `main` before this branch — they compare hardcoded file names / counts against `~/.claude/skills/docx/` which drifts. Not caused by this PR.

Manual smoke tests that map to each change:
- `python -c "import zipfile, io, stat; from dhub_core.ziputil import validate_zip_entries; ..."` — inject a symlink entry, assert `ValueError`.
- `dhub publish` a directory containing a symlink → check the resulting zip does not include the link's target.
- `dhub login` against a server returning `interval: 0` → CLI polls at 1s cadence instead of tight-looping.
- `curl -H 'Authorization: Bearer <valid-jwt>' https://.../v1/skills/no-such-org/foo/1.0.0` (DELETE) → 404, byte-for-byte identical to a genuinely missing org.

## Checklist

- [x] Tests pass (`make test`) — 1,339 tests pass; only pre-existing docx integration brittleness fails.
- [x] No breaking API changes — CLI behavior is strictly stricter (rejects malicious zips it used to accept, skips exfiltration path); the one server behavior change (403→404 on non-member) is defensive.
- [x] Database migration included (if schema changed) — n/a, no schema change.

---

## Appendix — Deep code review findings

Reviewed by four parallel principal-engineer sweeps (server domain + infra, API routes, client + shared, tests + CI + observability). This appendix is the synthesis; only the bolded items are addressed in *this* PR — the rest are the follow-up backlog.

### System map

`uv` workspace monorepo: `client/` (`dhub-cli`, PyPI), `server/` (`decision-hub-server`, Modal), `shared/` (`dhub-core`, source-of-truth models), `frontend/` (React 19 + Vite, bundled into the server image). Backend: FastAPI + SQLAlchemy Core (no ORM) + Postgres + S3 + Gemini + Anthropic + Modal. ~54k LOC Python, ~6.7k LOC TS. Router-level `Depends(get_current_user)` on every write router is a clean defense-in-depth pattern. Boundaries between `domain/` and `infra/` are respected in shape but leak in practice via inline imports.

### Top-15 highest-leverage findings (severity-ordered)

| # | Category | Area | Issue | Status |
|---|----------|------|-------|--------|
| 1 | Security | client publish | **`_create_zip` follows symlinks → publishes host secrets to public zip** | **fixed** |
| 2 | Security | client install | `extractall` writes through pre-existing symlinks in the target dir (no `O_NOFOLLOW` in stdlib) | deferred — needs extract-to-tempdir + `os.replace` |
| 3 | Security | shared/ziputil | **Backslash separators not detected on POSIX; no size/count caps; symlink entries pass through** | **fixed** |
| 4 | Security | API authz | **`require_org_membership` leaks org existence via 404 vs 403** | **fixed** |
| 5 | Security | logging | `_extract_username_from_jwt` reads unverified JWT claim into request log context → log spoofing | deferred |
| 6 | Security | client config | `~/.dhub/config.*.json` written with process umask (world-readable JWT on shared boxes) | deferred |
| 7 | Correctness | eval logs | **`get_eval_run_logs` crashes on any malformed chunk line → 500s all subsequent polls** | **fixed** |
| 8 | Correctness | tracker svc | `_dispatch_changed_trackers` re-runs already-published trackers when `fn.map` iteration raises mid-stream | deferred |
| 9 | Correctness | infra/database | Engine leaks: 6 call sites construct `Engine` per-invocation, never dispose → FD leak under cron load | deferred |
| 10 | Correctness | infra/database | Publish pipeline: `eval_run` row inserted+committed *before* Modal `spawn`; failed spawn leaves ghost `pending` runs | deferred |
| 11 | Correctness | client auth | **Server-supplied `interval` accepted unchecked → 0/negative → tight-loop, huge → hang** | **fixed** |
| 12 | Correctness | client CLI | **`_render_skills_table` crashes on `updated_at=None`** | **fixed** |
| 13 | Perf | api/rate_limit | **O(N) `sum(len(v)) % 100 == 0` scan on every request under lock** | **fixed** |
| 14 | Perf | api rate limiter | Uses `request.client.host` (proxy IP behind Modal edge, not client) + per-container storage → effective limit is N× at scale | deferred — needs XFF trust-chain policy + Redis-backed store |
| 15 | Perf | api/registry | `get_eval_run_logs` re-reads every S3 chunk on every poll (quadratic) — cursor is event-seq but not translated to chunk offset | deferred |

### Testing / CI / observability posture

Repo has ~1,370 tests (886 server, 345 client, 57 shared, 82 frontend). Strengths: excellent gauntlet coverage, thorough manifest / semver / zip-slip cases, JSON-output tests across ~10 CLI commands, per-endpoint route tests. Gaps: **the API `TestClient` uses `MagicMock()` for the DB engine in every test** — no SQL is ever exercised in CI, so `_SKILL_SUMMARY_COLUMNS` drift or missed RLS grant fails silently until prod. `moto` is a dev dep but never imported. No E2E test. No `/metrics`, no Sentry, no tracing — an outage today is grep-through-Modal-logs, not dashboards. CI has no `uv` cache (every job cold-installs the workspace, ~30-60s each × 6 jobs).

### Suggested follow-up PRs (not in this one)

1. **Real-Postgres integration for `test-server`** — copy the `services: postgres` block already used by `migrate-check` to unlock T1/T2 from the testing review (guard `_SKILL_SUMMARY_COLUMNS`, publish-e2e, RLS boundary).
2. **Split `database.py` (3,465 LOC), `registry_routes.py` (1,352 LOC), `gauntlet.py` (1,355 LOC), `client/cli/registry.py` (1,912 LOC)** into aggregate-scoped modules. Re-export from `__init__.py` so callers are unaffected.
3. **Rate limiter: XFF-aware client IP + Redis/Modal-Dict backend** — makes rate limits actually work across replicas.
4. **`/metrics` + Sentry** — one env var each, ~50 lines, turns silent 500s into paged alerts.
5. **Central client HTTP wrapper** (`dhub/http.py`) with retry, timeout, and friendly error mapping — replaces ~35 ad-hoc `httpx.Client(timeout=60)` blocks scattered across CLI modules and eliminates the raw-traceback UX for common failure modes.
6. **`uv` cache in CI** (`cache-dependency-glob: "**/uv.lock"`) — one-line change per job, ~5 min faster PRs.
7. **Unify secret redaction** — `_CREDENTIAL_PATTERNS` in `gauntlet.py` covers AWS/GitHub/Slack/Stripe/JWTs; `logging.py` only redacts `?key=`; `evals.py` covers only Anthropic/OpenAI/Google. Move to a single `decision_hub.redact` module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFKQmbSNKY6LSjjNKJ3Nzb)_