### PR TITLE
fix: crawler S3 orphan, JWT log injection, DRY holistic body reviewers

### DIFF
--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -922,6 +922,64 @@ class BodyReviewResult(BaseModel):
     reason: str
 
 
+def _run_body_review(
+    *,
+    client: dict,
+    model: str,
+    prompt: str,
+    skill_name: str,
+    review_kind: str,
+) -> dict:
+    """Run a holistic Gemini body review with one retry, fail-closed on error.
+
+    Shared engine for ``review_code_body_safety`` and ``review_prompt_body_safety``:
+    both post a single ``BodyReviewResult`` JSON object and treat any error
+    (LLM unreachable, unparseable response, validation failure) as dangerous.
+    ``review_kind`` is a short label (e.g. ``"code"``, ``"body"``) used only
+    in the retry-warning log line.
+    """
+    payload = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.0},
+    }
+
+    for attempt in range(2):
+        try:
+            data = _gemini_post(client, model, payload)
+
+            text = _extract_text(data)
+            if not text:
+                if attempt == 0:
+                    logger.warning(
+                        "Holistic {} review returned no response for '{}', retrying",
+                        review_kind,
+                        skill_name,
+                    )
+                    continue
+                return {"dangerous": True, "reason": "LLM returned no response (fail-closed)"}
+
+            text = _strip_markdown_fences(text)
+            result = json.loads(text)
+            review = BodyReviewResult.model_validate(result)
+            return review.model_dump()
+        except (json.JSONDecodeError, ValidationError, httpx.HTTPError):
+            if attempt == 0:
+                logger.opt(exception=True).warning(
+                    "Holistic {} review failed for '{}', retrying once",
+                    review_kind,
+                    skill_name,
+                )
+                continue
+            logger.opt(exception=True).warning(
+                "Holistic {} review failed for '{}' on retry, treating as dangerous (fail-closed)",
+                review_kind,
+                skill_name,
+            )
+            return {"dangerous": True, "reason": "Review failed (fail-closed)"}
+
+    return {"dangerous": True, "reason": "Review failed (fail-closed)"}
+
+
 def review_code_body_safety(
     client: dict,
     source_files: list[tuple[str, str]],
@@ -1013,38 +1071,13 @@ def review_code_body_safety(
         '  {"dangerous": true/false, "reason": "<brief explanation>"}\n'
     )
 
-    payload = {
-        "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"temperature": 0.0},
-    }
-
-    for attempt in range(2):
-        try:
-            data = _gemini_post(client, model, payload)
-
-            text = _extract_text(data)
-            if not text:
-                if attempt == 0:
-                    logger.warning("Holistic code review returned no response for '{}', retrying", skill_name)
-                    continue
-                return {"dangerous": True, "reason": "LLM returned no response (fail-closed)"}
-
-            text = _strip_markdown_fences(text)
-
-            result = json.loads(text)
-            review = BodyReviewResult.model_validate(result)
-            return review.model_dump()
-        except (json.JSONDecodeError, ValidationError, httpx.HTTPError):
-            if attempt == 0:
-                logger.opt(exception=True).warning("Holistic code review failed for '{}', retrying once", skill_name)
-                continue
-            logger.opt(exception=True).warning(
-                "Holistic code review failed for '{}' on retry, treating as dangerous (fail-closed)",
-                skill_name,
-            )
-            return {"dangerous": True, "reason": "Review failed (fail-closed)"}
-
-    return {"dangerous": True, "reason": "Review failed (fail-closed)"}
+    return _run_body_review(
+        client=client,
+        model=model,
+        prompt=prompt,
+        skill_name=skill_name,
+        review_kind="code",
+    )
 
 
 def review_prompt_body_safety(
@@ -1120,35 +1153,10 @@ def review_prompt_body_safety(
         '  {"dangerous": true/false, "reason": "<brief explanation>"}\n'
     )
 
-    payload = {
-        "contents": [{"parts": [{"text": prompt}]}],
-        "generationConfig": {"temperature": 0.0},
-    }
-
-    for attempt in range(2):
-        try:
-            data = _gemini_post(client, model, payload)
-
-            text = _extract_text(data)
-            if not text:
-                if attempt == 0:
-                    logger.warning("Holistic body review returned no response for '{}', retrying", skill_name)
-                    continue
-                return {"dangerous": True, "reason": "LLM returned no response (fail-closed)"}
-
-            text = _strip_markdown_fences(text)
-
-            result = json.loads(text)
-            review = BodyReviewResult.model_validate(result)
-            return review.model_dump()
-        except (json.JSONDecodeError, ValidationError, httpx.HTTPError):
-            if attempt == 0:
-                logger.opt(exception=True).warning("Holistic body review failed for '{}', retrying once", skill_name)
-                continue
-            logger.opt(exception=True).warning(
-                "Holistic body review failed for '{}' on retry, treating as dangerous (fail-closed)",
-                skill_name,
-            )
-            return {"dangerous": True, "reason": "Review failed (fail-closed)"}
-
-    return {"dangerous": True, "reason": "Review failed (fail-closed)"}
+    return _run_body_review(
+        client=client,
+        model=model,
+        prompt=prompt,
+        skill_name=skill_name,
+        review_kind="body",
+    )

--- a/server/src/decision_hub/logging.py
+++ b/server/src/decision_hub/logging.py
@@ -242,13 +242,32 @@ class RequestLoggingMiddleware:
                 )
 
 
+_JWT_USERNAME_MAX_LEN = 64
+
+
+def _sanitize_log_username(value: object) -> str:
+    """Coerce an unverified JWT claim to a safe log field.
+
+    The username claim comes from an unverified JWT (auth verification
+    happens later in the dependency layer). A hostile or malformed token
+    could carry newlines, ANSI escapes, or oversized payloads that would
+    corrupt log lines / terminals. Keep only printable ASCII (32-126) and
+    cap length.
+    """
+    if not isinstance(value, str):
+        return ""
+    cleaned = "".join(ch for ch in value if 32 <= ord(ch) <= 126)
+    return cleaned[:_JWT_USERNAME_MAX_LEN]
+
+
 def _extract_username_from_jwt(auth_header: str) -> str:
     """Extract the username from a Bearer JWT without verifying it.
 
     This is only used for logging context — actual auth verification
     happens in the dependency layer. We decode the payload segment
-    (base64url) to read the ``username`` claim. Returns empty string
-    on any failure.
+    (base64url) to read the ``username`` claim, then sanitize it so a
+    hostile token cannot inject newlines or escape sequences into logs.
+    Returns empty string on any failure.
     """
     import base64
 
@@ -263,6 +282,6 @@ def _extract_username_from_jwt(auth_header: str) -> str:
         payload_b64 = parts[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        return payload.get("username", "")
+        return _sanitize_log_username(payload.get("username", ""))
     except Exception:
         return ""

--- a/server/src/decision_hub/scripts/crawler/processing.py
+++ b/server/src/decision_hub/scripts/crawler/processing.py
@@ -539,7 +539,11 @@ def _finalize_skill(
     generate_and_store_skill_embedding(conn, prep.skill_id, prep.name, org.slug, category, prep.description, settings)
 
     s3_key = build_s3_key(org.slug, prep.name, prep.version)
-    upload_skill_zip(s3_client, settings.s3_bucket, s3_key, prep.zip_data)
+
+    # Insert the version row FIRST so a UniqueViolation aborts before we
+    # write anything to S3. The caller commits after this function returns;
+    # if the S3 upload below raises we skip the commit and the transaction
+    # rolls back — leaving neither a DB row nor an orphaned S3 object.
     try:
         version_record = insert_version(
             conn,
@@ -578,5 +582,9 @@ def _finalize_skill(
         from decision_hub.infra.database import upsert_skill_tracker
 
         upsert_skill_tracker(conn, bot_user_id, org.slug, source_repo_url)
+
+    # S3 upload is the last side effect. If it raises, the caller's
+    # `conn.commit()` never runs and all rows above roll back.
+    upload_skill_zip(s3_client, settings.s3_bucket, s3_key, prep.zip_data)
 
     return "published"

--- a/server/tests/test_api/test_logging.py
+++ b/server/tests/test_api/test_logging.py
@@ -181,3 +181,42 @@ class TestExtractUsernameFromJwt:
         token = f"{header}.{payload}.{sig}"
         result = _extract_username_from_jwt(f"Bearer {token}")
         assert result == ""
+
+    def _make_token_with_username(self, username: str) -> str:
+        """Build a JWT-shaped string with an arbitrary username claim payload."""
+        import base64
+
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+        payload_json = json.dumps({"username": username}).encode()
+        payload = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode()
+        return f"{header}.{payload}.fakesig"
+
+    def test_strips_newlines_from_username(self):
+        """A hostile JWT with newlines in the username claim must not be able
+        to inject fake log lines into the request-context log record."""
+        token = self._make_token_with_username("alice\nFAKE-LOG-LINE")
+        assert _extract_username_from_jwt(f"Bearer {token}") == "aliceFAKE-LOG-LINE"
+
+    def test_strips_ansi_control_chars_from_username(self):
+        """ANSI escapes and other control chars in the JWT username must be
+        stripped so terminal-tailed logs aren't recolored / cursor-moved."""
+        token = self._make_token_with_username("bob\x1b[31mRED\x1b[0m\x07")
+        assert _extract_username_from_jwt(f"Bearer {token}") == "bob[31mRED[0m"
+
+    def test_caps_username_length(self):
+        """A pathologically-long username claim is truncated so log records
+        can't be inflated by an untrusted claim."""
+        token = self._make_token_with_username("x" * 500)
+        result = _extract_username_from_jwt(f"Bearer {token}")
+        assert len(result) == 64
+        assert result == "x" * 64
+
+    def test_non_string_claim_returns_empty(self):
+        """A JWT whose ``username`` claim is not a string (e.g. an int or an
+        object) must not blow up — it falls back to the empty string."""
+        import base64
+
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(b'{"username":12345}').rstrip(b"=").decode()
+        token = f"{header}.{payload}.fakesig"
+        assert _extract_username_from_jwt(f"Bearer {token}") == ""

--- a/server/tests/test_infra/test_gemini.py
+++ b/server/tests/test_infra/test_gemini.py
@@ -17,6 +17,8 @@ from decision_hub.infra.gemini import (
     analyze_credential_entropy,
     classify_skill,
     create_gemini_client,
+    review_code_body_safety,
+    review_prompt_body_safety,
 )
 
 _DEFAULT_MODEL = get_default_gemini_model()
@@ -379,3 +381,79 @@ class TestAnalyzeCredentialEntropyLineAttribution:
 
         assert len(results) == 1
         assert results[0]["line"] == entropy_hits[0]["line"]
+
+
+class TestHolisticBodyReview:
+    """The two ``review_*_body_safety`` functions delegate to a single
+    ``_run_body_review`` helper. These tests lock in its fail-closed
+    behavior via the two public entry points.
+    """
+
+    @respx.mock
+    def test_code_review_valid_response(self, gemini_client: dict) -> None:
+        respx.post(_GEMINI_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {"content": {"parts": [{"text": json.dumps({"dangerous": False, "reason": "clean"})}]}}
+                    ]
+                },
+            )
+        )
+        result = review_code_body_safety(gemini_client, [("app.py", "print('hi')")], "test", "desc", _DEFAULT_MODEL)
+        assert result == {"dangerous": False, "reason": "clean"}
+
+    @respx.mock
+    def test_prompt_review_valid_response(self, gemini_client: dict) -> None:
+        respx.post(_GEMINI_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {"content": {"parts": [{"text": json.dumps({"dangerous": True, "reason": "injection"})}]}}
+                    ]
+                },
+            )
+        )
+        result = review_prompt_body_safety(gemini_client, "some body", "test", "desc", _DEFAULT_MODEL)
+        assert result == {"dangerous": True, "reason": "injection"}
+
+    @respx.mock
+    def test_fail_closed_on_unparseable_json_after_retry(self, gemini_client: dict) -> None:
+        """Two malformed responses in a row → fail-closed to dangerous."""
+        respx.post(_GEMINI_URL).mock(
+            side_effect=[
+                httpx.Response(200, json={"candidates": [{"content": {"parts": [{"text": "not json"}]}}]}),
+                httpx.Response(200, json={"candidates": [{"content": {"parts": [{"text": "still not json"}]}}]}),
+            ]
+        )
+        result = review_code_body_safety(gemini_client, [("a.py", "x=1")], "test", "desc", _DEFAULT_MODEL)
+        assert result == {"dangerous": True, "reason": "Review failed (fail-closed)"}
+
+    @respx.mock
+    def test_fail_closed_on_empty_text_after_retry(self, gemini_client: dict) -> None:
+        """Two empty-text responses → fail-closed with the no-response reason."""
+        empty = httpx.Response(200, json={"candidates": [{"content": {"parts": [{"text": ""}]}}]})
+        respx.post(_GEMINI_URL).mock(side_effect=[empty, empty])
+        result = review_prompt_body_safety(gemini_client, "body", "test", "desc", _DEFAULT_MODEL)
+        assert result == {"dangerous": True, "reason": "LLM returned no response (fail-closed)"}
+
+    @respx.mock
+    def test_retries_once_then_returns_on_second_success(self, gemini_client: dict) -> None:
+        """One bad response, one good response → returns the good one."""
+        respx.post(_GEMINI_URL).mock(
+            side_effect=[
+                httpx.Response(200, json={"candidates": [{"content": {"parts": [{"text": "bad"}]}}]}),
+                httpx.Response(
+                    200,
+                    json={
+                        "candidates": [
+                            {"content": {"parts": [{"text": json.dumps({"dangerous": False, "reason": "ok"})}]}}
+                        ]
+                    },
+                ),
+            ]
+        )
+        result = review_prompt_body_safety(gemini_client, "body", "test", "desc", _DEFAULT_MODEL)
+        assert result == {"dangerous": False, "reason": "ok"}

--- a/server/tests/test_scripts/test_crawler_processing.py
+++ b/server/tests/test_scripts/test_crawler_processing.py
@@ -334,6 +334,72 @@ class TestPublishOneSkillReturnsStatus:
         assert status == "failed"
 
 
+class TestPublishOneSkillOrdering:
+    """Regression: DB write happens before S3 upload so a version race
+    can't leave an orphaned zip in S3.
+    """
+
+    def _setup_publish_ready(self, mock_skill_deps):
+        skill_mock = MagicMock()
+        skill_mock.id = uuid4()
+        skill_mock.source_repo_url = None
+        mock_skill_deps["find_skill"].return_value = skill_mock
+        mock_skill_deps["resolve_latest_version"].return_value = None
+        mock_skill_deps["find_version"].return_value = None
+
+        report = MagicMock()
+        report.passed = True
+        report.grade = "A"
+        report.gauntlet_summary = "All checks passed"
+        mock_skill_deps["run_gauntlet_pipeline"].return_value = (report, {}, "reasoning")
+        mock_skill_deps["classify_skill_category"].return_value = "devops"
+
+    def test_s3_upload_skipped_on_version_race(self, mock_skill_deps, tmp_path):
+        """insert_version raising IntegrityError must NOT trigger upload_skill_zip.
+
+        Previously the crawler uploaded the zip first and then inserted the row;
+        a concurrent tracker/crawler winning the version race left the zip
+        orphaned in S3 forever.
+        """
+        from decision_hub.domain.publish_pipeline import VersionConflictError
+
+        self._setup_publish_ready(mock_skill_deps)
+        mock_skill_deps["insert_version"].side_effect = sqlalchemy.exc.IntegrityError(
+            "INSERT ...", {}, Exception("duplicate key")
+        )
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Test Skill\nA test skill")
+
+        with pytest.raises(VersionConflictError):
+            _publish_one_skill(_make_engine_mock(), MagicMock(), MagicMock(), make_org(), skill_dir)
+
+        assert mock_skill_deps["upload_skill_zip"].call_count == 0
+
+    def test_insert_version_called_before_s3_upload(self, mock_skill_deps, tmp_path):
+        """Confirm the ordering: DB insert first, then S3 upload."""
+        self._setup_publish_ready(mock_skill_deps)
+        mock_skill_deps["insert_version"].return_value = MagicMock(id=uuid4())
+
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Test Skill\nA test skill")
+
+        # Shared parent mock records call order across both children.
+        call_order = MagicMock()
+        call_order.attach_mock(mock_skill_deps["insert_version"], "insert_version")
+        call_order.attach_mock(mock_skill_deps["upload_skill_zip"], "upload_skill_zip")
+
+        status = _publish_one_skill(_make_engine_mock(), MagicMock(), MagicMock(), make_org(), skill_dir)
+        assert status == "published"
+
+        names = [call[0] for call in call_order.mock_calls]
+        assert "insert_version" in names
+        assert "upload_skill_zip" in names
+        assert names.index("insert_version") < names.index("upload_skill_zip")
+
+
 # ---------------------------------------------------------------------------
 # Parallel processing result collection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Three focused, self-contained fixes surfaced by a fresh deep-review pass over the server. Each ships with a regression test; nothing here changes user-visible behaviour on the healthy path. All 944 server tests + ruff + mypy stay green.

### 1. `crawler/processing.py::_finalize_skill` — orphaned S3 zip on version race (`correctness`)

`_finalize_skill` previously uploaded the zip to S3 first and then called `insert_version`. If a concurrent tracker or crawler container won the version race, `insert_version` raised `IntegrityError`, `VersionConflictError` propagated, and the zip stayed in S3 forever with no DB row pointing at it.

The `execute_publish` path in `publish_pipeline.py` already does the safe ordering (DB row first, S3 last, DB rollback on S3 failure) — the crawler now mirrors it. If S3 upload itself fails, the caller's `conn.commit()` is skipped and the whole transaction rolls back, so neither a stray DB row nor a stray S3 blob is possible.

### 2. `logging._extract_username_from_jwt` — log injection via unverified JWT claim (`security`)

The username claim from the incoming `Authorization: Bearer <jwt>` is read *without verification* (just so request-context log lines can name the caller — real auth happens later in the dependency layer). A hostile or malformed token could carry `\n`, ANSI escapes, or a multi-KB payload that would:

- inject fake log lines (`alice\n2026-01-01 INFO [FAKE ADMIN] "…"`),
- recolor / cursor-move a terminal tailing the JSON logs, or
- bloat every request record with a huge string.

Fix: sanitize the claim to printable ASCII (32–126) and cap at 64 chars before it ever reaches the log context.

### 3. `gemini.review_code_body_safety` / `review_prompt_body_safety` — DRY the retry+parse loop (`code-health`)

Both holistic-review functions had the exact same ~30-line retry / parse / `BodyReviewResult.model_validate` / fail-closed loop copy-pasted. Extracted into a single private `_run_body_review` helper; each caller now just builds its prompt and delegates. Net −60 lines, identical externally-observable behaviour (same fail-closed reasons, same retry cadence).

## Why

No linked issue — findings came from a scheduled review pass. Priors from earlier review PRs (#429–#438) covered rate-limiter, LIKE-escaping, zip hardening, config file perms, etc., so this batch targets what those didn't reach and stays small enough for a single reviewer pass.

## How to test

```bash
uvx ruff@0.15.3 check . && uvx ruff@0.15.3 format --check .   # clean
uvx mypy client/src/ server/src/ shared/src/                    # 88 files, no issues
uv run --package decision-hub-server --extra dev pytest server/tests/ -q -m "not slow" --no-cov   # 944 passed
```

New/updated tests locking each fix in place:

- `server/tests/test_scripts/test_crawler_processing.py::TestPublishOneSkillOrdering` — asserts `upload_skill_zip` is NOT called when `insert_version` raises, and that `insert_version` is called before `upload_skill_zip` on the healthy path.
- `server/tests/test_api/test_logging.py::TestExtractUsernameFromJwt` — 4 new cases: newline stripping, ANSI/control stripping, length cap, non-string claim → empty.
- `server/tests/test_infra/test_gemini.py::TestHolisticBodyReview` — 5 cases across both review entry points: valid response, retry-then-succeed, and both fail-closed paths (unparseable JSON, empty text after retry).

Manual sanity: publishing an unchanged skill continues to short-circuit as `skipped`; a duplicate-version race still surfaces as `VersionConflictError` and the container reports `"skipped"` (unchanged) — just without leaving an S3 object behind.

## Checklist
- [x] Tests pass (`make test`) — 944 server pass, ruff + mypy clean
- [x] No breaking API changes — external shapes unchanged
- [x] Database migration included (if schema changed) — n/a, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuvfB9JYsXZhLmBpyDXH9L)_