### PR TITLE
fix(frontend): guard useApi refetch race; stabilize useSEO deps; add hook tests

### DIFF
--- a/frontend/src/hooks/useApi.test.ts
+++ b/frontend/src/hooks/useApi.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useApi } from "./useApi";
 
@@ -40,10 +40,118 @@ describe("useApi", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.data).toBe("call-1");
 
-    result.current.refetch();
+    await act(async () => {
+      result.current.refetch();
+    });
 
     await waitFor(() => expect(result.current.data).toBe("call-2"));
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it("refetch() ignores an older in-flight response when called again", async () => {
+    // Regression: two rapid refetch()es (double-clicked retry button, or
+    // refetch() followed by a deps-driven reload) used to let whichever
+    // Promise resolved LAST win — usually the slower first one — so the
+    // UI silently showed stale data. Both calls must be tagged and only
+    // the most recent may write to state.
+    const resolvers: Array<(v: string) => void> = [];
+    const fetcher = vi.fn(
+      () => new Promise<string>((resolve) => resolvers.push(resolve)),
+    );
+    const { result } = renderHook(() => useApi(fetcher));
+
+    // Wait for the mount effect to actually invoke the fetcher, then
+    // settle it — the race we care about is between the two subsequent
+    // refetch()es, not the mount fetch.
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resolvers[0]("initial");
+    });
+    expect(result.current.data).toBe("initial");
+
+    // Two refetches in quick succession.
+    act(() => {
+      result.current.refetch();
+      result.current.refetch();
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(3));
+
+    // Resolve them in REVERSE order so the older refetch lands last.
+    await act(async () => {
+      resolvers[2]("newer");
+      resolvers[1]("older");
+    });
+
+    // The newer refetch must win, not whichever resolved last.
+    expect(result.current.data).toBe("newer");
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("refetch() error from stale call does not overwrite fresh success", async () => {
+    // Same failure mode, error path: an older fetch that rejects late
+    // must not blank out the successful data from a newer fetch.
+    const resolvers: Array<(v: string) => void> = [];
+    const rejectors: Array<(e: Error) => void> = [];
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          resolvers.push(resolve);
+          rejectors.push(reject);
+        }),
+    );
+    const { result } = renderHook(() => useApi(fetcher));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resolvers[0]("initial");
+    });
+
+    act(() => {
+      result.current.refetch();
+      result.current.refetch();
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      resolvers[2]("fresh");
+      rejectors[1](new Error("stale failure"));
+    });
+
+    expect(result.current.data).toBe("fresh");
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("late-resolving initial fetch does not overwrite refetch() result", async () => {
+    // If the caller triggers refetch() while the mount fetch is still in
+    // flight, the mount fetch's response must be discarded when it
+    // eventually resolves.
+    const resolvers: Array<(v: string) => void> = [];
+    const fetcher = vi.fn(
+      () => new Promise<string>((resolve) => resolvers.push(resolve)),
+    );
+    const { result } = renderHook(() => useApi(fetcher));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+
+    // Refetch BEFORE the mount fetch resolves.
+    act(() => {
+      result.current.refetch();
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolvers[1]("refetch-result");
+    });
+    expect(result.current.data).toBe("refetch-result");
+
+    // Now let the mount fetch finally resolve. Without the staleness
+    // guard, this would clobber "refetch-result".
+    await act(async () => {
+      resolvers[0]("stale-mount-result");
+    });
+
+    expect(result.current.data).toBe("refetch-result");
   });
 });

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 interface UseApiResult<T> {
   data: T | null;
@@ -12,36 +12,53 @@ export function useApi<T>(fetcher: () => Promise<T>, deps: unknown[] = []): UseA
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Manual refetch (no staleness guard — caller triggers intentionally)
-  const refetch = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    fetcher()
-      .then(setData)
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  // Monotonically-increasing fetch id. Every in-flight request captures
+  // the id it started with and is silently ignored on resolution when a
+  // newer one has been issued. Guards against two independent races:
+  //   1. Deps change while a fetch is in flight — old response would
+  //      otherwise overwrite the new one.
+  //   2. refetch() is called twice quickly (double-click on a retry
+  //      button, or refetch() + subsequent deps change) — without this,
+  //      whichever fetch resolves last wins, not the most recent one.
+  const fetchIdRef = useRef(0);
 
-  // Auto-fetch on dep changes with staleness guard to prevent
-  // old responses from overwriting newer ones when deps change rapidly.
-  useEffect(() => {
-    let cancelled = false;
+  const refetch = useCallback(() => {
+    const id = ++fetchIdRef.current;
     setLoading(true);
     setError(null);
     fetcher()
       .then((result) => {
-        if (!cancelled) setData(result);
+        if (id !== fetchIdRef.current) return;
+        setData(result);
       })
       .catch((err) => {
-        if (!cancelled) setError(err.message);
+        if (id !== fetchIdRef.current) return;
+        setError(err.message);
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (id !== fetchIdRef.current) return;
+        setLoading(false);
       });
-    return () => {
-      cancelled = true;
-    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  useEffect(() => {
+    const id = ++fetchIdRef.current;
+    setLoading(true);
+    setError(null);
+    fetcher()
+      .then((result) => {
+        if (id !== fetchIdRef.current) return;
+        setData(result);
+      })
+      .catch((err) => {
+        if (id !== fetchIdRef.current) return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (id !== fetchIdRef.current) return;
+        setLoading(false);
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 

--- a/frontend/src/hooks/useLocalStorage.test.ts
+++ b/frontend/src/hooks/useLocalStorage.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLocalStorage } from "./useLocalStorage";
+
+// Map-backed localStorage stub — jsdom's is flaky under Node 22 in the
+// same way `useRecentlyViewed.test.ts` documents.
+let store: Record<string, string>;
+const storageMock: Storage = {
+  get length() {
+    return Object.keys(store).length;
+  },
+  key(i: number) {
+    return Object.keys(store)[i] ?? null;
+  },
+  getItem(k: string) {
+    return store[k] ?? null;
+  },
+  setItem(k: string, v: string) {
+    store[k] = v;
+  },
+  removeItem(k: string) {
+    delete store[k];
+  },
+  clear() {
+    store = {};
+  },
+};
+
+describe("useLocalStorage", () => {
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal("localStorage", storageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the initial value when localStorage is empty", () => {
+    const { result } = renderHook(() => useLocalStorage("k", "fallback"));
+    expect(result.current[0]).toBe("fallback");
+  });
+
+  it("reads and JSON-parses an existing value", () => {
+    localStorage.setItem("k", JSON.stringify({ n: 42 }));
+    const { result } = renderHook(() =>
+      useLocalStorage<{ n: number }>("k", { n: 0 }),
+    );
+    expect(result.current[0]).toEqual({ n: 42 });
+  });
+
+  it("falls back to initial when the stored value is corrupt JSON", () => {
+    // Regression: a hand-edited or half-written localStorage entry
+    // used to crash the whole page with SyntaxError. The initializer
+    // must swallow parse errors and hand back the caller's fallback.
+    localStorage.setItem("k", "not-json{{{");
+    const { result } = renderHook(() => useLocalStorage("k", "default"));
+    expect(result.current[0]).toBe("default");
+  });
+
+  it("setter persists the new value and updates state", () => {
+    const { result } = renderHook(() => useLocalStorage<number>("k", 0));
+
+    act(() => result.current[1](7));
+
+    expect(result.current[0]).toBe(7);
+    expect(JSON.parse(localStorage.getItem("k")!)).toBe(7);
+  });
+
+  it("setter supports the (prev) => next functional form", () => {
+    const { result } = renderHook(() => useLocalStorage<number>("k", 10));
+
+    act(() => result.current[1]((prev) => prev + 5));
+
+    expect(result.current[0]).toBe(15);
+    expect(JSON.parse(localStorage.getItem("k")!)).toBe(15);
+  });
+
+  it("survives a localStorage quota error without throwing", () => {
+    // Some browsers throw QuotaExceededError on setItem when the tab's
+    // storage budget is full (Safari private mode is the classic case).
+    // The hook must swallow the error so the UI keeps rendering — the
+    // value still lives in React state even if it can't be persisted.
+    const setItem = vi.fn(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    vi.stubGlobal("localStorage", { ...storageMock, setItem });
+
+    const { result } = renderHook(() => useLocalStorage<string>("k", "a"));
+
+    expect(() => act(() => result.current[1]("b"))).not.toThrow();
+    expect(result.current[0]).toBe("b");
+  });
+});

--- a/frontend/src/hooks/useSEO.test.ts
+++ b/frontend/src/hooks/useSEO.test.ts
@@ -1,0 +1,153 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSEO } from "./useSEO";
+
+const DEFAULT_TITLE = "Decision Hub - Skill Registry for AI Agents";
+const DEFAULT_DESCRIPTION =
+  "Decision Hub is the skill registry for AI coding agents. Every skill is automatically evaluated in a sandbox, security-graded A through F, and searchable in natural language.";
+const BASE_URL = "https://hub.decision.ai";
+const JSON_LD_ID = "seo-json-ld";
+
+function metaContent(attribute: "name" | "property", key: string): string | null {
+  const el = document.querySelector<HTMLMetaElement>(
+    `meta[${attribute}="${key}"]`,
+  );
+  return el?.getAttribute("content") ?? null;
+}
+
+function canonicalHref(): string | null {
+  const el = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  // Read the raw attribute, not the resolved `.href` — jsdom normalises
+  // absolute-URL hrefs by appending a trailing slash, which would make
+  // the assertion depend on browser URL-parsing quirks rather than what
+  // the component actually wrote.
+  return el?.getAttribute("href") ?? null;
+}
+
+function jsonLdContent(): string | null {
+  const el = document.getElementById(JSON_LD_ID) as HTMLScriptElement | null;
+  return el?.textContent ?? null;
+}
+
+describe("useSEO", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.title = "";
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = "";
+    document.title = "";
+  });
+
+  it("sets document.title, meta description, OG, Twitter, canonical", () => {
+    renderHook(() =>
+      useSEO({
+        title: "Skills",
+        description: "Browse the registry",
+        path: "/skills",
+      }),
+    );
+
+    expect(document.title).toBe("Skills | Decision Hub");
+    expect(metaContent("name", "description")).toBe("Browse the registry");
+    expect(metaContent("property", "og:title")).toBe("Skills | Decision Hub");
+    expect(metaContent("property", "og:description")).toBe("Browse the registry");
+    expect(metaContent("property", "og:url")).toBe(`${BASE_URL}/skills`);
+    expect(metaContent("name", "twitter:title")).toBe("Skills | Decision Hub");
+    expect(metaContent("name", "twitter:description")).toBe("Browse the registry");
+    expect(canonicalHref()).toBe(`${BASE_URL}/skills`);
+  });
+
+  it("falls back to defaults when title/description/path omitted", () => {
+    renderHook(() => useSEO({}));
+
+    expect(document.title).toBe(DEFAULT_TITLE);
+    expect(metaContent("name", "description")).toBe(DEFAULT_DESCRIPTION);
+    expect(canonicalHref()).toBe(BASE_URL);
+  });
+
+  it("restores defaults on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useSEO({ title: "Page", description: "Body", path: "/x" }),
+    );
+
+    expect(document.title).toBe("Page | Decision Hub");
+
+    unmount();
+
+    expect(document.title).toBe(DEFAULT_TITLE);
+    expect(metaContent("name", "description")).toBe(DEFAULT_DESCRIPTION);
+    expect(canonicalHref()).toBe(BASE_URL);
+  });
+
+  it("injects JSON-LD as an application/ld+json script tag", () => {
+    const ld = {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "Test",
+    };
+    renderHook(() => useSEO({ path: "/", jsonLd: ld }));
+
+    const el = document.getElementById(JSON_LD_ID) as HTMLScriptElement | null;
+    expect(el).not.toBeNull();
+    expect(el?.type).toBe("application/ld+json");
+    expect(el?.textContent && JSON.parse(el.textContent)).toEqual(ld);
+  });
+
+  it("removes the JSON-LD script tag on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useSEO({ path: "/", jsonLd: { a: 1 } }),
+    );
+
+    expect(document.getElementById(JSON_LD_ID)).not.toBeNull();
+
+    unmount();
+
+    expect(document.getElementById(JSON_LD_ID)).toBeNull();
+  });
+
+  it("does not re-run the effect when jsonLd is a fresh object with same content", () => {
+    // Regression: the deps array used to include the jsonLd object
+    // reference. Consumers that forgot to wrap the object in useMemo
+    // would pass a new reference on every parent render — the effect
+    // would re-run, its cleanup would flash the tags back to defaults
+    // before writing them again, and the <script> tag would briefly
+    // disappear. Guard by depending on the serialized JSON-LD.
+    const initialLd = { "@type": "WebSite", name: "Test" };
+    const { rerender } = renderHook(({ jsonLd }) => useSEO({ jsonLd }), {
+      initialProps: { jsonLd: initialLd },
+    });
+
+    const scriptBefore = document.getElementById(JSON_LD_ID);
+    expect(scriptBefore).not.toBeNull();
+    const contentBefore = jsonLdContent();
+
+    // Re-render with a NEW object reference but equivalent content.
+    rerender({ jsonLd: { "@type": "WebSite", name: "Test" } });
+
+    // Same physical element must survive — if the cleanup+re-run cycle
+    // fired, the element would be a fresh one (identity !==).
+    const scriptAfter = document.getElementById(JSON_LD_ID);
+    expect(scriptAfter).toBe(scriptBefore);
+    expect(jsonLdContent()).toBe(contentBefore);
+  });
+
+  it("does update JSON-LD when the content actually changes", () => {
+    const { rerender } = renderHook(({ jsonLd }) => useSEO({ jsonLd }), {
+      initialProps: { jsonLd: { "@type": "WebSite", name: "A" } },
+    });
+
+    expect(jsonLdContent() && JSON.parse(jsonLdContent()!)).toEqual({
+      "@type": "WebSite",
+      name: "A",
+    });
+
+    rerender({ jsonLd: { "@type": "WebSite", name: "B" } });
+
+    expect(jsonLdContent() && JSON.parse(jsonLdContent()!)).toEqual({
+      "@type": "WebSite",
+      name: "B",
+    });
+  });
+});

--- a/frontend/src/hooks/useSEO.ts
+++ b/frontend/src/hooks/useSEO.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 const SITE_NAME = "Decision Hub";
 const BASE_URL = "https://hub.decision.ai";
@@ -69,6 +69,14 @@ function setJsonLd(data: Record<string, unknown> | undefined) {
  * Call once per page component. Tags are restored to defaults on unmount.
  */
 export function useSEO({ title, description, path, jsonLd }: SEOProps) {
+  // Depend on the serialized JSON-LD, not the object reference. Consumers
+  // that forget to wrap the object in useMemo would otherwise pass a
+  // fresh reference on every parent render — the effect would re-run,
+  // its cleanup would fire, and the browser would see title/canonical/OG
+  // tags flicker and the JSON-LD <script> tag briefly disappear on every
+  // keystroke or state change in the parent.
+  const jsonLdKey = useMemo(() => (jsonLd ? JSON.stringify(jsonLd) : ""), [jsonLd]);
+
   useEffect(() => {
     const fullTitle = title ? `${title} | ${SITE_NAME}` : `${SITE_NAME} - Skill Registry for AI Agents`;
     const desc = description ?? DEFAULT_DESCRIPTION;
@@ -91,8 +99,9 @@ export function useSEO({ title, description, path, jsonLd }: SEOProps) {
     // Canonical
     setCanonical(url);
 
-    // JSON-LD
-    setJsonLd(jsonLd);
+    // JSON-LD — parse from the serialized key so the DOM write is
+    // driven by the same value as the dep-array comparison.
+    setJsonLd(jsonLdKey ? (JSON.parse(jsonLdKey) as Record<string, unknown>) : undefined);
 
     return () => {
       // Restore defaults on unmount so navigating away resets
@@ -106,5 +115,5 @@ export function useSEO({ title, description, path, jsonLd }: SEOProps) {
       setCanonical(BASE_URL);
       setJsonLd(undefined);
     };
-  }, [title, description, path, jsonLd]);
+  }, [title, description, path, jsonLdKey]);
 }


### PR DESCRIPTION
## What changed

Two frontend-hook correctness fixes plus test coverage for three hooks that were previously untested or under-tested.

### 1. `useApi.refetch()` — staleness guard on every call *(bug fix)*

The previous implementation only cancelled the auto-fetch effect on deps change; `refetch()` had **no in-flight id**, so two rapid `refetch()` calls (double-clicked retry button, or `refetch()` immediately followed by a deps-driven reload) would let whichever `Promise` resolved **last** win — typically the slower, older one. The UI silently showed stale data with no error surfaced. A late-resolving mount fetch could also clobber a fresh `refetch()` result.

**Fix:** a single monotonic `fetchIdRef` captured by every call site (mount effect and `refetch`). Only the resolution whose captured id still matches the current one writes to state; older ones are discarded on both success and error paths.

### 2. `useSEO({ jsonLd })` — depend on serialized content, not object reference *(defensive)*

The deps array included the raw `jsonLd` object. Consumers who pass an inline object literal (or an object built without `useMemo`) hand a fresh reference on every parent render. The effect re-runs, its cleanup fires first — flashing `document.title`, meta description, canonical, and Open Graph tags back to site defaults, and removing the JSON-LD `<script>` tag — before writing them again on every keystroke or state change in the parent.

Today `HomePage` and `SkillDetailPage` happen to memoize `jsonLd`, so production is clean — but it's a footgun with no lint rule to catch it, and the recon pass flagged `useSEO` as fully untested.

**Fix:** memoize `JSON.stringify(jsonLd)` and depend on that key. Equivalent JSON-LD objects compare equal; the effect only re-runs when serialized content actually changes. The DOM write uses `JSON.parse(key)` so what's written matches what was compared.

### 3. New test coverage

- `useApi.test.ts`: **3 new tests** for the refetch race, the error-path race, and the late-resolving mount-vs-refetch race. Existing `refetch() resets loading` test wrapped in `act()` to drop the pre-existing warning.
- `useSEO.test.ts` *(new file, 7 tests)*: title / meta description / canonical / OG / Twitter / JSON-LD injection, unmount restore, JSON-LD script tag removal, the "stable DOM identity across equivalent re-renders" regression, and content-change updates.
- `useLocalStorage.test.ts` *(new file, 6 tests)*: read/write, initial-value fallback, corrupt-JSON recovery, functional-updater form, and `QuotaExceededError` survival (Safari private-mode behavior).

## Why

Test coverage gap flagged during a principal-engineer review pass — `useSEO`, `useLocalStorage`, `useInfiniteScroll`, and `useCountUp` are all currently untested. This PR closes two of those and fixes the two real correctness bugs found while auditing the same code. Follows the recent series of surgical review-driven PRs (#436–#445).

## How to test

```bash
cd frontend
npm install                      # if first time
npx vitest run                   # 98/98 tests pass
npx tsc -b                       # clean
npx eslint src/hooks             # clean
```

Manual verification of the `useSEO` fix: on a page that passes `jsonLd`, trigger a parent re-render (e.g. type in a search box). Before this PR, the JSON-LD `<script>` tag identity in DevTools changes on every keystroke; after, it stays stable.

## Checklist
- [x] Tests pass (`make test-frontend` — 98/98)
- [x] No breaking API changes (internal hook implementation only)
- [x] No database migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wJ9zJk35zXvU89TkJT3At

---
_Generated by [Claude Code](https://claude.ai/code/session_016wJ9zJk35zXvU89TkJT3At)_