### PR TITLE
fix: correctness bugs and CLAUDE.md rule compliance across server/client

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -14,12 +14,27 @@ CONFIG_DIR = Path.home() / ".dhub"
 _DEFAULT_API_URLS: dict[str, str] = {
     "dev": "https://pymc-labs--api-dev.modal.run",
     "prod": "https://pymc-labs--api.modal.run",
+    "local": "http://localhost:8000",
 }
+_VALID_ENVS: frozenset[str] = frozenset(_DEFAULT_API_URLS)
 
 
 def get_env() -> str:
-    """Return current environment name from DHUB_ENV (default: 'prod')."""
-    return os.environ.get("DHUB_ENV", "prod")
+    """Return current environment name from DHUB_ENV (default: 'prod').
+
+    Rejects unknown values (e.g. a typo like ``DHUB_ENV=devv``) so a
+    misspelling never silently degrades to production traffic — a
+    surprisingly costly failure mode discovered in review.
+    """
+    env = os.environ.get("DHUB_ENV", "prod")
+    if env not in _VALID_ENVS:
+        import typer
+        from rich.console import Console
+
+        valid = ", ".join(sorted(_VALID_ENVS))
+        Console(stderr=True).print(f"[red]Error: DHUB_ENV={env!r} is not recognized. Valid values: {valid}.[/]")
+        raise typer.Exit(1)
+    return env
 
 
 def default_api_url(env: str | None = None) -> str:

--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -14,6 +14,9 @@ from rich.panel import Panel
 from rich.table import Table
 
 console = Console()
+# Separate stderr console for informational chatter that must NOT contaminate
+# stdout when the CLI is invoked with `--output json` (callers parse stdout).
+err_console = Console(stderr=True)
 
 
 def _publish_skill_directory(
@@ -496,23 +499,26 @@ def _auto_detect_org(api_url: str, token: str) -> str:
     1. DHUB_DEFAULT_ORG env var or config default_org
     2. Cached orgs from config (if exactly one)
     3. Falls back to API call (for old configs without cached orgs)
+
+    All informational chatter goes to stderr so that ``dhub publish --output
+    json`` produces clean, parseable JSON on stdout.
     """
     from dhub.cli.config import build_headers, get_default_org, load_config, raise_for_status
 
     # 1. Check default org (env var takes priority over config)
     default = get_default_org()
     if default:
-        console.print(f"Using default namespace: [cyan]{default}[/]")
+        err_console.print(f"Using default namespace: [cyan]{default}[/]")
         return default
 
     # 2. Check cached orgs from config
     config = load_config()
     if config.orgs:
         if len(config.orgs) == 1:
-            console.print(f"Auto-detected namespace: [cyan]{config.orgs[0]}[/]")
+            err_console.print(f"Auto-detected namespace: [cyan]{config.orgs[0]}[/]")
             return config.orgs[0]
         slugs = ", ".join(config.orgs)
-        console.print(
+        err_console.print(
             f"[red]Error: You have multiple namespaces ({slugs}). "
             f"Run 'dhub config default-org' to set a default, "
             f"or set DHUB_DEFAULT_ORG, "
@@ -530,12 +536,12 @@ def _auto_detect_org(api_url: str, token: str) -> str:
         orgs = resp.json()
 
     if len(orgs) == 0:
-        console.print("[red]Error: No namespaces available. Run 'dhub login' to refresh your org memberships.[/]")
+        err_console.print("[red]Error: No namespaces available. Run 'dhub login' to refresh your org memberships.[/]")
         raise typer.Exit(1)
 
     if len(orgs) > 1:
         slugs = ", ".join(o["slug"] for o in orgs)
-        console.print(
+        err_console.print(
             f"[red]Error: You have multiple namespaces ({slugs}). "
             f"Run 'dhub config default-org' to set a default, "
             f"or set DHUB_DEFAULT_ORG, "
@@ -544,7 +550,7 @@ def _auto_detect_org(api_url: str, token: str) -> str:
         raise typer.Exit(1)
 
     org_slug = orgs[0]["slug"]
-    console.print(f"Auto-detected namespace: [cyan]{org_slug}[/]")
+    err_console.print(f"Auto-detected namespace: [cyan]{org_slug}[/]")
     return org_slug
 
 
@@ -1117,6 +1123,9 @@ def _install_from_repo(
     console.print(f"\n[green]Installed {succeeded}/{len(skills)} skills from {repo_ref}[/]")
     if failed:
         console.print(f"[yellow]{failed} skills failed to install.[/]")
+        # Non-zero exit so scripts that pipe `dhub install --repo` can detect
+        # partial failure. Publish's per-skill loop already does this.
+        raise typer.Exit(1)
 
 
 def install_command(
@@ -1633,6 +1642,9 @@ def _update_all_skills() -> None:
                 failed += 1
 
     console.print(f"\nDone: [green]{updated} updated[/], {up_to_date} up to date, [red]{failed} failed[/]")
+    if failed:
+        # Non-zero exit so `dhub update` in CI / cron flags partial failure.
+        raise typer.Exit(1)
 
 
 def visibility_command(

--- a/client/src/dhub/core/git_repo.py
+++ b/client/src/dhub/core/git_repo.py
@@ -50,6 +50,32 @@ def _looks_like_sha(ref: str) -> bool:
     return bool(_SHA_PATTERN.match(ref))
 
 
+# Default wall-clock cap for a single git operation. Prevents a network-
+# unreachable server or a giant repo from hanging the CLI indefinitely (per
+# CLAUDE.md "Sanitize subprocess credentials" / no-hang rules).
+_CLONE_TIMEOUT_SECONDS = 120
+
+
+def _run_git(cmd: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run a git subprocess with a wall-clock cap.
+
+    Wraps ``TimeoutExpired`` in a ``RuntimeError`` naming the git subcommand
+    (never the full argv) so any credential embedded in a URL argument is
+    never re-emitted in error messages.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_CLONE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        subcmd = cmd[1] if len(cmd) > 1 else "git"
+        raise RuntimeError(f"git {subcmd} timed out after {_CLONE_TIMEOUT_SECONDS}s") from exc
+
+
 def clone_repo(repo_url: str, ref: str | None = None) -> Path:
     """Clone a git repository into a temporary directory.
 
@@ -61,37 +87,32 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Path:
         Path to the cloned repository root.
 
     Raises:
-        RuntimeError: If the clone or checkout fails.
+        RuntimeError: If the clone or checkout fails or exceeds the wall-clock cap.
     """
     tmp_dir = Path(tempfile.mkdtemp(prefix="dhub-repo-"))
     repo_path = tmp_dir / "repo"
 
-    if ref and _looks_like_sha(ref):
-        # Commit SHAs don't work with --depth 1 --branch; do a full
-        # clone then checkout the specific commit.
-        cmd = ["git", "clone", repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
-        checkout = subprocess.run(
-            ["git", "checkout", ref],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
-        if checkout.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
-    else:
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd += ["--branch", ref]
-        cmd += [repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    try:
+        if ref and _looks_like_sha(ref):
+            # Commit SHAs don't work with --depth 1 --branch; do a full
+            # clone then checkout the specific commit.
+            result = _run_git(["git", "clone", repo_url, str(repo_path)])
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+            checkout = _run_git(["git", "checkout", ref], cwd=str(repo_path))
+            if checkout.returncode != 0:
+                raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
+        else:
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd += ["--branch", ref]
+            cmd += [repo_url, str(repo_path)]
+            result = _run_git(cmd)
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    except Exception:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return repo_path
 

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -169,3 +169,29 @@ class TestGetDefaultOrg:
         result = get_default_org()
 
         assert result is None
+
+
+class TestGetEnvWhitelist:
+    """get_env rejects unknown DHUB_ENV values instead of silently degrading."""
+
+    def test_valid_env_returned(self, monkeypatch):
+        from dhub.cli.config import get_env
+
+        for value in ("dev", "prod", "local"):
+            monkeypatch.setenv("DHUB_ENV", value)
+            assert get_env() == value
+
+    def test_default_when_unset(self, monkeypatch):
+        from dhub.cli.config import get_env
+
+        monkeypatch.delenv("DHUB_ENV", raising=False)
+        assert get_env() == "prod"
+
+    def test_unknown_env_exits(self, monkeypatch):
+        """A typo like DHUB_ENV=devv must NOT silently degrade to prod traffic."""
+        from dhub.cli.config import get_env
+
+        monkeypatch.setenv("DHUB_ENV", "devv")
+
+        with pytest.raises(click.exceptions.Exit):
+            get_env()

--- a/client/tests/test_cli/test_install_repo.py
+++ b/client/tests/test_cli/test_install_repo.py
@@ -235,7 +235,9 @@ class TestInstallRepo:
 
         result = runner.invoke(app, ["install", "--repo", "acme/repo"])
 
-        assert result.exit_code == 0
+        # Exit 1 on any per-skill failure so scripts can detect partial failure,
+        # while still processing every other skill in the repo.
+        assert result.exit_code == 1
         assert "Installed 1/2" in result.output
         assert "1 skills failed" in result.output
 
@@ -274,6 +276,8 @@ class TestInstallRepo:
 
         result = runner.invoke(app, ["install", "--repo", "acme/repo"])
 
-        assert result.exit_code == 0
+        # A rate-limited skill is a partial failure — exit 1 so CI/cron notices,
+        # but the other skills still install successfully.
+        assert result.exit_code == 1
         assert "Installed 1/2" in result.output
         assert "rate limited" in result.output

--- a/client/tests/test_cli/test_registry_cli.py
+++ b/client/tests/test_cli/test_registry_cli.py
@@ -1362,6 +1362,24 @@ class TestEvalReportJsonOutput:
 # ---------------------------------------------------------------------------
 
 
+class TestAutoDetectOrgStdout:
+    """`_auto_detect_org` must never contaminate stdout — publish --output json
+    parses stdout, so an informational line about the auto-detected namespace
+    would break machine consumers."""
+
+    @patch("dhub.cli.config.get_default_org", return_value="myorg")
+    def test_prints_to_stderr_not_stdout(self, _mock_org, capsys) -> None:
+        """The 'Using default namespace: …' line lands on stderr."""
+        from dhub.cli.registry import _auto_detect_org
+
+        result = _auto_detect_org("http://test:8000", "unused-token")
+
+        assert result == "myorg"
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "myorg" in captured.err
+
+
 class TestPublishJsonOutput:
     @respx.mock
     @patch("dhub.cli.registry._auto_detect_org", return_value="myorg")

--- a/client/tests/test_cli/test_update_cli.py
+++ b/client/tests/test_cli/test_update_cli.py
@@ -313,6 +313,40 @@ class TestUpdateCommand:
         assert resolve_route.called
         assert "allow_risky=true" in str(resolve_route.calls[0].request.url)
 
+    @respx.mock
+    @patch("dhub.core.install.get_dhub_skill_path")
+    @patch(
+        "dhub.core.install.list_installed_skills",
+        return_value=[("myorg", "skill-a"), ("myorg", "skill-b")],
+    )
+    @patch("dhub.core.install.get_installed_version", return_value=InstalledVersion("1.0.0"))
+    @patch("dhub.cli.config.get_optional_token", return_value="test-token")
+    @patch("dhub.cli.config.get_api_url", return_value="http://test:8000")
+    def test_update_all_exits_nonzero_on_failure(
+        self,
+        _mock_url,
+        _mock_token,
+        _mock_installed_ver,
+        _mock_list,
+        mock_skill_path,
+        tmp_path: Path,
+    ) -> None:
+        """--all exits 1 when any per-skill update fails so CI/cron flags it."""
+        mock_skill_path.side_effect = lambda org, name: tmp_path / org / name
+
+        # Both /latest-version calls return 5xx errors — every skill fails.
+        respx.get("http://test:8000/v1/skills/myorg/skill-a/latest-version").mock(
+            return_value=httpx.Response(500, text="boom")
+        )
+        respx.get("http://test:8000/v1/skills/myorg/skill-b/latest-version").mock(
+            return_value=httpx.Response(500, text="boom")
+        )
+
+        result = runner.invoke(app, ["update", "--all"])
+
+        assert result.exit_code == 1
+        assert "2 failed" in result.output
+
 
 class TestVersionTracking:
     def test_save_and_get_installed_version(self, tmp_path: Path) -> None:

--- a/client/tests/test_core/test_git_repo.py
+++ b/client/tests/test_core/test_git_repo.py
@@ -1,8 +1,12 @@
 """Tests for dhub.core.git_repo -- clone and skill discovery."""
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from dhub.core.git_repo import discover_skills
+import pytest
+
+from dhub.core.git_repo import clone_repo, discover_skills
 
 
 class TestDiscoverSkills:
@@ -73,3 +77,42 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         names = [p.name for p in result]
         assert names == sorted(names)
+
+
+class TestCloneRepoTimeout:
+    """clone_repo wraps subprocess calls with a wall-clock cap."""
+
+    def test_timeout_raises_sanitized_runtime_error(self) -> None:
+        """subprocess.TimeoutExpired never leaks to the caller; a RuntimeError
+        naming the subcommand is raised instead. The URL — which may embed a
+        token — is not echoed in the message.
+        """
+        # Simulate a hung `git clone` — the URL argument holds a fake token
+        # to confirm it's never surfaced in the raised message.
+        secret_url = "https://x-access-token:sekrittoken@github.com/o/r"
+        with (
+            patch(
+                "dhub.core.git_repo.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd=["git", "clone", secret_url], timeout=120),
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            clone_repo(secret_url)
+
+        message = str(exc_info.value)
+        assert "timed out" in message
+        assert "clone" in message
+        # The token embedded in the URL must not appear in the error message.
+        assert "sekrittoken" not in message
+        assert secret_url not in message
+
+    def test_timeout_wraps_git_command(self) -> None:
+        """Even a non-clone subcommand (e.g. `git checkout`) reports as a timeout."""
+        with (
+            patch(
+                "dhub.core.git_repo.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd=["git", "clone"], timeout=120),
+            ),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            clone_repo("https://github.com/o/r")

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -1098,22 +1098,33 @@ def _run_to_response(run) -> EvalRunResponse:
 
 
 def _check_zombie(conn: Connection, run) -> str:
-    """Check if a running eval run has a stale heartbeat (zombie).
+    """Check if an in-flight eval run has gone stale (zombie).
 
-    If heartbeat_at is older than _STALE_HEARTBEAT_SECONDS, marks the
-    run as failed and returns "failed". Otherwise returns run.status.
+    Compares the newer of ``heartbeat_at`` and ``created_at`` against
+    ``_STALE_HEARTBEAT_SECONDS`` — falling back to ``created_at`` covers the
+    case where the Modal worker crashed (OOM, provisioning failure) before it
+    ever wrote its first heartbeat, which would otherwise leave the row
+    pending/provisioning forever.
+
+    Marks the run as failed and returns "failed" on staleness; otherwise
+    returns the existing ``run.status``.
     """
-    if run.status not in ("running", "judging", "provisioning"):
+    if run.status not in ("pending", "provisioning", "running", "judging"):
         return run.status
-    if run.heartbeat_at is None:
+    # Fall back to created_at when heartbeat_at is missing so pre-heartbeat
+    # crashes (e.g. Modal worker OOMs before run_streaming_eval writes the
+    # first heartbeat) are still detected instead of hanging indefinitely.
+    reference = run.heartbeat_at or run.created_at
+    if reference is None:
         return run.status
-    elapsed = (datetime.now(UTC) - run.heartbeat_at).total_seconds()
+    elapsed = (datetime.now(UTC) - reference).total_seconds()
     if elapsed > _STALE_HEARTBEAT_SECONDS:
+        reason = "Stale heartbeat" if run.heartbeat_at else "No heartbeat since creation"
         update_eval_run_status(
             conn,
             run.id,
             status="failed",
-            error_message=f"Stale heartbeat ({int(elapsed)}s). Worker may have crashed.",
+            error_message=f"{reason} ({int(elapsed)}s). Worker may have crashed.",
             completed_at=datetime.now(UTC),
         )
         return "failed"

--- a/server/src/decision_hub/api/seo_routes.py
+++ b/server/src/decision_hub/api/seo_routes.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_cache, get_connection, get_settings
 from decision_hub.infra.cache import TTLCache
-from decision_hub.infra.database import organizations_table, skills_table
+from decision_hub.infra.database import _exclude_removed_or_archived, organizations_table, skills_table
 from decision_hub.settings import Settings
 
 router = APIRouter(tags=["seo"])
@@ -40,7 +40,8 @@ def sitemap_xml(
         (f"{_BASE_URL}/how-it-works", today, "monthly"),
     ]
 
-    # Public skills
+    # Public skills — excluding source-repo-removed and GitHub-archived, so
+    # search engines don't index detail pages that 404 or serve stale content.
     stmt = (
         sa.select(
             organizations_table.c.slug.label("org_slug"),
@@ -59,11 +60,12 @@ def sitemap_xml(
         )
         .order_by(organizations_table.c.slug, skills_table.c.name)
     )
+    stmt = _exclude_removed_or_archived(stmt)
     for row in conn.execute(stmt):
         lastmod = row.latest_published_at.strftime("%Y-%m-%d") if row.latest_published_at else today
         urls.append((f"{_BASE_URL}/skills/{row.org_slug}/{row.skill_name}", lastmod, "weekly"))
 
-    # Public orgs (only those with at least one published skill)
+    # Public orgs (only those with at least one non-removed published skill)
     org_stmt = (
         sa.select(sa.distinct(organizations_table.c.slug))
         .select_from(
@@ -78,6 +80,7 @@ def sitemap_xml(
         )
         .order_by(organizations_table.c.slug)
     )
+    org_stmt = _exclude_removed_or_archived(org_stmt)
     for row in conn.execute(org_stmt):
         urls.append((f"{_BASE_URL}/orgs/{row[0]}", today, "weekly"))
 

--- a/server/src/decision_hub/domain/tracker_service.py
+++ b/server/src/decision_hub/domain/tracker_service.py
@@ -613,30 +613,33 @@ def _persist_orphaned_tracker_errors(
     *,
     error_msg: str,
 ) -> None:
-    """Update last_error for trackers whose Modal containers died before writing a result."""
-    from decision_hub.infra.database import update_skill_tracker
+    """Update last_error/last_checked_at for trackers whose Modal containers died.
+
+    Uses two bulk UPDATEs (one to set ``last_error``, one to bump
+    ``last_checked_at``) instead of N per-tracker updates so the cron doesn't
+    stall when the orphan set is large.
+    """
+    from decision_hub.infra.database import batch_set_tracker_errors, batch_set_tracker_last_checked
 
     if not orphaned_ids:
         return
 
-    now = datetime.now(UTC)
     tracker_by_id = {t.id: t for t, _ in changed_trackers}
+    for tid in orphaned_ids:
+        tracker = tracker_by_id.get(tid)
+        logger.warning(
+            "tracker_id={} repo={} status=orphaned_failure error={}",
+            tid,
+            tracker.repo_url if tracker else "?",
+            error_msg,
+        )
+
+    id_list = list(orphaned_ids)
+    now = datetime.now(UTC)
     try:
         with engine.connect() as conn:
-            for tid in orphaned_ids:
-                tracker = tracker_by_id.get(tid)
-                logger.warning(
-                    "tracker_id={} repo={} status=orphaned_failure error={}",
-                    tid,
-                    tracker.repo_url if tracker else "?",
-                    error_msg,
-                )
-                update_skill_tracker(
-                    conn,
-                    tid,
-                    last_checked_at=now,
-                    last_error=error_msg,
-                )
+            batch_set_tracker_errors(conn, id_list, error_msg)
+            batch_set_tracker_last_checked(conn, id_list, now)
             conn.commit()
     except Exception:
         logger.opt(exception=True).error("Failed to persist orphaned tracker errors")

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -1775,6 +1775,35 @@ def _build_skills_filters(
     return base
 
 
+def _tracker_exists_subquery():
+    """Correlated EXISTS subquery: does an enabled tracker cover this skill's repo?
+
+    A tracker's ``repo_url`` covers a skill when it either equals the skill's
+    ``source_repo_url`` (top-level skill) or is a strict prefix of it (skill
+    lives in a subdirectory of the tracked repo — e.g. tracker
+    ``https://github.com/org/repo`` covers skill
+    ``https://github.com/org/repo/skills/foo``).
+
+    Emits a single boolean via EXISTS(...) so it can be selected as a scalar
+    or dropped into a WHERE clause.
+    """
+    prefix_match = skills_table.c.source_repo_url.like(skill_trackers_table.c.repo_url + sa.literal("/%"))
+    return (
+        sa.select(sa.literal(True))
+        .where(
+            sa.and_(
+                sa.or_(
+                    skill_trackers_table.c.repo_url == skills_table.c.source_repo_url,
+                    prefix_match,
+                ),
+                skill_trackers_table.c.enabled.is_(True),
+            )
+        )
+        .correlate(skills_table)
+        .exists()
+    )
+
+
 def fetch_all_skills_for_index(
     conn: Connection,
     *,
@@ -1806,18 +1835,7 @@ def fetch_all_skills_for_index(
     and sorting by updated/name/downloads.
     """
     # Subquery: does an enabled tracker exist for this skill's source repo?
-    tracker_exists = (
-        sa.select(sa.literal(True))
-        .where(
-            sa.and_(
-                skill_trackers_table.c.repo_url == skills_table.c.source_repo_url,
-                skill_trackers_table.c.enabled.is_(True),
-            )
-        )
-        .correlate(skills_table)
-        .exists()
-        .label("has_tracker")
-    )
+    tracker_exists = _tracker_exists_subquery().label("has_tracker")
 
     base = (
         sa.select(
@@ -1936,18 +1954,7 @@ def fetch_skills_by_repo(
     """
     normalized = _normalize_repo_url(repo_url)
 
-    tracker_exists = (
-        sa.select(sa.literal(True))
-        .where(
-            sa.and_(
-                skill_trackers_table.c.repo_url == skills_table.c.source_repo_url,
-                skill_trackers_table.c.enabled.is_(True),
-            )
-        )
-        .correlate(skills_table)
-        .exists()
-        .label("has_tracker")
-    )
+    tracker_exists = _tracker_exists_subquery().label("has_tracker")
 
     base = (
         sa.select(*_SKILL_SUMMARY_COLUMNS, tracker_exists)
@@ -2128,6 +2135,9 @@ def fetch_similar_skills(
         .order_by(sa.text("vec_dist ASC"))
         .limit(limit)
     )
+    # Don't suggest skills whose repo was removed or archived — the CLI can't
+    # download them and the detail page shows a dead banner.
+    vec_stmt = _exclude_removed_or_archived(vec_stmt)
     rows = conn.execute(vec_stmt).all()
     return [_row_to_skill_summary(r) for r in rows]
 
@@ -3032,6 +3042,22 @@ def batch_set_tracker_errors(conn: Connection, tracker_ids: list[UUID], error_me
         sa.update(skill_trackers_table)
         .where(skill_trackers_table.c.id.in_(tracker_ids))
         .values(last_error=error_message)
+    )
+    return conn.execute(stmt).rowcount
+
+
+def batch_set_tracker_last_checked(
+    conn: Connection,
+    tracker_ids: list[UUID],
+    last_checked_at: datetime,
+) -> int:
+    """Bump last_checked_at for multiple trackers in one UPDATE. Returns rowcount."""
+    if not tracker_ids:
+        return 0
+    stmt = (
+        sa.update(skill_trackers_table)
+        .where(skill_trackers_table.c.id.in_(tracker_ids))
+        .values(last_checked_at=last_checked_at)
     )
     return conn.execute(stmt).rowcount
 

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -171,6 +171,99 @@ class TestGetEvalRun:
 
         assert resp.status_code == 404
 
+    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_zombie_detection_uses_created_at_when_no_heartbeat(
+        self,
+        mock_find_run: MagicMock,
+        mock_update_status: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A pre-heartbeat crash (Modal OOM before first heartbeat) is detected.
+
+        Regression: previously ``_check_zombie`` returned early when
+        ``heartbeat_at`` was NULL, leaving the row pending/provisioning forever
+        if the worker died before writing its first heartbeat.
+        """
+        stale_created = datetime.now(UTC) - timedelta(seconds=400)
+        run = _make_eval_run(
+            status="provisioning",
+            heartbeat_at=None,
+            created_at=stale_created,
+        )
+        failed_run = _make_eval_run(
+            id=run.id,
+            status="failed",
+            error_message="No heartbeat since creation",
+            heartbeat_at=None,
+            created_at=stale_created,
+        )
+        mock_find_run.side_effect = [run, failed_run]
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "failed"
+        mock_update_status.assert_called_once()
+        assert "No heartbeat" in mock_update_status.call_args.kwargs.get("error_message", "")
+
+    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_zombie_detection_covers_pending_status(
+        self,
+        mock_find_run: MagicMock,
+        mock_update_status: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A stale ``pending`` run is now marked failed (was previously skipped)."""
+        stale_created = datetime.now(UTC) - timedelta(seconds=400)
+        run = _make_eval_run(
+            status="pending",
+            heartbeat_at=None,
+            created_at=stale_created,
+        )
+        failed_run = _make_eval_run(
+            id=run.id,
+            status="failed",
+            error_message="No heartbeat since creation",
+            heartbeat_at=None,
+            created_at=stale_created,
+        )
+        mock_find_run.side_effect = [run, failed_run]
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "failed"
+        mock_update_status.assert_called_once()
+
+    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_zombie_detection_uses_heartbeat_when_present(
+        self,
+        mock_find_run: MagicMock,
+        mock_update_status: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """When heartbeat_at exists, it takes precedence over created_at."""
+        recent_heartbeat = datetime.now(UTC) - timedelta(seconds=30)
+        old_created = datetime.now(UTC) - timedelta(hours=1)
+        run = _make_eval_run(
+            status="running",
+            heartbeat_at=recent_heartbeat,
+            created_at=old_created,
+        )
+        mock_find_run.return_value = run
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+        mock_update_status.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/eval-runs/{run_id}/logs — cursor-based event pagination

--- a/server/tests/test_domain/test_tracker_service.py
+++ b/server/tests/test_domain/test_tracker_service.py
@@ -630,9 +630,10 @@ class TestDispatchChangedTrackers:
         assert processed == 0
         assert failed == 1
 
-    @patch("decision_hub.infra.database.update_skill_tracker")
-    def test_persist_orphaned_tracker_errors(self, mock_update):
-        """When Modal containers die (timeout/OOM), last_error should be persisted."""
+    @patch("decision_hub.infra.database.batch_set_tracker_last_checked")
+    @patch("decision_hub.infra.database.batch_set_tracker_errors")
+    def test_persist_orphaned_tracker_errors(self, mock_set_errors, mock_set_checked):
+        """When Modal containers die (timeout/OOM), last_error should be persisted via batch UPDATEs."""
         tracker = self._make_tracker()
         changed = [(tracker, "new_sha")]
         mock_engine = MagicMock()
@@ -647,15 +648,46 @@ class TestDispatchChangedTrackers:
             error_msg="Modal container failed (timeout/OOM)",
         )
 
-        mock_update.assert_called_once()
-        call_kwargs = mock_update.call_args
-        assert call_kwargs[0][1] == tracker.id
-        assert "timeout" in call_kwargs[1]["last_error"]
-        assert call_kwargs[1]["last_checked_at"] is not None
+        mock_set_errors.assert_called_once()
+        errors_args = mock_set_errors.call_args
+        assert errors_args[0][1] == [tracker.id]
+        assert "timeout" in errors_args[0][2]
+
+        mock_set_checked.assert_called_once()
+        checked_args = mock_set_checked.call_args
+        assert checked_args[0][1] == [tracker.id]
+        assert checked_args[0][2] is not None
+
         mock_conn.commit.assert_called_once()
 
-    @patch("decision_hub.infra.database.update_skill_tracker")
-    def test_persist_orphaned_no_op_when_all_completed(self, mock_update):
+    @patch("decision_hub.infra.database.batch_set_tracker_last_checked")
+    @patch("decision_hub.infra.database.batch_set_tracker_errors")
+    def test_persist_orphaned_batches_all_ids_in_one_call(self, mock_set_errors, mock_set_checked):
+        """A large orphan set should be persisted in exactly two UPDATEs, not N."""
+        trackers = [self._make_tracker() for _ in range(50)]
+        changed = [(t, "sha") for t in trackers]
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        orphaned = {t.id for t in trackers}
+        _persist_orphaned_tracker_errors(
+            orphaned,
+            changed,
+            mock_engine,
+            error_msg="Modal container failed",
+        )
+
+        # Exactly one bulk UPDATE for last_error and one for last_checked_at.
+        assert mock_set_errors.call_count == 1
+        assert mock_set_checked.call_count == 1
+        assert set(mock_set_errors.call_args[0][1]) == orphaned
+        assert set(mock_set_checked.call_args[0][1]) == orphaned
+
+    @patch("decision_hub.infra.database.batch_set_tracker_last_checked")
+    @patch("decision_hub.infra.database.batch_set_tracker_errors")
+    def test_persist_orphaned_no_op_when_all_completed(self, mock_set_errors, mock_set_checked):
         """When all trackers completed, no DB update should happen."""
         mock_engine = MagicMock()
 
@@ -666,7 +698,8 @@ class TestDispatchChangedTrackers:
             error_msg="should not be written",
         )
 
-        mock_update.assert_not_called()
+        mock_set_errors.assert_not_called()
+        mock_set_checked.assert_not_called()
         mock_engine.connect.assert_not_called()
 
 


### PR DESCRIPTION
## What changed

Focused correctness pass distilled from a deep review of the codebase. Nine independently-verified real bugs and CLAUDE.md rule violations across the server and client, each covered by new or updated tests. Big structural refactors flagged by the review (splitting `database.py`, `registry.py`, `registry_routes.py`; unifying client/server zip/discover helpers; extracting the rate-limiter factory; frontend design-token migration) are intentionally deferred to keep this PR reviewable.

## Why

None of these bugs have an existing GitHub issue — they were surfaced by a full-repo review pass. The scope is limited to fixes small enough that each stands on its own; every larger structural change flagged by the review is called out at the bottom for follow-up PRs. Skipping the `Closes #` line since no umbrella issue exists yet.

## Server fixes

**1. `_check_zombie` — detect pre-heartbeat crashes and stale `pending` runs.** `server/src/decision_hub/api/registry_routes.py`
Previously returned immediately when `run.heartbeat_at IS NULL` and only checked `{running, judging, provisioning}`. A Modal worker that crashed before writing its first heartbeat (OOM, provisioning failure) left the run pinned at `status="pending"` forever. Fix: fall back to `created_at` when `heartbeat_at` is missing, and include `"pending"` in the checked status set. Emits a distinguishable "No heartbeat since creation" error message.
Tests: `test_zombie_detection_uses_created_at_when_no_heartbeat`, `test_zombie_detection_covers_pending_status`, `test_zombie_detection_uses_heartbeat_when_present`.

**2. `has_tracker` — match subdirectory skills against their repo-level tracker.** `server/src/decision_hub/infra/database.py`
The correlated EXISTS subquery used strict `repo_url == source_repo_url` equality. Trackers store `https://github.com/org/repo`; sub-skills store `.../repo/subdir/x`. Result: every skill in a multi-skill repo showed `is_auto_synced=false` in the UI. Extracted a shared `_tracker_exists_subquery()` that matches either equality or strict prefix (`repo_url + '/%'`); both call sites (`fetch_all_skills_for_index`, `fetch_skills_by_repo`) now share one definition.

**3. `sitemap_xml` — exclude removed/archived skills.** `server/src/decision_hub/api/seo_routes.py`
The sitemap listed public skills without applying `_exclude_removed_or_archived`, so Google indexed detail pages that either 404 or serve stale content. Now applied to both the skill URL enumeration and the org URL enumeration.

**4. `fetch_similar_skills` — same filter on the "similar skills" panel.** `server/src/decision_hub/infra/database.py`
The recommender was suggesting skills whose repo had gone away — the UI showed a dead banner and the CLI couldn't download them.

**5. `_persist_orphaned_tracker_errors` — bulk UPDATE instead of N per-tracker.** `server/src/decision_hub/domain/tracker_service.py`
When a Modal batch dispatch lost N tracker containers, the cron issued N sequential `update_skill_tracker` calls with the same error. Now uses `batch_set_tracker_errors` plus a new `batch_set_tracker_last_checked` helper — two bulk UPDATEs regardless of orphan count.
Tests: existing coverage patched to the new helpers; new `test_persist_orphaned_batches_all_ids_in_one_call` asserts a 50-tracker set is persisted in exactly two calls, not fifty.

## Client fixes

**6. `_install_from_repo` / `_update_all_skills` — non-zero exit on partial failure.** `client/src/dhub/cli/registry.py`
Both commands counted failures, printed them, and exited 0 — so CI/cron scripts couldn't detect partial failure. Both now `raise typer.Exit(1)` when at least one item failed, while still processing every other item. Existing "continues on failure" tests updated to expect exit 1; new positive test for `dhub update --all` added.

**7. `clone_repo` — 120s wall-clock cap with credential-safe errors.** `client/src/dhub/core/git_repo.py`
Neither `git clone` nor `git checkout` had a `timeout=` — an unreachable server hung the CLI indefinitely (a CLAUDE.md rule that `server/src/decision_hub/domain/repo_utils.py` already respects). Wrapped both in a `_run_git` helper that applies `timeout=120` and converts `TimeoutExpired` into a `RuntimeError` naming only the subcommand — the full argv (which can contain tokenized URLs) is never re-emitted.
Tests: `test_timeout_raises_sanitized_runtime_error` explicitly asserts a URL-embedded token never appears in the raised message; `test_timeout_wraps_git_command`.

**8. `get_env()` — whitelist known environments.** `client/src/dhub/cli/config.py`
`os.environ.get("DHUB_ENV", "prod")` accepted any value verbatim, and `default_api_url` fell through to prod for unknowns. A typo like `DHUB_ENV=devv` silently sent test traffic to production. Now validates against `{"dev", "prod", "local"}` (also adds `"local"` to the URL map, which was missing) and errors out with a clear message on anything else.
Test: `TestGetEnvWhitelist` (valid values pass; typo exits).

**9. `_auto_detect_org` — informational lines to stderr.** `client/src/dhub/cli/registry.py`
Every call printed "Using default namespace: …" / "Auto-detected namespace: …" to stdout via the module-level Rich console, so `dhub publish --output json` emitted broken hybrid Rich-text-plus-JSON on stdout. Now uses a dedicated `err_console = Console(stderr=True)` for those informational lines. Errors already went to stderr via `exit_error()`.
Test: `TestAutoDetectOrgStdout` asserts `capsys.readouterr().out == ""` and the namespace only appears on stderr.

## How to test

```bash
# Fast automated coverage:
make test-server              # 937 passed
make test-client              # 322 passed (5 pre-existing docx-integration
                              # length/count failures are unrelated — same
                              # failures reproduce on the base commit)
uv run ruff check server/src client/src client/tests server/src server/tests shared/
uvx mypy client/src/ server/src/ shared/src/

# Manual smoke tests (post-deploy):
DHUB_ENV=dev dhub publish --output json <skill-dir> | jq .   # confirms clean JSON on stdout
DHUB_ENV=devv dhub list                                        # confirms typo exits with clear error
```

## Deferred to follow-up PRs

Recorded here so nothing gets dropped between reviews. All flagged by the same review pass, each too large to responsibly bundle with this correctness set:

- Split `server/src/decision_hub/infra/database.py` (3465 LOC) into `infra/database/{skills,orgs,evals,trackers,scans}.py`.
- Split `client/src/dhub/cli/registry.py` (1912 LOC) into `cli/{publish,install,discover,logs}.py`.
- Extract the 8× copy-pasted `_enforce_*_rate_limit` helpers into a single `limiter_for(name)` factory.
- Move `create_zip`, `discover_skills`, and `_MAX_ZIP_ENTRIES` into `dhub_core` and delete the client/server duplicates (client `discover_skills` currently misses dedup logic the server has).
- Frontend: migrate hardcoded font sizes (`GradeBadge.module.css`, `FileBrowser.tsx`, `NotFoundPage.tsx`, `OrgDetailPage.tsx`) to `--text-*` variables and add a stylelint gate.
- Fix `SkillDetailPage.loadZip` stuck-spinner state machine (`frontend/src/pages/SkillDetailPage.tsx:200-223`).
- Replace parallel `test_api/conftest.py` FastAPI wiring with the real `create_app()` so production middleware changes fail tests.

## Checklist
- [x] Tests pass (`make test-server`, `make test-client`; frontend not affected; pre-existing docx failures unrelated)
- [x] No breaking API changes (`get_env()` whitelist change now errors on `DHUB_ENV` typos — considered a fix, not a regression, since the prior behavior silently degraded to production)
- [x] Database migration included (if schema changed) — N/A, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_019TNjtBGxDF9USHMCzk4SAY)_