### PR TITLE
fix: correctness and safety fixes across server, CLI, and shared

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -1,5 +1,6 @@
 """CLI configuration file management for ~/.dhub/config.{env}.json."""
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -82,7 +83,9 @@ def load_config() -> CliConfig:
 def save_config(config: CliConfig) -> None:
     """Save CLI config to ~/.dhub/config.{env}.json.
 
-    Creates the ~/.dhub directory if it does not already exist.
+    Creates the ~/.dhub directory if it does not already exist and writes
+    the file with 0600 permissions (owner read/write only) so the bearer
+    token is not world-readable on shared machines.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = config_file()
@@ -90,6 +93,11 @@ def save_config(config: CliConfig) -> None:
         json.dumps(asdict(config), indent=2) + "\n",
         encoding="utf-8",
     )
+    # POSIX-only. Windows has no meaningful equivalent for a config file
+    # in a per-user home directory, so silently skip if chmod is a no-op
+    # or errors.
+    with contextlib.suppress(OSError, NotImplementedError):
+        path.chmod(0o600)
 
 
 def get_api_url() -> str:
@@ -103,12 +111,19 @@ def get_api_url() -> str:
 def get_token() -> str:
     """Get the auth token from DHUB_TOKEN env var or saved config.
 
+    Env-var values are stripped so a stray newline (common with
+    ``export DHUB_TOKEN=$(cat token)``) does not become part of the
+    ``Authorization: Bearer …`` header — httpx would emit an invalid
+    request and the server would reject it with an opaque 400.
+
     Raises:
         typer.Exit: If no token is available (user not logged in).
     """
     env_token = os.environ.get("DHUB_TOKEN")
     if env_token:
-        return env_token
+        stripped = env_token.strip()
+        if stripped:
+            return stripped
 
     token = load_config().token
     if not token:
@@ -124,10 +139,14 @@ def get_optional_token() -> str | None:
     Unlike :func:`get_token`, this never exits — it simply returns
     ``None`` when no credentials are configured.  Use this for commands
     that work without authentication (e.g. installing public skills).
+
+    Env-var values are stripped for the same reason as :func:`get_token`.
     """
     env_token = os.environ.get("DHUB_TOKEN")
     if env_token:
-        return env_token
+        stripped = env_token.strip()
+        if stripped:
+            return stripped
     return load_config().token
 
 
@@ -155,6 +174,27 @@ def build_headers(token: str | None = None) -> dict[str, str]:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
+
+
+def extract_error_detail(resp: httpx.Response, default: str) -> str:
+    """Best-effort extraction of a FastAPI ``detail`` field from an error response.
+
+    FastAPI usually returns ``{"detail": "..."}`` on 4xx, but a proxy,
+    load balancer, or misconfigured middleware can return HTML or a bare
+    text/plain body. Calling ``resp.json()`` unconditionally in that case
+    crashes with ``json.JSONDecodeError``. This helper falls back to the
+    stripped response text, and to ``default`` if the body is empty.
+    """
+    try:
+        payload = resp.json()
+    except (ValueError, json.JSONDecodeError):
+        text = resp.text.strip()
+        return text or default
+    if isinstance(payload, dict):
+        detail = payload.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail
+    return default
 
 
 def raise_for_status(resp: httpx.Response) -> None:

--- a/client/src/dhub/cli/registry.py
+++ b/client/src/dhub/cli/registry.py
@@ -35,7 +35,7 @@ def _publish_skill_directory(
     Returns True on success, False on skip (no changes).
     Raises typer.Exit on errors.
     """
-    from dhub.cli.config import build_headers, raise_for_status
+    from dhub.cli.config import build_headers, extract_error_detail, raise_for_status
     from dhub.core.validation import (
         FIRST_VERSION,
         bump_version,
@@ -109,7 +109,11 @@ def _publish_skill_directory(
             console.print(f"[red]Error: Version {version} already exists for {org}/{name}.[/]")
             raise typer.Exit(1)
         if resp.status_code == 422:
-            detail = resp.json().get("detail", "Gauntlet checks failed")
+            # A proxy in front of the API can return text/plain or HTML
+            # instead of the FastAPI JSON envelope; ``resp.json()`` would
+            # crash with a raw JSONDecodeError. Use the safe helper so
+            # the user always sees the intended "Rejected" message.
+            detail = extract_error_detail(resp, "Gauntlet checks failed")
             console.print(f"[red]Rejected (Grade F): {detail}[/]")
             raise typer.Exit(1)
         if resp.status_code == 503:

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -119,6 +119,96 @@ class TestGetToken:
 
         assert result == "env-token-123"
 
+    def test_env_var_whitespace_is_stripped(self, monkeypatch):
+        """A trailing newline in DHUB_TOKEN (common with ``$(cat token)``)
+        used to end up inside the ``Authorization: Bearer …`` header,
+        producing an invalid HTTP request that the server rejects with
+        an opaque 400. The value must be stripped before use."""
+        from dhub.cli.config import get_optional_token, get_token
+
+        monkeypatch.setenv("DHUB_TOKEN", "  env-token-123\n\n")
+
+        assert get_token() == "env-token-123"
+        assert get_optional_token() == "env-token-123"
+
+    def test_whitespace_only_env_var_falls_back_to_config(self, tmp_path, monkeypatch):
+        """A blank env var should not shadow the saved config token."""
+        from dhub.cli.config import get_optional_token
+
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+        monkeypatch.setenv("DHUB_TOKEN", "   \n")
+
+        config_path = tmp_path / "config.dev.json"
+        config_path.write_text(json.dumps({"api_url": "https://x.example.com", "token": "saved-tok"}))
+
+        assert get_optional_token() == "saved-tok"
+
+
+class TestSaveConfigPermissions:
+    """save_config should write the token file with 0600 (owner-only) perms."""
+
+    def test_file_has_owner_only_perms(self, tmp_path, monkeypatch):
+        """Regression: the token file used to inherit the process umask
+        (typically 0644 world-readable). On a shared host any other user
+        could read the bearer token from ``~/.dhub/config.dev.json``."""
+        import os
+        import stat
+
+        if os.name != "posix":
+            pytest.skip("POSIX-only permission check")
+
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://x.example.com", token="secret"))
+
+        path = tmp_path / "config.dev.json"
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600, f"expected 0600 permissions, got {oct(mode)}"
+
+
+class TestExtractErrorDetail:
+    """extract_error_detail should never raise on non-JSON responses."""
+
+    def test_returns_detail_from_json_body(self):
+        import httpx
+
+        from dhub.cli.config import extract_error_detail
+
+        resp = httpx.Response(422, json={"detail": "safety check failed"})
+
+        assert extract_error_detail(resp, "fallback") == "safety check failed"
+
+    def test_returns_default_when_json_has_no_detail(self):
+        import httpx
+
+        from dhub.cli.config import extract_error_detail
+
+        resp = httpx.Response(422, json={"other": "field"})
+
+        assert extract_error_detail(resp, "fallback") == "fallback"
+
+    def test_returns_body_text_when_not_json(self):
+        """A proxy returning text/plain used to crash the CLI with
+        ``json.JSONDecodeError``; the helper must return the plain text."""
+        import httpx
+
+        from dhub.cli.config import extract_error_detail
+
+        resp = httpx.Response(422, text="Upstream timed out", headers={"content-type": "text/plain"})
+
+        assert extract_error_detail(resp, "fallback") == "Upstream timed out"
+
+    def test_returns_default_when_body_empty_and_not_json(self):
+        import httpx
+
+        from dhub.cli.config import extract_error_detail
+
+        resp = httpx.Response(422, text="", headers={"content-type": "text/plain"})
+
+        assert extract_error_detail(resp, "fallback") == "fallback"
+
 
 class TestGetDefaultOrg:
     """get_default_org should check DHUB_DEFAULT_ORG env var first."""

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -45,7 +45,7 @@ from decision_hub.infra.database import (
     find_audit_logs,
     find_eval_report_by_skill,
     find_eval_run,
-    find_eval_runs_for_version,
+    find_eval_runs_for_version_and_user,
     find_latest_scan_report_for_skill,
     find_org_by_slug,
     find_scan_findings_for_report,
@@ -1132,9 +1132,12 @@ def get_eval_run(
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
     _check_zombie(conn, run)
-    # Re-read after potential zombie update
-    run = find_eval_run(conn, parsed_id)
-    return _run_to_response(run)
+    # Re-read after potential zombie update to get the fresh status /
+    # error_message. A concurrent delete between the two reads is rare
+    # but would previously crash _run_to_response(None) with a 500; fall
+    # back to the pre-zombie row so the caller still gets a valid response.
+    refreshed = find_eval_run(conn, parsed_id)
+    return _run_to_response(refreshed if refreshed is not None else run)
 
 
 @router.get("/eval-runs/{run_id}/logs", response_model=EvalRunLogsResponse)
@@ -1197,8 +1200,11 @@ def list_eval_runs(
     """List eval runs, optionally filtered by version ID."""
     if version_id is not None:
         parsed_vid = _parse_uuid(version_id, "version_id")
-        runs = find_eval_runs_for_version(conn, parsed_vid)
-        runs = [r for r in runs if r.user_id == current_user.id]
+        # Filter by user in SQL so foreign-tenant rows never leave the DB
+        # (the old code fetched every run for the version then filtered in
+        # Python, which both wasted work and momentarily held cross-tenant
+        # data in request memory).
+        runs = find_eval_runs_for_version_and_user(conn, parsed_vid, current_user.id)
     else:
         runs = find_active_eval_runs_for_user(conn, current_user.id)
     return [_run_to_response(r) for r in runs]

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -262,7 +262,12 @@ def update_tracker(
     )
 
     updated = find_skill_tracker(conn, tid)
-    assert updated is not None
+    if updated is None:
+        # ``assert`` would be stripped under ``python -O`` and leaves the
+        # response builder to crash with AttributeError; a concurrent
+        # delete between UPDATE and re-read is unlikely but real. Return
+        # 404 so the client learns the tracker is gone.
+        raise HTTPException(status_code=404, detail="Tracker not found")
     return _tracker_to_response(updated)
 
 

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -959,18 +959,25 @@ def update_org_github_metadata(
     description: str | None = None,
     blog: str | None = None,
 ) -> None:
-    """Update GitHub-sourced metadata and set github_synced_at = now()."""
-    stmt = (
-        sa.update(organizations_table)
-        .where(organizations_table.c.id == org_id)
-        .values(
-            avatar_url=avatar_url,
-            email=email,
-            description=description,
-            blog=blog,
-            github_synced_at=sa.func.now(),
-        )
-    )
+    """Update GitHub-sourced metadata and set ``github_synced_at = now()``.
+
+    Only fields that are not ``None`` overwrite the stored value. GitHub
+    frequently returns null for optional fields (``description``, ``blog``,
+    ``email``); previously those nulls silently wiped values that were
+    legitimately populated on a prior sync (or set manually in the DB).
+    Pass an empty string if the intent is to explicitly clear a field.
+    """
+    values: dict[str, object] = {"github_synced_at": sa.func.now()}
+    if avatar_url is not None:
+        values["avatar_url"] = avatar_url
+    if email is not None:
+        values["email"] = email
+    if description is not None:
+        values["description"] = description
+    if blog is not None:
+        values["blog"] = blog
+
+    stmt = sa.update(organizations_table).where(organizations_table.c.id == org_id).values(**values)
     conn.execute(stmt)
 
 
@@ -2709,11 +2716,37 @@ def find_eval_run(conn: Connection, run_id: UUID) -> EvalRun | None:
 
 
 def find_eval_runs_for_version(conn: Connection, version_id: UUID) -> list[EvalRun]:
-    """List all eval runs for a version, newest first."""
+    """List all eval runs for a version, newest first.
+
+    Prefer :func:`find_eval_runs_for_version_and_user` for user-scoped
+    listings so tenant isolation happens in SQL rather than Python.
+    """
     stmt = (
         sa.select(eval_runs_table)
         .where(eval_runs_table.c.version_id == version_id)
-        .order_by(eval_runs_table.c.created_at.desc())
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
+    )
+    rows = conn.execute(stmt).all()
+    return [_row_to_eval_run(row) for row in rows]
+
+
+def find_eval_runs_for_version_and_user(
+    conn: Connection,
+    version_id: UUID,
+    user_id: UUID,
+) -> list[EvalRun]:
+    """List eval runs for a version owned by ``user_id``, newest first.
+
+    The user filter is applied in SQL so foreign-tenant rows never leave
+    the database.
+    """
+    stmt = (
+        sa.select(eval_runs_table)
+        .where(
+            eval_runs_table.c.version_id == version_id,
+            eval_runs_table.c.user_id == user_id,
+        )
+        .order_by(eval_runs_table.c.created_at.desc(), eval_runs_table.c.id.desc())
     )
     rows = conn.execute(stmt).all()
     return [_row_to_eval_run(row) for row in rows]
@@ -2788,7 +2821,13 @@ def insert_search_log(
 
 
 def _row_to_skill_tracker(row: sa.Row) -> SkillTracker:
-    """Map a database row to a SkillTracker model."""
+    """Map a database row to a SkillTracker model.
+
+    Every persisted column on ``skill_trackers`` must be mapped here.
+    Missing a column silently falls back to the dataclass default and
+    hides real state from every caller (past bug: ``consecutive_permanent_failures``
+    was dropped, so every tracker looked healthy regardless of DB state).
+    """
     return SkillTracker(
         id=row.id,
         user_id=row.user_id,
@@ -2802,6 +2841,7 @@ def _row_to_skill_tracker(row: sa.Row) -> SkillTracker:
         last_published_at=row.last_published_at,
         last_error=row.last_error,
         next_check_at=row.next_check_at,
+        consecutive_permanent_failures=row.consecutive_permanent_failures,
         created_at=row.created_at,
     )
 

--- a/server/tests/test_api/test_eval_logs.py
+++ b/server/tests/test_api/test_eval_logs.py
@@ -134,6 +134,35 @@ class TestGetEvalRun:
         assert resp.json()["status"] == "running"
         mock_update_status.assert_not_called()
 
+    @patch("decision_hub.api.registry_routes.update_eval_run_status")
+    @patch("decision_hub.api.registry_routes.find_eval_run")
+    def test_get_run_survives_concurrent_delete_after_zombie_check(
+        self,
+        mock_find_run: MagicMock,
+        mock_update_status: MagicMock,
+        client: TestClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Regression: the route re-reads the run after the zombie
+        sweep to pick up the fresh status. If a concurrent delete lands
+        between the sweep and the re-read, the second ``find_eval_run``
+        returns None; the response builder used to dereference that and
+        crash with a 500. The route must fall back to the pre-zombie
+        row so the caller still gets a valid response."""
+        stale_heartbeat = datetime.now(UTC) - timedelta(seconds=400)
+        run = _make_eval_run(status="running", heartbeat_at=stale_heartbeat)
+
+        # 1st find (auth + zombie): returns the run.
+        # 2nd find (post-sweep refresh): returns None (concurrent delete).
+        mock_find_run.side_effect = [run, None]
+
+        resp = client.get(f"/v1/eval-runs/{run.id}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        # The response builder ran on the pre-zombie row; the id matches
+        # and no 500 was raised.
+        assert resp.json()["id"] == str(run.id)
+
     @patch("decision_hub.api.registry_routes.find_eval_run")
     def test_completed_run_not_checked_for_zombie(
         self,
@@ -434,7 +463,7 @@ class TestListEvalRuns:
         assert len(data) == 1
         assert data[0]["id"] == str(run.id)
 
-    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version")
+    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version_and_user")
     def test_list_runs_by_version_id(
         self,
         mock_find_runs: MagicMock,
@@ -454,6 +483,11 @@ class TestListEvalRuns:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["version_id"] == str(version_id)
+        # The SQL helper must be scoped to the current user so no
+        # cross-tenant filtering has to happen in Python.
+        call_args = mock_find_runs.call_args
+        assert call_args.args[1] == version_id
+        assert call_args.args[2] == SAMPLE_USER_ID
 
     @patch("decision_hub.api.registry_routes.find_active_eval_runs_for_user")
     def test_list_runs_empty(
@@ -469,18 +503,23 @@ class TestListEvalRuns:
         assert resp.status_code == 200
         assert resp.json() == []
 
-    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version")
-    def test_list_by_version_filters_to_current_user(
+    @patch("decision_hub.api.registry_routes.find_eval_runs_for_version_and_user")
+    def test_list_by_version_scopes_to_current_user_in_sql(
         self,
         mock_find_runs: MagicMock,
         client: TestClient,
         auth_headers: dict[str, str],
     ) -> None:
-        """When filtering by version_id, only the current user's runs are returned."""
+        """User isolation happens in SQL, not Python.
+
+        The route calls the SQL helper with the caller's user_id so the
+        database only ever returns rows the user owns; the previous
+        implementation fetched every user's rows and filtered in Python,
+        which momentarily held cross-tenant data in request memory.
+        """
         version_id = uuid4()
         own_run = _make_eval_run(version_id=version_id, user_id=SAMPLE_USER_ID)
-        other_run = _make_eval_run(version_id=version_id, user_id=uuid4())
-        mock_find_runs.return_value = [own_run, other_run]
+        mock_find_runs.return_value = [own_run]
 
         resp = client.get(
             f"/v1/eval-runs?version_id={version_id}",
@@ -491,6 +530,9 @@ class TestListEvalRuns:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["id"] == str(own_run.id)
+        # Assert the DB helper receives user_id so filtering is SQL-side.
+        call_args = mock_find_runs.call_args
+        assert call_args.args[2] == SAMPLE_USER_ID
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_api/test_tracker_routes.py
+++ b/server/tests/test_api/test_tracker_routes.py
@@ -266,6 +266,31 @@ class TestUpdateTracker:
         assert resp.status_code == 200
         assert resp.json()["poll_interval_minutes"] == 30
 
+    @patch("decision_hub.api.tracker_routes.find_skill_tracker")
+    @patch("decision_hub.api.tracker_routes.update_skill_tracker")
+    def test_update_tracker_returns_404_on_concurrent_delete(
+        self, mock_update, mock_find, tracker_client, auth_headers, sample_user_id
+    ):
+        """Regression: the route used to ``assert updated is not None``
+        after the UPDATE, which (a) crashes with AttributeError under
+        ``python -O`` when the assertion is stripped and the response
+        builder dereferences None, and (b) manifests as an opaque 500
+        even without ``-O``. A concurrent delete between UPDATE and
+        re-read is rare but real (admin cleanup, cascade from org
+        deletion). The route must return 404 instead."""
+        tracker = _make_tracker(user_id=sample_user_id)
+        # First find() (auth check) returns the tracker; the post-update
+        # re-read simulates the concurrent delete by returning None.
+        mock_find.side_effect = [tracker, None]
+
+        resp = tracker_client.patch(
+            f"/v1/trackers/{tracker.id}",
+            headers=auth_headers,
+            json={"enabled": False},
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Tracker not found"
+
 
 class TestDeleteTracker:
     @patch("decision_hub.api.tracker_routes.delete_skill_tracker")

--- a/server/tests/test_infra/test_orgs_db.py
+++ b/server/tests/test_infra/test_orgs_db.py
@@ -1,0 +1,91 @@
+"""Database function tests for organization metadata helpers.
+
+Uses mocked connections; the emitted SQLAlchemy statement is compiled
+and inspected so a regression to the old "always overwrite" behaviour
+is caught.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from decision_hub.infra.database import update_org_github_metadata
+
+
+class TestUpdateOrgGithubMetadata:
+    def _compiled_values(self, conn: MagicMock) -> str:
+        """Return the compiled SQL of the last UPDATE with literal binds."""
+        conn.execute.assert_called_once()
+        stmt = conn.execute.call_args[0][0]
+        return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    def test_omits_none_fields_from_update(self):
+        """Regression: when GitHub returns null for ``description`` /
+        ``blog`` / ``email`` (very common for org accounts), the sync
+        used to overwrite the stored value with NULL — silently wiping
+        data that was populated on a prior sync or set manually. The
+        helper must only update fields the caller explicitly provided.
+        """
+        conn = MagicMock()
+        org_id = uuid4()
+
+        update_org_github_metadata(
+            conn,
+            org_id,
+            avatar_url="https://gh/avatar.png",
+            email=None,
+            description=None,
+            blog=None,
+        )
+
+        compiled = self._compiled_values(conn)
+        assert "avatar_url" in compiled
+        assert "github_synced_at" in compiled
+        # These must NOT appear in the SET clause — they were None.
+        assert "description=" not in compiled.replace(" ", "")
+        assert "blog=" not in compiled.replace(" ", "")
+        assert "email=" not in compiled.replace(" ", "")
+
+    def test_updates_all_provided_fields(self):
+        conn = MagicMock()
+        org_id = uuid4()
+
+        update_org_github_metadata(
+            conn,
+            org_id,
+            avatar_url="https://gh/avatar.png",
+            email="alice@example.com",
+            description="hello",
+            blog="https://alice.dev",
+        )
+
+        compiled = self._compiled_values(conn)
+        assert "avatar_url" in compiled
+        assert "email" in compiled
+        assert "description" in compiled
+        assert "blog" in compiled
+        assert "github_synced_at" in compiled
+
+    def test_empty_string_is_explicit_clear(self):
+        """An empty string is a caller-provided value (``""``, not None)
+        and should reach the DB — this is how a user explicitly clears
+        a field via the API."""
+        conn = MagicMock()
+        org_id = uuid4()
+
+        update_org_github_metadata(conn, org_id, description="")
+
+        compiled = self._compiled_values(conn)
+        assert "description" in compiled
+
+    def test_all_none_still_bumps_sync_timestamp(self):
+        """Even when every metadata field is null, the helper must
+        update ``github_synced_at`` so ``sync_org_github_metadata``'s
+        24 h TTL check moves forward and does not re-hit GitHub every
+        request."""
+        conn = MagicMock()
+        org_id = uuid4()
+
+        update_org_github_metadata(conn, org_id)
+
+        compiled = self._compiled_values(conn)
+        assert "github_synced_at" in compiled

--- a/server/tests/test_infra/test_tracker_db.py
+++ b/server/tests/test_infra/test_tracker_db.py
@@ -36,8 +36,14 @@ def _make_tracker_row(
     enabled: bool = True,
     last_error: str | None = None,
     next_check_at: datetime | None = None,
+    consecutive_permanent_failures: int = 0,
 ) -> MagicMock:
-    """Create a mock row that simulates a skill_trackers row."""
+    """Create a mock row that simulates a skill_trackers row.
+
+    Every persisted column on ``skill_trackers`` must be set here — a
+    missing attribute becomes a MagicMock and silently propagates through
+    ``_row_to_skill_tracker`` into the dataclass, hiding real bugs.
+    """
     row = MagicMock()
     row.id = tracker_id or uuid4()
     row.user_id = user_id or uuid4()
@@ -51,6 +57,7 @@ def _make_tracker_row(
     row.last_published_at = None
     row.last_error = last_error
     row.next_check_at = next_check_at
+    row.consecutive_permanent_failures = consecutive_permanent_failures
     row.created_at = datetime.now(UTC)
     return row
 
@@ -73,6 +80,15 @@ class TestRowToSkillTracker:
         row = _make_tracker_row(next_check_at=now)
         tracker = _row_to_skill_tracker(row)
         assert tracker.next_check_at == now
+
+    def test_maps_consecutive_permanent_failures(self):
+        """Regression: the mapper used to drop this column, so every
+        SkillTracker returned by ``find_skill_tracker`` / ``claim_due_trackers``
+        was silently reset to zero regardless of DB state. Callers that
+        threshold on the count would then never escalate."""
+        row = _make_tracker_row(consecutive_permanent_failures=7)
+        tracker = _row_to_skill_tracker(row)
+        assert tracker.consecutive_permanent_failures == 7
 
 
 class TestInsertSkillTracker:

--- a/shared/src/dhub_core/manifest.py
+++ b/shared/src/dhub_core/manifest.py
@@ -93,37 +93,54 @@ def parse_skill_md(path: Path) -> SkillManifest:
 def parse_frontmatter_yaml(frontmatter_str: str) -> dict:
     """Parse YAML frontmatter with a fallback for unquoted special characters.
 
-    When yaml.safe_load fails, falls back to quoting values that contain
-    markdown links [text](url) or unquoted colons, then retries parsing.
+    When ``yaml.safe_load`` fails, falls back to quoting values that contain
+    markdown links ``[text](url)`` or unquoted colons, then retries parsing.
+
+    Always returns a dict — callers can safely call ``.get()`` on the
+    result. An empty frontmatter block (``---\\n---``) or a document that
+    parses to ``None`` returns an empty dict rather than propagating
+    ``None`` which would surface as a confusing ``AttributeError`` in the
+    field-extraction code below.
     """
+    parsed: object
     try:
-        return yaml.safe_load(frontmatter_str)
+        parsed = yaml.safe_load(frontmatter_str)
     except yaml.YAMLError:
-        pass
+        # Fallback: quote values containing markdown links [text](url) which
+        # YAML misinterprets as flow sequences, then retry parsing.
+        lines = frontmatter_str.split("\n")
+        patched: list[str] = []
+        for line in lines:
+            m = re.match(r"^(\s*[\w][\w-]*:\s*)(.+)$", line)
+            if m:
+                value = m.group(2)
+                needs_quoting = (
+                    not value.startswith('"')
+                    and not value.startswith("'")
+                    and not value.startswith(">")
+                    and not value.startswith("|")
+                    and ("](" in value or (":" in value and not value.startswith("[")))
+                )
+                if needs_quoting:
+                    escaped = value.replace('"', '\\"')
+                    patched.append(f'{m.group(1)}"{escaped}"')
+                    continue
+            patched.append(line)
 
-    # Fallback: quote values containing markdown links [text](url) which
-    # YAML misinterprets as flow sequences, then retry parsing.
-    lines = frontmatter_str.split("\n")
-    patched: list[str] = []
-    for line in lines:
-        m = re.match(r"^(\s*[\w][\w-]*:\s*)(.+)$", line)
-        if m:
-            value = m.group(2)
-            needs_quoting = (
-                not value.startswith('"')
-                and not value.startswith("'")
-                and not value.startswith(">")
-                and not value.startswith("|")
-                and ("](" in value or (":" in value and not value.startswith("[")))
-            )
-            if needs_quoting:
-                escaped = value.replace('"', '\\"')
-                patched.append(f'{m.group(1)}"{escaped}"')
-                continue
-        patched.append(line)
+        patched_str = "\n".join(patched)
+        parsed = yaml.safe_load(patched_str)
 
-    patched_str = "\n".join(patched)
-    return yaml.safe_load(patched_str)
+    if parsed is None:
+        # Empty or all-blank frontmatter — return an empty mapping so
+        # downstream ``.get()`` calls do not crash. The caller's
+        # ``isinstance(data, dict)`` guard still catches the
+        # "required field 'name' is missing" case with a clear message.
+        return {}
+    # A non-mapping shape (list, scalar, tuple) still needs to reach
+    # the caller so ``isinstance(data, dict)`` can reject it with a
+    # precise error; return-type is documented as dict but callers
+    # already handle the malformed case explicitly.
+    return parsed  # type: ignore[return-value]
 
 
 def split_frontmatter(content: str) -> tuple[str, str]:

--- a/shared/tests/test_manifest.py
+++ b/shared/tests/test_manifest.py
@@ -86,6 +86,26 @@ class TestParseFrontmatterYaml:
         with pytest.raises(yaml.YAMLError):
             parse_frontmatter_yaml(":\n  :\n    - [invalid")
 
+    def test_empty_frontmatter_returns_empty_dict(self) -> None:
+        """Regression: an empty frontmatter block (``---\\n---``) used
+        to yield ``None`` from ``yaml.safe_load``, which then crashed
+        the caller with ``AttributeError`` on ``.get("name")``. The
+        parser must always hand back a mapping so downstream field
+        extraction can raise a clean 'name is missing' error instead."""
+        assert parse_frontmatter_yaml("") == {}
+        assert parse_frontmatter_yaml("\n\n") == {}
+        assert parse_frontmatter_yaml("# just a comment\n") == {}
+
+    def test_empty_frontmatter_produces_clean_error_via_parse_skill_md(self, tmp_path) -> None:
+        """End-to-end: a SKILL.md with an empty frontmatter block should
+        surface as "Required field 'name' is missing.", not a Python
+        traceback."""
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("---\n---\nBody without any metadata.")
+
+        with pytest.raises(ValueError, match="name"):
+            parse_skill_md(skill_md)
+
 
 # ---------------------------------------------------------------------------
 # parse_runtime


### PR DESCRIPTION
## What changed

Nine focused correctness and safety fixes surfaced by a full-codebase review as architect + principal engineer, each with a matching regression test. No behaviour is broadened; no new endpoints or public API surface. Every change is independently reasoned in the diff.

### Server correctness / safety

- **`database._row_to_skill_tracker`** — restore the missing `consecutive_permanent_failures` column. The row mapper silently dropped it, so every tracker returned by `find_skill_tracker` / `claim_due_trackers` / `list_skill_trackers_for_user` carried the dataclass default (`0`), hiding real failure state from every caller that thresholds on it.
- **`database.update_org_github_metadata`** — stop overwriting stored fields with `NULL` when GitHub returns null values (very common for `description` / `blog` / `email`). Only fields the caller explicitly provided reach the `UPDATE`; `github_synced_at` still advances so the sync TTL keeps ticking. An empty string is still treated as an explicit clear.
- **`registry_routes.list_eval_runs`** — filter runs by `user_id` in SQL via the new `find_eval_runs_for_version_and_user` helper instead of pulling every tenant's rows and filtering in Python. Removes cross-tenant work from the DB and cross-tenant data from request memory.
- **`registry_routes.get_eval_run`** — the post-zombie refresh could return `None` on a concurrent delete, crashing `_run_to_response` with a 500. Fall back to the pre-zombie row so the caller still gets a valid response.
- **`tracker_routes.update_tracker`** — replace the production `assert updated is not None` (stripped under `python -O`) with an explicit `HTTPException(404)` so a concurrent delete surfaces as a proper 404 rather than an `AttributeError`.

### CLI robustness

- **`config.get_token` / `get_optional_token`** — strip whitespace from the `DHUB_TOKEN` env var. A trailing newline (common with `export DHUB_TOKEN=$(cat token)`) was ending up inside the `Authorization: Bearer …` header and being rejected by the server with an opaque 400. Whitespace-only values now fall back to the saved config token.
- **`config.save_config`** — chmod the token file to `0600` (POSIX). Previously it inherited the process umask and was often world-readable, exposing the bearer token on shared hosts.
- **`config.extract_error_detail`** — new helper for tolerant error-body parsing. The publish `422` handler now uses it, so a proxy returning `text/plain` no longer crashes the CLI with `JSONDecodeError` and the "Rejected (Grade F): …" message always reaches the user.

### Shared library

- **`manifest.parse_frontmatter_yaml`** — return `{}` instead of `None` for empty or comment-only frontmatter. The caller's `isinstance(data, dict)` check still rejects lists/scalars, and an all-blank frontmatter now surfaces cleanly as `"Required field 'name' is missing"` rather than an `AttributeError` on `.get()`.

## Why

Findings from an architect + principal-engineer review pass across all four workspace packages (`server`, `client`, `shared`, `frontend`) and their test suites. The scope was chosen for the highest correctness / safety leverage per line of change; every fix is small, self-contained, and independently testable. Larger structural findings (rate-limiter proxy-IP handling, eval-log S3 read pattern, publish-pipeline transactional contract, missing `ErrorBoundary`, frontend duplication, test-pyramid gaps) are noted for follow-up PRs rather than mixed in here.

## How to test

- `make test-server` — 940 passed, 34 slow deselected.
- `make test-shared` — 100 passed.
- `make test-client` — 298 passed (excluding `client/tests/test_core/test_docx_integration.py`, whose 5 failures reproduce on the pre-change tree and are unrelated to this refactor).
- `uvx ruff@0.15.3 check .` — all checks passed.
- `uvx ruff@0.15.3 format --check .` — 186 files already formatted.

New regression tests included with each fix:

- `server/tests/test_infra/test_tracker_db.py::TestRowToSkillTracker::test_maps_consecutive_permanent_failures`
- `server/tests/test_infra/test_orgs_db.py` (new file — 4 tests on `update_org_github_metadata`)
- `server/tests/test_api/test_eval_logs.py::TestGetEvalRun::test_get_run_survives_concurrent_delete_after_zombie_check`
- `server/tests/test_api/test_eval_logs.py::TestListEvalRuns::test_list_by_version_scopes_to_current_user_in_sql`
- `server/tests/test_api/test_tracker_routes.py::TestUpdateTracker::test_update_tracker_returns_404_on_concurrent_delete`
- `client/tests/test_cli/test_config.py::TestGetToken::{test_env_var_whitespace_is_stripped,test_whitespace_only_env_var_falls_back_to_config}`
- `client/tests/test_cli/test_config.py::TestSaveConfigPermissions::test_file_has_owner_only_perms`
- `client/tests/test_cli/test_config.py::TestExtractErrorDetail` (4 tests)
- `shared/tests/test_manifest.py::TestParseFrontmatterYaml::{test_empty_frontmatter_returns_empty_dict,test_empty_frontmatter_produces_clean_error_via_parse_skill_md}`

## Checklist

- [x] Tests pass (`make test` on affected suites; server + shared + non-docx CLI green)
- [x] No breaking API changes — response shapes and status codes unchanged on happy paths; only failure modes improve (500→404, 500→200-with-valid-body, silent NULL-clobber→no-op)
- [x] No database migration needed — no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_019Xvpjdyw5mQvXhQgqbHv1P)_