### PR TITLE
refactor: rate-limit factory, subprocess safety, atomic config, query tiebreakers

### DIFF
--- a/client/src/dhub/cli/config.py
+++ b/client/src/dhub/cli/config.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import stat
+import tempfile
 from dataclasses import asdict, dataclass
 from importlib.metadata import version
 from pathlib import Path
@@ -80,16 +82,37 @@ def load_config() -> CliConfig:
 
 
 def save_config(config: CliConfig) -> None:
-    """Save CLI config to ~/.dhub/config.{env}.json.
+    """Save CLI config to ~/.dhub/config.{env}.json atomically with 0600 perms.
 
+    Writes to a temp file in the same directory, chmods to 0o600
+    (owner-only read/write, so the bearer token isn't world-readable on
+    shared machines), then atomically renames.  A crash or SIGINT
+    mid-write leaves the previous config intact instead of a truncated
+    file that would trip ``load_config``'s "corrupted config" branch.
     Creates the ~/.dhub directory if it does not already exist.
     """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = config_file()
-    path.write_text(
-        json.dumps(asdict(config), indent=2) + "\n",
-        encoding="utf-8",
+    payload = json.dumps(asdict(config), indent=2) + "\n"
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
     )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        # POSIX file modes only; on Windows this call is a no-op for
+        # group/other bits, which matches Python's own behavior.
+        os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def get_api_url() -> str:

--- a/client/src/dhub/core/git_repo.py
+++ b/client/src/dhub/core/git_repo.py
@@ -13,6 +13,33 @@ from pathlib import Path
 _GIT_URL_PREFIXES = ("https://", "http://", "git@", "ssh://", "git://")
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
 
+# Bounds on how long we'll wait for git to talk to the remote before
+# giving up.  Without this, ``dhub publish <url>`` hangs indefinitely if
+# the remote is unresponsive or a credential prompt blocks stdin.
+_GIT_CLONE_TIMEOUT_SECONDS = 300
+_GIT_CHECKOUT_TIMEOUT_SECONDS = 60
+
+
+def _run_git(cmd: list[str], *, cwd: str | None = None, timeout: int) -> subprocess.CompletedProcess[str]:
+    """Run a git subcommand with a bounded timeout, raising ``RuntimeError`` on failure.
+
+    Timeouts are surfaced as ``RuntimeError`` (not ``TimeoutExpired``)
+    so callers only have to catch one exception type.  Non-zero exits
+    are re-raised as ``RuntimeError`` with the sanitised stderr — the
+    argv is never included in the message so tokens embedded in URLs
+    stay out of user-facing errors.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"git {cmd[1]} timed out after {exc.timeout:.0f}s — remote unreachable?") from exc
+
 
 def git_url_to_https(url: str) -> str | None:
     """Convert a git-cloneable URL to an HTTPS browse URL.
@@ -66,32 +93,36 @@ def clone_repo(repo_url: str, ref: str | None = None) -> Path:
     tmp_dir = Path(tempfile.mkdtemp(prefix="dhub-repo-"))
     repo_path = tmp_dir / "repo"
 
-    if ref and _looks_like_sha(ref):
-        # Commit SHAs don't work with --depth 1 --branch; do a full
-        # clone then checkout the specific commit.
-        cmd = ["git", "clone", repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
-        checkout = subprocess.run(
-            ["git", "checkout", ref],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
-        if checkout.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
-    else:
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd += ["--branch", ref]
-        cmd += [repo_url, str(repo_path)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    try:
+        if ref and _looks_like_sha(ref):
+            # Commit SHAs don't work with --depth 1 --branch; do a full
+            # clone then checkout the specific commit.
+            result = _run_git(
+                ["git", "clone", repo_url, str(repo_path)],
+                timeout=_GIT_CLONE_TIMEOUT_SECONDS,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+            checkout = _run_git(
+                ["git", "checkout", ref],
+                cwd=str(repo_path),
+                timeout=_GIT_CHECKOUT_TIMEOUT_SECONDS,
+            )
+            if checkout.returncode != 0:
+                raise RuntimeError(f"git checkout {ref} failed:\n{checkout.stderr.strip()}")
+        else:
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd += ["--branch", ref]
+            cmd += [repo_url, str(repo_path)]
+            result = _run_git(cmd, timeout=_GIT_CLONE_TIMEOUT_SECONDS)
+            if result.returncode != 0:
+                raise RuntimeError(f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}")
+    except BaseException:
+        # Clean up the temp dir on any failure path (including
+        # KeyboardInterrupt) so we don't leak junk under /tmp.
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
 
     return repo_path
 

--- a/client/tests/test_cli/test_config.py
+++ b/client/tests/test_cli/test_config.py
@@ -1,6 +1,8 @@
 """Tests for dhub.cli.config -- CLI configuration management."""
 
 import json
+import os
+import stat
 
 import click
 import pytest
@@ -90,6 +92,49 @@ class TestSaveConfig:
 
         assert loaded.orgs == ("alice", "pymc-labs")
         assert loaded.default_org == "pymc-labs"
+
+    def test_save_is_atomic_no_tempfile_left(self, tmp_path, monkeypatch):
+        """After a successful save, no temp files should remain in the config dir."""
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://x", token="t"))
+
+        siblings = [p.name for p in tmp_path.iterdir()]
+        assert siblings == ["config.dev.json"], f"stray files left after save: {siblings}"
+
+    def test_save_writes_owner_only_permissions(self, tmp_path, monkeypatch):
+        """Config file must not be world/group readable — it holds the bearer token."""
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        save_config(CliConfig(api_url="https://x", token="secret"))
+
+        mode = stat.S_IMODE(os.stat(tmp_path / "config.dev.json").st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_save_failure_preserves_previous_file(self, tmp_path, monkeypatch):
+        """If the write blows up mid-way, the previous config must stay intact."""
+        monkeypatch.setattr("dhub.cli.config.CONFIG_DIR", tmp_path)
+        monkeypatch.setenv("DHUB_ENV", "dev")
+
+        # Write a good config first.
+        save_config(CliConfig(api_url="https://old", token="old-tok"))
+
+        # Force os.replace to fail; the previous file must still be readable.
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("dhub.cli.config.os.replace", _boom)
+
+        with pytest.raises(OSError, match="disk full"):
+            save_config(CliConfig(api_url="https://new", token="new-tok"))
+
+        loaded = load_config()
+        assert loaded.token == "old-tok"
+        # No stray temp files were left behind either.
+        siblings = [p.name for p in tmp_path.iterdir()]
+        assert siblings == ["config.dev.json"]
 
     def test_backward_compat_no_orgs_field(self, tmp_path, monkeypatch):
         """Loading old config without orgs field should use defaults."""

--- a/client/tests/test_core/test_git_repo.py
+++ b/client/tests/test_core/test_git_repo.py
@@ -1,8 +1,12 @@
 """Tests for dhub.core.git_repo -- clone and skill discovery."""
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from dhub.core.git_repo import discover_skills
+import pytest
+
+from dhub.core.git_repo import clone_repo, discover_skills
 
 
 class TestDiscoverSkills:
@@ -73,3 +77,44 @@ class TestDiscoverSkills:
         result = discover_skills(tmp_path)
         names = [p.name for p in result]
         assert names == sorted(names)
+
+
+class TestCloneRepoTimeout:
+    """clone_repo must never block indefinitely on an unresponsive remote."""
+
+    def test_clone_timeout_raises_runtime_error(self) -> None:
+        """A hung `git clone` surfaces as a friendly RuntimeError, not TimeoutExpired."""
+        with patch("dhub.core.git_repo.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git", "clone"], timeout=300)
+            with pytest.raises(RuntimeError, match="timed out"):
+                clone_repo("https://github.com/example/hangs.git")
+
+    def test_clone_passes_timeout_to_subprocess(self) -> None:
+        """The subprocess call is invoked with a bounded timeout keyword."""
+        with patch("dhub.core.git_repo.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "clone"], returncode=0, stdout="", stderr=""
+            )
+            clone_repo("https://github.com/example/repo.git")
+            # Any positive timeout is fine — the point is that we pass one.
+            _, kwargs = mock_run.call_args
+            assert kwargs.get("timeout", 0) > 0
+
+    def test_clone_cleans_tmpdir_on_timeout(self, tmp_path: Path) -> None:
+        """Timed-out clones don't leak stale directories under /tmp."""
+        seen_paths: list[Path] = []
+
+        def _fake_run(cmd, **kwargs):
+            # Grab the destination path git was told to write to so we can
+            # assert on it after the failure surfaces.
+            seen_paths.append(Path(cmd[-1]).parent)
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        with (
+            patch("dhub.core.git_repo.subprocess.run", side_effect=_fake_run),
+            pytest.raises(RuntimeError),
+        ):
+            clone_repo("https://github.com/example/hangs.git")
+
+        assert seen_paths, "expected clone_repo to invoke git at least once"
+        assert not seen_paths[0].exists(), "tmp dir should be removed after timeout"

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -26,16 +26,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = rate_limit_dep("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -1,10 +1,30 @@
-"""In-memory sliding-window rate limiter for FastAPI dependencies."""
+"""In-memory sliding-window rate limiter for FastAPI dependencies.
+
+The public helper is :func:`rate_limit_dep`, which returns a FastAPI
+dependency that lazily instantiates one :class:`RateLimiter` per named
+bucket on the app state. Endpoints wire it up like::
+
+    dependencies=[Depends(rate_limit_dep("search"))]
+
+The bucket name (``"search"``) drives two conventions:
+
+* the settings fields ``<bucket>_rate_limit`` / ``<bucket>_rate_window``
+* the app-state attribute ``_rate_limiter_<bucket>`` for reuse
+
+This replaces the previous pattern of writing a dedicated
+``_enforce_<bucket>_rate_limit`` helper per endpoint — 9 near-identical
+copies had grown across ``registry_routes``, ``search_routes``, and
+``auth_routes``.
+"""
 
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+from decision_hub.settings import Settings
 
 
 class RateLimiter:
@@ -26,11 +46,17 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # Prune stale IP buckets every N accepted requests. Kept as a class
+    # attribute so tests can lower it without patching the module.
+    _PURGE_INTERVAL: int = 256
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        # Cheap O(1) counter — avoids sum() over every bucket per request.
+        self._accepted_since_purge = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -40,9 +66,13 @@ class RateLimiter:
         with self._lock:
             # Prune expired timestamps for this key
             timestamps = self._requests[key]
-            self._requests[key] = [t for t in timestamps if t > cutoff]
+            fresh = [t for t in timestamps if t > cutoff]
 
-            if len(self._requests[key]) >= self.max_requests:
+            if len(fresh) >= self.max_requests:
+                # Overwrite so the freshly pruned list is retained even
+                # when we reject — avoids unbounded growth for a hot
+                # attacker IP.
+                self._requests[key] = fresh
                 raise HTTPException(
                     status_code=429,
                     detail=(
@@ -50,16 +80,56 @@ class RateLimiter:
                     ),
                 )
 
-            self._requests[key].append(now)
+            fresh.append(now)
+            self._requests[key] = fresh
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            # Periodically drop IPs with no recent activity. Runs off a
+            # simple accepted-request counter so it's O(1) per request
+            # instead of the old O(N-buckets) sum.
+            self._accepted_since_purge += 1
+            if self._accepted_since_purge >= self._PURGE_INTERVAL:
                 self._purge_stale(cutoff)
+                self._accepted_since_purge = 0
 
     def _purge_stale(self, cutoff: float) -> None:
         """Remove IPs with no recent activity. Caller must hold self._lock."""
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+def _get_or_create_limiter(request: Request, bucket: str) -> RateLimiter:
+    """Return the RateLimiter for *bucket*, creating it on first use.
+
+    Reads ``<bucket>_rate_limit`` and ``<bucket>_rate_window`` from
+    ``app.state.settings`` and caches the limiter under
+    ``app.state._rate_limiter_<bucket>``.
+    """
+    state = request.app.state
+    attr = f"_rate_limiter_{bucket}"
+    limiter = getattr(state, attr, None)
+    if limiter is None:
+        settings: Settings = state.settings
+        limiter = RateLimiter(
+            max_requests=getattr(settings, f"{bucket}_rate_limit"),
+            window_seconds=getattr(settings, f"{bucket}_rate_window"),
+        )
+        setattr(state, attr, limiter)
+    return limiter
+
+
+def rate_limit_dep(bucket: str) -> Callable[[Request], None]:
+    """Return a FastAPI dependency that rate-limits requests for *bucket*.
+
+    ``bucket`` names the settings pair (``<bucket>_rate_limit`` /
+    ``<bucket>_rate_window``) and the cached app-state attribute
+    (``_rate_limiter_<bucket>``). One helper per bucket replaces the
+    previous per-endpoint ``_enforce_*_rate_limit`` copies.
+    """
+
+    def _enforce(request: Request) -> None:
+        _get_or_create_limiter(request, bucket)(request)
+
+    _enforce.__name__ = f"enforce_{bucket}_rate_limit"
+    _enforce.__doc__ = f"Rate-limit dependency for the {bucket!r} bucket."
+    return _enforce

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -6,7 +6,7 @@ import zipfile
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -19,7 +19,7 @@ from decision_hub.api.deps import (
     get_s3_client,
     get_settings,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,88 +83,16 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
+# Rate limiters — one FastAPI dependency per bucket, all sharing the
+# common factory in decision_hub.api.rate_limit. Each name matches the
+# ``<bucket>_rate_limit`` / ``<bucket>_rate_window`` pair in Settings.
+_enforce_list_skills_rate_limit = rate_limit_dep("list_skills")
+_enforce_resolve_rate_limit = rate_limit_dep("resolve")
+_enforce_similar_skills_rate_limit = rate_limit_dep("similar_skills")
+_enforce_download_rate_limit = rate_limit_dep("download")
+_enforce_audit_log_rate_limit = rate_limit_dep("audit_log")
+_enforce_scan_report_rate_limit = rate_limit_dep("scan_report")
+_enforce_publish_rate_limit = rate_limit_dep("publish")
 
 
 _VALID_VISIBILITIES = {"public", "org"}
@@ -893,7 +821,11 @@ def get_scan_report(
 
     latest_semver = version.semver
     report = find_scan_report_for_version(conn, version.id)
-    if report is None:
+    if report is None and not semver:
+        # Only fall back to "latest for the skill" when the caller didn't
+        # ask for a specific version. If they did, and that version has no
+        # scan report, returning some other version's findings would
+        # display stale severity/badges against a fresh version.
         report = find_latest_scan_report_for_skill(conn, org_slug, skill_name)
     if report is None:
         return None

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import rate_limit_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -29,16 +29,7 @@ from decision_hub.settings import Settings
 router = APIRouter(prefix="/v1", tags=["search"])
 
 
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = rate_limit_dep("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/infra/database.py
+++ b/server/src/decision_hub/infra/database.py
@@ -2040,7 +2040,10 @@ def search_skills_hybrid(
             ]
         )
         fts_stmt = fts_stmt.where(skills_table.c.search_vector.op("@@")(combined_tsquery))
-        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC")).limit(limit)
+        # Tiebreak on skills.id so equal-rank rows page deterministically —
+        # short queries and near-duplicate descriptions produce many equal
+        # ts_rank_cd scores, which the old ORDER BY did not disambiguate.
+        fts_stmt = fts_stmt.order_by(sa.text("fts_rank DESC"), skills_table.c.id).limit(limit)
         fts_rows = conn.execute(fts_stmt).all()
 
     # --- 2. Vector query (if embedding available) ---
@@ -2052,7 +2055,10 @@ def search_skills_hybrid(
             ]
         )
         vec_stmt = vec_stmt.where(skills_table.c.embedding.isnot(None))
-        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC")).limit(limit)
+        # Same tiebreaker rationale as the FTS branch above: duplicate
+        # embeddings (auto-synced forks, near-identical descriptions) yield
+        # identical distances and would otherwise page nondeterministically.
+        vec_stmt = vec_stmt.order_by(sa.text("vec_dist ASC"), skills_table.c.id).limit(limit)
         vec_rows = conn.execute(vec_stmt).all()
 
     # --- 3. Union + dedup (vector first, then FTS-only) ---
@@ -2125,7 +2131,7 @@ def fetch_similar_skills(
                 )
             ),
         )
-        .order_by(sa.text("vec_dist ASC"))
+        .order_by(sa.text("vec_dist ASC"), skills_table.c.id)
         .limit(limit)
     )
     rows = conn.execute(vec_stmt).all()
@@ -3249,7 +3255,14 @@ def insert_tracker_metrics(
 
 def list_tracker_metrics(conn: Connection, *, limit: int = 50) -> list[TrackerMetrics]:
     """Return recent tracker metrics rows, newest first."""
-    stmt = sa.select(tracker_metrics_table).order_by(tracker_metrics_table.c.recorded_at.desc()).limit(limit)
+    stmt = (
+        sa.select(tracker_metrics_table)
+        # Tiebreak on id so LIMIT with equal recorded_at (same-tick rows)
+        # yields a deterministic order — otherwise pagination on the
+        # trackers dashboard can skip or duplicate rows.
+        .order_by(tracker_metrics_table.c.recorded_at.desc(), tracker_metrics_table.c.id.desc())
+        .limit(limit)
+    )
     rows = conn.execute(stmt).all()
     return [_row_to_tracker_metrics(row) for row in rows]
 

--- a/server/src/decision_hub/infra/github.py
+++ b/server/src/decision_hub/infra/github.py
@@ -22,6 +22,12 @@ GITHUB_USER_ORGS_URL = "https://api.github.com/user/orgs"
 
 _ACCEPT_JSON = "application/json"
 
+# All outbound GitHub calls share a single timeout so a stalled github.com
+# can never hang an auth request forever (which used to keep a request-scoped
+# DB connection open and starve the pool). Matches the 30s timeout that
+# github_client.py already uses for its sync counterpart.
+_GITHUB_HTTP_TIMEOUT = 30
+
 
 class AuthorizationPending(Exception):
     """Raised when the user has not yet completed GitHub authorization."""
@@ -44,7 +50,7 @@ async def request_device_code(client_id: str) -> DeviceCodeResponse:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.post(
             GITHUB_DEVICE_CODE_URL,
             data={"client_id": client_id, "scope": "read:org"},
@@ -79,7 +85,7 @@ async def poll_for_access_token(client_id: str, device_code: str, interval: int 
         RuntimeError: If the user denies access or the device code expires.
         httpx.HTTPStatusError: If the GitHub API returns an unexpected error.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.post(
             GITHUB_ACCESS_TOKEN_URL,
             data={
@@ -123,7 +129,7 @@ async def get_github_user(access_token: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             GITHUB_USER_URL,
             headers={
@@ -168,7 +174,7 @@ async def list_user_orgs(access_token: str) -> list[dict]:
     orgs: list[dict] = []
     url: str | None = f"{GITHUB_USER_ORGS_URL}?per_page=100"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         while url is not None:
             response = await client.get(
                 url,
@@ -201,7 +207,7 @@ async def check_org_membership(access_token: str, org: str, username: str) -> bo
     Returns:
         True if the user is a member of the organization.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org}/members/{username}",
             headers={
@@ -235,7 +241,7 @@ async def fetch_org_metadata(access_token: str, org_login: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/orgs/{org_login}",
             headers={
@@ -270,7 +276,7 @@ async def fetch_user_metadata(access_token: str, username: str) -> dict:
     Raises:
         httpx.HTTPStatusError: If the GitHub API returns an error response.
     """
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_GITHUB_HTTP_TIMEOUT) as client:
         response = await client.get(
             f"https://api.github.com/users/{username}",
             headers={

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -1,11 +1,12 @@
 """Tests for decision_hub.api.rate_limit -- per-IP sliding-window rate limiter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, rate_limit_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,91 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_sliding_window_expires_oldest_slot(self) -> None:
+        """Half-window advance frees exactly one slot — sliding, not fixed."""
+        limiter = RateLimiter(max_requests=3, window_seconds=60)
+        request = _make_request()
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            limiter(request)  # slot at t=1000
+            mock_time.monotonic.return_value = 1020.0
+            limiter(request)  # slot at t=1020
+            mock_time.monotonic.return_value = 1040.0
+            limiter(request)  # slot at t=1040
+
+            # At t=1061 the t=1000 slot has aged out (>60s), leaving 2
+            # slots in the window. A new request should be accepted.
+            mock_time.monotonic.return_value = 1061.0
+            limiter(request)
+
+            # But a second request in that same tick puts us at 3
+            # active slots (1020, 1040, 1061) — the next one 429s.
+            with pytest.raises(HTTPException):
+                limiter(request)
+
+    def test_purges_stale_ip_buckets_after_threshold(self) -> None:
+        """Bounded memory: idle IP buckets get evicted after PURGE_INTERVAL requests."""
+        limiter = RateLimiter(max_requests=1000, window_seconds=1)
+        limiter._PURGE_INTERVAL = 5  # tighten for the test
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            # Populate a bunch of one-shot IPs, all in the same tick.
+            for i in range(4):
+                limiter(_make_request(f"10.0.0.{i}"))
+            assert len(limiter._requests) == 4
+
+            # Advance past the window so those IPs are stale, then hit
+            # the purge threshold from a new IP.
+            mock_time.monotonic.return_value = 1002.0
+            limiter(_make_request("10.0.1.1"))
+            # The 5th accepted request triggers the purge; only the
+            # fresh 10.0.1.1 bucket should survive.
+            assert list(limiter._requests) == ["10.0.1.1"]
+
+
+class TestRateLimitDep:
+    """Tests for the rate_limit_dep factory."""
+
+    def _make_request_with_state(self, host: str = "127.0.0.1"):
+        """Build a Request with the settings/state attributes rate_limit_dep reads."""
+        settings = SimpleNamespace(
+            demo_rate_limit=2,
+            demo_rate_window=60,
+        )
+        state = SimpleNamespace(settings=settings)
+        request = MagicMock()
+        request.client.host = host
+        request.app.state = state
+        return request, state
+
+    def test_dep_lazily_creates_one_limiter_per_bucket(self) -> None:
+        dep = rate_limit_dep("demo")
+        request, state = self._make_request_with_state()
+
+        assert not hasattr(state, "_rate_limiter_demo")
+        dep(request)
+        first = state._rate_limiter_demo
+        assert isinstance(first, RateLimiter)
+        assert first.max_requests == 2
+        assert first.window_seconds == 60
+
+        # A second call re-uses the cached limiter instance.
+        dep(request)
+        assert state._rate_limiter_demo is first
+
+    def test_dep_shares_bucket_across_endpoints_with_same_name(self) -> None:
+        """Two dependencies for the same bucket share one limiter."""
+        dep_a = rate_limit_dep("demo")
+        dep_b = rate_limit_dep("demo")
+        request, state = self._make_request_with_state()
+
+        dep_a(request)
+        dep_b(request)  # exhausts the 2-per-window budget
+        with pytest.raises(HTTPException) as exc:
+            dep_b(request)
+        assert exc.value.status_code == 429
+        # And only one limiter was cached.
+        assert state._rate_limiter_demo is state._rate_limiter_demo


### PR DESCRIPTION
## What changed

A focused, review-driven cleanup covering four small, testable items motivated by rules in `CLAUDE.md` or concrete failure modes surfaced during a deep-dive code review. No behavior changes visible at API contract or CLI UX level.

**Server**
- Collapsed **9 near-identical `_enforce_*_rate_limit` helpers** across `registry_routes.py`, `search_routes.py`, `auth_routes.py` into a single factory `rate_limit_dep(bucket)` in `api/rate_limit.py`. Reads `<bucket>_rate_limit` / `<bucket>_rate_window` from `Settings` and caches one limiter per bucket on `app.state`. Net −90 lines of boilerplate; adding a new rate-limited endpoint is now one line.
- **Rate limiter perf**: replaced the O(N-buckets) `sum(len(v) for v in ...)` scan in the request path with an O(1) accepted-request counter, and retained the pruned timestamp list on the 429 path so a hot attacker IP can't grow the bucket unbounded (`api/rate_limit.py`).
- **httpx timeouts** on every `AsyncClient` in `infra/github.py` (30s, matching the sync counterpart in `github_client.py`). Without them a stalled `github.com` would hang `POST /auth/github/token`, keeping the request-scoped DB connection open — the exact hang path the `CLIVersionMiddleware` docstring warns about.
- **Query determinism**: added `skills.id` / `tracker_metrics.id` tiebreakers to the FTS + vector `ORDER BY ... LIMIT` queries in `search_skills_hybrid` (`infra/database.py:2043,2055`), `fetch_similar_skills` (`:2128`), and `list_tracker_metrics` (`:3252`). Equal-rank / equal-distance / same-tick rows now page deterministically — per the `CLAUDE.md` "SQL query correctness" rule.
- **Scan report correctness**: `GET /v1/skills/{org}/{skill}/scan-report?semver=X` no longer silently falls back to some other version's scan when the requested version has no report. The fallback (`find_latest_scan_report_for_skill`) is now only used when the caller didn't specify a version. Prevents stale severity badges being displayed against a fresh version in the UI.

**Client**
- **`clone_repo` subprocess safety** (`core/git_repo.py`): every `subprocess.run` now has a bounded timeout (300 s for `git clone`, 60 s for `git checkout`), and `subprocess.TimeoutExpired` is mapped to a friendly `RuntimeError` with no argv leakage. Temp dir is cleaned on any failure path including `KeyboardInterrupt`. Matches the `CLAUDE.md` "Sanitize subprocess credentials" and "catch TimeoutExpired / CalledProcessError" rules — a hostile git server or unresponsive remote used to hang `dhub publish <url>` forever.
- **`save_config` atomic write** (`cli/config.py`): writes to a sibling tempfile, `chmod 0o600`, then `os.replace`s over the real config. A crash / SIGINT mid-write no longer leaves a truncated `~/.dhub/config.dev.json` that would trip the "corrupted config" branch on the next command, and the bearer token is no longer world-readable on shared machines.

**Tests** (+10 new, all pass)
- `RateLimiter` sliding-window boundary + bucket-purge threshold; `rate_limit_dep` lazy creation + shared-bucket-per-name.
- `clone_repo` timeout maps to `RuntimeError`, timeout kwarg is passed, tmpdir cleaned on timeout.
- `save_config` atomicity (no stray tempfiles), 0o600 mode, previous file preserved on failed replace.

## Why

Scheduled review pass identified these as the highest-leverage, lowest-risk items across the codebase. Every change either enforces an existing `CLAUDE.md` rule or fixes a concrete failure scenario (token leak on shared machine, indefinite hang on unresponsive remote, non-deterministic pagination, stale scan-report display). Closes #

## How to test

```bash
# Focused
uv run --package decision-hub-server --extra dev pytest server/tests/test_api/test_rate_limit.py -v
uv run --package dhub-cli --extra dev pytest client/tests/test_core/test_git_repo.py client/tests/test_cli/test_config.py -v

# Broader regression sweep (all pass on this branch)
uv run --package decision-hub-server --extra dev pytest server/tests/test_api/ -q --no-cov
uv run --package dhub-core --extra dev pytest shared/tests/ -q --no-cov
uvx ruff@0.15.3 check .
uvx mypy client/src/ server/src/ shared/src/
```

Manual smoke:
- Publish a skill against dev — rate limiter should behave identically (`X-RateLimit-*` unchanged, 429 message unchanged).
- Search on dev — pagination stays stable across identical-relevance results.
- `dhub login` on a shared machine — check `stat -c %a ~/.dhub/config.dev.json` is `600`.

## Checklist
- [x] Tests pass (server API 230/230, client core+cli 26/26, shared 98/98; 5 pre-existing `test_docx_integration.py` failures on `main` unrelated to this diff)
- [x] No breaking API changes (rate-limiter buckets and settings names unchanged; scan-report change is a defensive tightening for a specific-semver query that previously returned misleading data)
- [x] Database migration included (if schema changed) — n/a, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_014zUrJSRre9UdfhkvURQoHT)_