### PR TITLE
fix: deterministic pagination, eval-run rate limit, log-parse robustness

### DIFF
--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -69,11 +69,17 @@ export default function SkillDetailPage() {
   const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const MAX_ZIP_ATTEMPTS = 3;
 
-  // Reset state when navigating to a different skill
+  // Reset state when navigating to a different skill.
+  // Also resets `activeTab` and `copied` — otherwise clicking a related-skill
+  // link from the Audit tab keeps you on that tab for the new skill, and the
+  // "Copied!" badge persists across skills.
   useEffect(() => {
+    setActiveTab("overview");
+    setCopied(false);
     setZipData(null);
     setZipError(null);
     setZipLoading(false);
+    setDownloading(false);
     setFiles([]);
     setSkillMdContent(null);
     zipRetries.current = 0;

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -83,88 +83,43 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
+def _make_rate_limit_enforcer(name: str):
+    """Return a FastAPI dependency that enforces a named rate limit.
+
+    Reads ``{name}_rate_limit`` and ``{name}_rate_window`` from settings and
+    lazily creates a singleton RateLimiter on ``app.state`` keyed by name.
+    All per-endpoint limits go through this factory so a new endpoint just
+    needs settings entries — no boilerplate helper.
+    """
+    state_attr = f"_{name}_rate_limiter"
+    limit_attr = f"{name}_rate_limit"
+    window_attr = f"{name}_rate_window"
+
+    def _enforce(request: Request) -> None:
+        state = request.app.state
+        limiter = getattr(state, state_attr, None)
+        if limiter is None:
+            settings: Settings = state.settings
+            limiter = RateLimiter(
+                max_requests=getattr(settings, limit_attr),
+                window_seconds=getattr(settings, window_attr),
+            )
+            setattr(state, state_attr, limiter)
+        limiter(request)
+
+    _enforce.__name__ = f"_enforce_{name}_rate_limit"
+    _enforce.__doc__ = f"Rate-limit dependency for '{name}' endpoints."
+    return _enforce
 
 
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+_enforce_list_skills_rate_limit = _make_rate_limit_enforcer("list_skills")
+_enforce_resolve_rate_limit = _make_rate_limit_enforcer("resolve")
+_enforce_similar_skills_rate_limit = _make_rate_limit_enforcer("similar_skills")
+_enforce_download_rate_limit = _make_rate_limit_enforcer("download")
+_enforce_audit_log_rate_limit = _make_rate_limit_enforcer("audit_log")
+_enforce_scan_report_rate_limit = _make_rate_limit_enforcer("scan_report")
+_enforce_publish_rate_limit = _make_rate_limit_enforcer("publish")
+_enforce_eval_runs_rate_limit = _make_rate_limit_enforcer("eval_runs")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -1120,7 +1075,11 @@ def _check_zombie(conn: Connection, run) -> str:
     return run.status
 
 
-@router.get("/eval-runs/{run_id}", response_model=EvalRunResponse)
+@router.get(
+    "/eval-runs/{run_id}",
+    response_model=EvalRunResponse,
+    dependencies=[Depends(_enforce_eval_runs_rate_limit)],
+)
 def get_eval_run(
     run_id: str,
     conn: Connection = Depends(get_connection),
@@ -1137,7 +1096,11 @@ def get_eval_run(
     return _run_to_response(run)
 
 
-@router.get("/eval-runs/{run_id}/logs", response_model=EvalRunLogsResponse)
+@router.get(
+    "/eval-runs/{run_id}/logs",
+    response_model=EvalRunLogsResponse,
+    dependencies=[Depends(_enforce_eval_runs_rate_limit)],
+)
 def get_eval_run_logs(
     run_id: str,
     cursor: int = Query(0, ge=0, description="Return events with seq > cursor"),
@@ -1165,19 +1128,26 @@ def get_eval_run_logs(
         after_seq=0,
     )
 
-    # Read and parse events from each chunk, filtering by cursor
+    # Read and parse events from each chunk, filtering by cursor. A concurrent
+    # writer can flush a partial line to S3; skip the malformed tail instead
+    # of returning 500 for the whole poll and stalling the client's log feed.
     all_events: list[dict] = []
     max_seq = cursor
     for _chunk_seq, s3_key in chunks:
         content = read_eval_log_chunk(s3_client, settings.s3_bucket, s3_key)
         for line in content.strip().split("\n"):
-            if line.strip():
+            if not line.strip():
+                continue
+            try:
                 event = json.loads(line)
-                event_seq = event.get("seq", 0)
-                if event_seq > cursor:
-                    all_events.append(event)
-                if event_seq > max_seq:
-                    max_seq = event_seq
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed log line in {} (run={})", s3_key, run.id)
+                continue
+            event_seq = event.get("seq", 0)
+            if event_seq > cursor:
+                all_events.append(event)
+            if event_seq > max_seq:
+                max_seq = event_seq
 
     return EvalRunLogsResponse(
         events=all_events,
@@ -1188,7 +1158,11 @@ def get_eval_run_logs(
     )
 
 
-@router.get("/eval-runs", response_model=list[EvalRunResponse])
+@router.get(
+    "/eval-runs",
+    response_model=list[EvalRunResponse],
+    dependencies=[Depends(_enforce_eval_runs_rate_limit)],
+)
 def list_eval_runs(
     version_id: str | None = Query(None, description="Filter by version ID"),
     conn: Connection = Depends(get_connection),

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2040,7 +2040,9 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # skills.id tiebreaker keeps rank-tied rows in the same order across
+        # requests so the dedup at the bottom of this function is stable.
+        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC"), skills_table.c.id.asc()).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2054,7 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC"), skills_table.c.id.asc()).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2125,7 +2127,7 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id.asc())
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -2724,7 +2726,7 @@ def find_active_eval_runs_for_user(conn: Connection, user_id: UUID, limit: int =
     stmt = (
         sa.select(eval_runs_table)
         .where(eval_runs_table.c.user_id == user_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.asc())
         .limit(limit)
     )
     rows = conn.execute(stmt).all()
@@ -2884,7 +2886,7 @@ def list_skill_trackers_for_user(conn: Connection, user_id: UUID) -> list[SkillT
     stmt = (
         sa.select(skill_trackers_table)
         .where(skill_trackers_table.c.user_id == user_id)
-        .order_by(skill_trackers_table.c.created_at.desc())
+        .order_by(skill_trackers_table.c.created_at.desc(), skill_trackers_table.c.id.asc())
     )
     rows = conn.execute(stmt).all()
     return [_row_to_skill_tracker(row) for row in rows]
@@ -2928,7 +2930,10 @@ def claim_due_trackers(
     locked_ids_cte = (
         sa.select(skill_trackers_table.c.id)
         .where(due_filter)
-        .order_by(skill_trackers_table.c.next_check_at.asc().nulls_first())
+        .order_by(
+            skill_trackers_table.c.next_check_at.asc().nulls_first(),
+            skill_trackers_table.c.id.asc(),
+        )
         .limit(batch_size)
         .with_for_update(skip_locked=True)
         .cte("locked_ids")
@@ -3249,7 +3254,11 @@ def insert_tracker_metrics(
 
 def list_tracker_metrics(conn: Connection, *, limit: int = 50) -> list[TrackerMetrics]:
     """Return recent tracker metrics rows, newest first."""
-    stmt = sa.select(tracker_metrics_table).order_by(tracker_metrics_table.c.recorded_at.desc()).limit(limit)
+    stmt = (
+        sa.select(tracker_metrics_table)
+        .order_by(tracker_metrics_table.c.recorded_at.desc(), tracker_metrics_table.c.id.asc())
+        .limit(limit)
+    )
     rows = conn.execute(stmt).all()
     return [_row_to_tracker_metrics(row) for row in rows]
 

--- a/server/src/decision_hub/scripts/backfill_embeddings.py
+++ b/server/src/decision_hub/scripts/backfill_embeddings.py
@@ -54,6 +54,9 @@ def backfill(batch_size: int = 100) -> None:
                     )
                 )
                 .where(skills_table.c.embedding.is_(None))
+                # id ordering makes the batch loop deterministic under concurrent
+                # inserts — required by CLAUDE.md "every LIMIT needs ORDER BY".
+                .order_by(skills_table.c.id.asc())
                 .limit(batch_size)
             )
             rows = conn.execute(stmt).all()

--- a/server/src/decision_hub/settings.py
+++ b/server/src/decision_hub/settings.py
@@ -92,6 +92,12 @@ class Settings(BaseSettings):
     publish_rate_window: int = 60  # window in seconds
     auth_rate_limit: int = 10  # max requests per window
     auth_rate_window: int = 60  # window in seconds
+    # Eval-run polling endpoints. Poll cadence is per-second per client while a
+    # run is in-flight, and each log poll fetches every S3 chunk for the run,
+    # so an aggressive client can drain the container threadpool and S3 quota
+    # without a limit. Sized well above the ~1 Hz per-run polling from the UI.
+    eval_runs_rate_limit: int = 120
+    eval_runs_rate_window: int = 60
 
     # Sandbox resource limits for agent evals
     sandbox_memory_mb: int = 4096

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -52,6 +52,8 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.eval_runs_rate_limit = 120
+    settings.eval_runs_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -382,6 +382,41 @@ class TestGetEvalRunLogs:
 
         assert resp.status_code == 404
 
+    @patch("decision_hub.api.registry_routes.read_eval_log_chunk")
+    @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_malformed_json_line_is_skipped(
+        self,
+        mock_find_run: MagicMock,
+        mock_list_chunks: MagicMock,
+        mock_read_chunk: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A partial-flush truncated line should not 500 the whole log poll.
+
+        A concurrent writer flushing a JSONL chunk can leave a partial trailing
+        line in S3. The reader must skip that line and keep parsing valid ones
+        so the client's log feed does not stall until the writer completes.
+        """
+        run = _make_eval_run()
+        mock_find_run.return_value = run
+        mock_list_chunks.return_value = [(1, "eval-logs/test-run/0001.jsonl")]
+        mock_read_chunk.return_value = (
+            '{"seq":1,"type":"setup","content":"init"}\n'
+            '{"seq":2,"type":"log","conte'  # truncated mid-line
+        )
+
+        resp = client.get(
+            f"/v1/eval-runs/{run.id}/logs?cursor=0",
+            headers=auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [e["seq"] for e in data["events"]] == [1]
+        assert data["next_cursor"] == 1
+
     @patch("decision_hub.api.registry_routes.update_eval_run_status")
     @patch("decision_hub.api.registry_routes.list_eval_log_chunks")
     @patch("decision_hub.api.registry_routes.find_eval_run")
@@ -527,3 +562,62 @@ class TestEvalRunUUIDValidation:
         resp = client.get("/v1/eval-runs?version_id=not-a-uuid", headers=auth_headers)
         assert resp.status_code == 422
         assert "Invalid UUID" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestEvalRunsRateLimit:
+    """The eval-run endpoints must enforce a per-IP rate limit.
+
+    Without one, an authenticated user polling the log endpoint aggressively
+    can drain the container's threadpool + S3 quota (every poll re-lists and
+    reads every chunk for the run).
+    """
+
+    @patch("decision_hub.api.registry_routes.find_active_eval_runs_for_user")
+    def test_list_eval_runs_returns_429_after_limit(
+        self,
+        mock_find_runs: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_settings: MagicMock,
+    ) -> None:
+        mock_find_runs.return_value = []
+        test_settings.eval_runs_rate_limit = 3
+        test_settings.eval_runs_rate_window = 60
+
+        # New app state → fresh limiter for this test.
+        client.app.state._eval_runs_rate_limiter = None
+
+        for _ in range(3):
+            r = client.get("/v1/eval-runs", headers=auth_headers)
+            assert r.status_code == 200
+
+        resp = client.get("/v1/eval-runs", headers=auth_headers)
+        assert resp.status_code == 429
+        assert "Rate limit exceeded" in resp.json()["detail"]
+
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_get_eval_run_returns_429_after_limit(
+        self,
+        mock_find_run: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        test_settings: MagicMock,
+    ) -> None:
+        run = _make_eval_run()
+        mock_find_run.return_value = run
+        test_settings.eval_runs_rate_limit = 2
+        test_settings.eval_runs_rate_window = 60
+
+        client.app.state._eval_runs_rate_limiter = None
+
+        for _ in range(2):
+            r = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+            assert r.status_code == 200
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+        assert resp.status_code == 429

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,5 +1,6 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -84,3 +85,67 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+
+class TestRateLimitEnforcerFactory:
+    """`_make_rate_limit_enforcer` collapses the per-endpoint boilerplate.
+
+    Each returned dependency must be self-contained (its own singleton
+    limiter, its own settings pair) and independent from other names.
+    """
+
+    @staticmethod
+    def _request(state: SimpleNamespace, host: str = "10.0.0.1") -> MagicMock:
+        request = MagicMock()
+        request.app.state = state
+        request.client.host = host
+        return request
+
+    def test_factory_lazily_builds_and_reuses_limiter(self) -> None:
+        from decision_hub.api.registry_routes import _make_rate_limit_enforcer
+
+        enforcer = _make_rate_limit_enforcer("widget")
+
+        state = SimpleNamespace(settings=SimpleNamespace(widget_rate_limit=3, widget_rate_window=60))
+        request = self._request(state)
+
+        for _ in range(3):
+            enforcer(request)
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforcer(request)
+        assert exc_info.value.status_code == 429
+
+        # Limiter is cached on app.state for reuse across requests
+        assert hasattr(state, "_widget_rate_limiter")
+        first_limiter = state._widget_rate_limiter
+        # Reset counter so we can prove it's the same instance being reused
+        first_limiter._requests.clear()
+        enforcer(request)
+        assert state._widget_rate_limiter is first_limiter
+
+    def test_different_names_have_independent_limiters(self) -> None:
+        from decision_hub.api.registry_routes import _make_rate_limit_enforcer
+
+        enforcer_a = _make_rate_limit_enforcer("alpha")
+        enforcer_b = _make_rate_limit_enforcer("beta")
+
+        state = SimpleNamespace(
+            settings=SimpleNamespace(
+                alpha_rate_limit=1,
+                alpha_rate_window=60,
+                beta_rate_limit=5,
+                beta_rate_window=60,
+            )
+        )
+        request = self._request(state)
+
+        enforcer_a(request)
+        with pytest.raises(HTTPException):
+            enforcer_a(request)
+
+        # beta must not have been consumed by alpha's calls
+        for _ in range(5):
+            enforcer_b(request)
+        with pytest.raises(HTTPException):
+            enforcer_b(request)

--- a/server/tests/test_domain/test_search.py
+++ b/server/tests/test_domain/test_search.py
@@ -3,6 +3,7 @@
 from decision_hub.domain.search import (
     build_index_entry,
     format_trust_score,
+    resolve_author_display,
     serialize_index,
 )
 
@@ -112,3 +113,30 @@ def test_serialize_index_includes_github_metadata():
 def test_serialize_empty():
     jsonl = serialize_index([])
     assert jsonl == ""
+
+
+def test_resolve_author_display_maps_tracker_prefix():
+    """Tracker-published versions display as 'auto-sync' instead of the raw UUID."""
+    assert resolve_author_display("tracker:12345678-1234-5678-1234-567812345678") == "auto-sync"
+    assert resolve_author_display("tracker:anything") == "auto-sync"
+
+
+def test_resolve_author_display_passes_normal_usernames_through():
+    assert resolve_author_display("lfiaschi") == "lfiaschi"
+    assert resolve_author_display("") == ""
+
+
+def test_serialize_index_marks_removed_source_before_archived():
+    """When both flags are set, source_repo_removed takes priority over archived."""
+    entry = build_index_entry(
+        "org",
+        "skill",
+        "Desc",
+        "1.0.0",
+        "passed",
+        source_repo_removed=True,
+        github_is_archived=True,
+    )
+    jsonl = serialize_index([entry])
+    assert '"source_status": "removed"' in jsonl
+    assert '"source_status": "archived"' not in jsonl


### PR DESCRIPTION
## What changed

Correctness and hardening pass surfaced by an architectural review. Six independent fixes with tests, no schema or public API changes.

- **SQL determinism** — Adds `id` tiebreakers to seven `LIMIT` queries where two rows with the same rank or timestamp could reshuffle between requests (CLAUDE.md rule: every `LIMIT` needs `ORDER BY` with a unique tiebreaker). Locations:
  - `search_skills_hybrid` FTS branch (`database.py:2043`) and vector branch (`database.py:2055`) — the tie-shuffle reached the `(org_slug, skill_name)` dedup at the bottom of the function and produced non-repeatable candidate sets between requests.
  - `fetch_similar_skills` (`database.py:2128`), `find_active_eval_runs_for_user` (`database.py:2727`), `list_skill_trackers_for_user` (`database.py:2887`), `list_tracker_metrics` (`database.py:3252`), and `claim_due_trackers` (`database.py:2931`).
  - `backfill_embeddings.py:57` batch loop.

- **Rate-limit gap** — `/v1/eval-runs`, `/v1/eval-runs/{id}`, and `/v1/eval-runs/{id}/logs` had no limiter. The log endpoint re-lists and re-reads every S3 chunk for the run per poll; an authenticated user polling aggressively can drain the container threadpool and S3 quota. Adds a per-IP limiter (default 120 req/60 s, sized well above the ~1 Hz per-run UI polling) and settings entries.

- **Log-parse robustness** — `get_eval_run_logs` called `json.loads(line)` with no guard. A concurrent writer flushing a JSONL chunk can leave a partial trailing line in S3; the raw `JSONDecodeError` returned HTTP 500 for the whole poll and stalled the client's log feed until the next flush. Now logs a warning and skips the bad line.

- **Rate-limiter factory dedup** — Seven near-identical `_enforce_*_rate_limit` helpers in `registry_routes.py` (~80 lines) collapse into one `_make_rate_limit_enforcer(name)` factory. Reads `{name}_rate_limit` / `{name}_rate_window` from settings and lazily caches the singleton on `app.state`. A new endpoint now needs only a settings pair — no boilerplate helper.

- **Frontend stale state** — `SkillDetailPage`'s reset effect cleared zip state but not `activeTab` or `copied`. Clicking a related-skill link from the Audit tab kept you on that tab for the new skill, and the "Copied!" badge persisted across skills.

- **Tests** — `resolve_author_display("tracker:…")` → `auto-sync` (previously untested); `source_repo_removed=True + github_is_archived=True` serialises `source_status: "removed"` (removed beats archived); the rate-limit factory lazily builds & caches a singleton per name and different names are independent; the eval-run endpoints return 429 after their configured limit; a truncated trailing line in an S3 chunk is skipped and the poll still returns valid events and advances the cursor.

## Why

Findings from a deep review of the server and frontend by three parallel review agents (bugs / dead code / test coverage). Ranked findings by severity and impact, then picked a coherent, low-risk PR: correctness fixes plus one bounded refactor and its tests. No new endpoints, no schema changes, no breaking API changes.

## How to test

Locally:

```
make test-server         # 941 passed, 34 slow-deselected
make test-frontend       # 82 passed
uvx ruff@0.15.3 check .
cd frontend && npx tsc -b && npx eslint .
```

Manual smoke:
- Poll `GET /v1/eval-runs/{id}/logs?cursor=0` 130× within 60 s → last requests return HTTP 429.
- Repeat a `GET /v1/ask` request; candidate order is stable across runs when rank/distance ties exist.
- Navigate SkillDetailPage → click Audit tab → click a related skill → new skill opens on Overview tab, "Copied!" badge cleared.

## Checklist
- [x] Tests pass (`make test-server`, `make test-frontend`)
- [x] No breaking API changes
- [x] No schema migration required

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzRXjBiw5WPFVykCirs9Yo)_