### PR TITLE
Fix rate-limiter races, retry bugs, and other correctness issues

### DIFF
--- a/server/src/decision_hub/api/app.py
+++ b/server/src/decision_hub/api/app.py
@@ -12,6 +12,7 @@ from loguru import logger
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from decision_hub.api.deps import get_current_user
+from decision_hub.api.rate_limit import RateLimiters
 from decision_hub.infra.database import create_engine
 from decision_hub.infra.storage import create_s3_client
 from decision_hub.logging import RequestLoggingMiddleware, setup_logging
@@ -158,6 +159,10 @@ def create_app() -> FastAPI:
     app.state.engine = engine
     app.state.settings = settings
     app.state.s3_client = s3_client
+
+    # Rate limiters are constructed eagerly here so route dependencies can
+    # look them up by name without racing (see api/rate_limit.py).
+    app.state.rate_limiters = RateLimiters(settings)
 
     # In-memory TTL cache for hot read paths (per-container, not shared
     # across Modal replicas).

--- a/server/src/decision_hub/api/auth_routes.py
+++ b/server/src/decision_hub/api/auth_routes.py
@@ -1,13 +1,13 @@
 """Authentication routes - GitHub Device Flow login."""
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 
 from decision_hub.api.deps import get_connection, get_engine, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import limiter_dep
 from decision_hub.domain.auth import create_jwt
 from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs
 from decision_hub.infra.database import upsert_user
@@ -25,17 +25,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-
-def _enforce_auth_rate_limit(request: Request) -> None:
-    """Rate-limit auth endpoints."""
-    state = request.app.state
-    if not hasattr(state, "_auth_rate_limiter"):
-        settings: Settings = state.settings
-        state._auth_rate_limiter = RateLimiter(
-            max_requests=settings.auth_rate_limit,
-            window_seconds=settings.auth_rate_window,
-        )
-    state._auth_rate_limiter(request)
+_enforce_auth_rate_limit = limiter_dep("auth")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/deps.py
+++ b/server/src/decision_hub/api/deps.py
@@ -50,6 +50,17 @@ def get_connection(
         yield conn
 
 
+def parse_uuid_or_422(value: str, name: str) -> UUID:
+    """Parse a UUID string, raising HTTP 422 with a clear message on invalid input.
+
+    Shared between route modules so callers don't reinvent the same helper.
+    """
+    try:
+        return UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
+
+
 def get_current_user(
     request: Request,
     settings: Settings = Depends(get_settings),

--- a/server/src/decision_hub/api/rate_limit.py
+++ b/server/src/decision_hub/api/rate_limit.py
@@ -1,10 +1,22 @@
-"""In-memory sliding-window rate limiter for FastAPI dependencies."""
+"""In-memory sliding-window rate limiter for FastAPI dependencies.
+
+Each named limiter is built once at application startup from the matching
+``<name>_rate_limit`` / ``<name>_rate_window`` fields on :class:`Settings`.
+Route modules ask for the limiter by name via :func:`limiter_dep`, which
+returns a FastAPI dependency callable — no per-route boilerplate, no
+lazy ``hasattr`` initialisation on ``app.state`` (which raced when two
+threads first hit an endpoint concurrently, silently discarding the loser's
+counter).
+"""
 
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request
+
+from decision_hub.settings import Settings
 
 
 class RateLimiter:
@@ -26,11 +38,22 @@ class RateLimiter:
         def search(...): ...
     """
 
+    # Purge stale IP buckets every N requests. Amortises O(n_ips) work
+    # across many cheap O(1) request checks so a bursty-IP attack cannot
+    # inflate the per-request cost.
+    _PURGE_EVERY = 100
+
     def __init__(self, max_requests: int, window_seconds: int) -> None:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self._requests: dict[str, list[float]] = defaultdict(list)
         self._lock = threading.Lock()
+        # Monotonic counter of admitted requests -- used to trigger the
+        # periodic purge. sum(len(v) for v in ...) previously ran per
+        # request under the lock (O(n_ips)) and could easily never land
+        # on exactly 100, so the purge fired at unpredictable intervals
+        # or not at all.
+        self._request_count = 0
 
     def __call__(self, request: Request) -> None:
         key = request.client.host if request.client else "unknown"
@@ -52,10 +75,8 @@ class RateLimiter:
 
             self._requests[key].append(now)
 
-            # Periodically purge stale IPs to bound memory growth.
-            # Check every 100 requests (cheap modulo on list length).
-            total = sum(len(v) for v in self._requests.values())
-            if total % 100 == 0:
+            self._request_count += 1
+            if self._request_count % self._PURGE_EVERY == 0:
                 self._purge_stale(cutoff)
 
     def _purge_stale(self, cutoff: float) -> None:
@@ -63,3 +84,65 @@ class RateLimiter:
         stale = [k for k, v in self._requests.items() if not v or v[-1] < cutoff]
         for k in stale:
             del self._requests[k]
+
+
+class RateLimiters:
+    """Container of eagerly-constructed named rate limiters.
+
+    One instance is built in :func:`create_app` from :class:`Settings` and
+    attached to ``app.state.rate_limiters``. Named limiters are looked up
+    at import time by route modules via :func:`limiter_dep`.
+
+    Attribute names follow the convention ``<name>_rate_limit`` /
+    ``<name>_rate_window`` on :class:`Settings` (e.g. ``publish`` reads
+    ``publish_rate_limit`` and ``publish_rate_window``). Adding a new
+    limiter is one entry in ``_NAMES`` here plus the pair of settings
+    fields.
+    """
+
+    _NAMES: tuple[str, ...] = (
+        "auth",
+        "search",
+        "list_skills",
+        "resolve",
+        "similar_skills",
+        "download",
+        "audit_log",
+        "scan_report",
+        "publish",
+    )
+
+    def __init__(self, settings: Settings) -> None:
+        self._limiters: dict[str, RateLimiter] = {}
+        for name in self._NAMES:
+            self._limiters[name] = RateLimiter(
+                max_requests=getattr(settings, f"{name}_rate_limit"),
+                window_seconds=getattr(settings, f"{name}_rate_window"),
+            )
+
+    def get(self, name: str) -> RateLimiter:
+        try:
+            return self._limiters[name]
+        except KeyError as exc:
+            raise KeyError(f"Unknown rate limiter '{name}'. Known: {sorted(self._limiters)}") from exc
+
+
+def limiter_dep(name: str) -> Callable[[Request], None]:
+    """Return a FastAPI dependency that enforces the named rate limiter.
+
+    Usage::
+
+        @router.get("/foo", dependencies=[Depends(limiter_dep("resolve"))])
+        def foo(...): ...
+
+    Resolution happens per request via ``request.app.state.rate_limiters``
+    so the returned callable is safe to bind at module import time — the
+    settings-driven limiters do not need to exist yet.
+    """
+
+    def _dep(request: Request) -> None:
+        limiters: RateLimiters = request.app.state.rate_limiters
+        limiters.get(name)(request)
+
+    _dep.__name__ = f"enforce_{name}_rate_limit"
+    return _dep

--- a/server/src/decision_hub/api/registry_routes.py
+++ b/server/src/decision_hub/api/registry_routes.py
@@ -4,9 +4,8 @@ import json
 import math
 import zipfile
 from datetime import UTC, datetime
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection
@@ -18,8 +17,9 @@ from decision_hub.api.deps import (
     get_current_user_optional,
     get_s3_client,
     get_settings,
+    parse_uuid_or_422,
 )
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import limiter_dep
 from decision_hub.api.registry_service import (
     require_org_membership,
 )
@@ -83,99 +83,7 @@ router = APIRouter(prefix="/v1", tags=["registry"])
 public_router = APIRouter(prefix="/v1", tags=["registry"])
 
 
-def _enforce_list_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the skills list endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_list_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._list_skills_rate_limiter = RateLimiter(
-            max_requests=settings.list_skills_rate_limit,
-            window_seconds=settings.list_skills_rate_window,
-        )
-    state._list_skills_rate_limiter(request)
-
-
-def _enforce_resolve_rate_limit(request: Request) -> None:
-    """Rate-limit the resolve endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_resolve_rate_limiter"):
-        settings: Settings = state.settings
-        state._resolve_rate_limiter = RateLimiter(
-            max_requests=settings.resolve_rate_limit,
-            window_seconds=settings.resolve_rate_window,
-        )
-    state._resolve_rate_limiter(request)
-
-
-def _enforce_similar_skills_rate_limit(request: Request) -> None:
-    """Rate-limit the similar skills endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_similar_skills_rate_limiter"):
-        settings: Settings = state.settings
-        state._similar_skills_rate_limiter = RateLimiter(
-            max_requests=settings.similar_skills_rate_limit,
-            window_seconds=settings.similar_skills_rate_window,
-        )
-    state._similar_skills_rate_limiter(request)
-
-
-def _enforce_download_rate_limit(request: Request) -> None:
-    """Rate-limit the download endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_download_rate_limiter"):
-        settings: Settings = state.settings
-        state._download_rate_limiter = RateLimiter(
-            max_requests=settings.download_rate_limit,
-            window_seconds=settings.download_rate_window,
-        )
-    state._download_rate_limiter(request)
-
-
-def _enforce_audit_log_rate_limit(request: Request) -> None:
-    """Rate-limit the audit log endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_audit_log_rate_limiter"):
-        settings: Settings = state.settings
-        state._audit_log_rate_limiter = RateLimiter(
-            max_requests=settings.audit_log_rate_limit,
-            window_seconds=settings.audit_log_rate_window,
-        )
-    state._audit_log_rate_limiter(request)
-
-
-def _enforce_scan_report_rate_limit(request: Request) -> None:
-    """Rate-limit the scan report endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_scan_report_rate_limiter"):
-        settings: Settings = state.settings
-        state._scan_report_rate_limiter = RateLimiter(
-            max_requests=settings.scan_report_rate_limit,
-            window_seconds=settings.scan_report_rate_window,
-        )
-    state._scan_report_rate_limiter(request)
-
-
-def _enforce_publish_rate_limit(request: Request) -> None:
-    """Rate-limit the publish endpoint."""
-    state = request.app.state
-    if not hasattr(state, "_publish_rate_limiter"):
-        settings: Settings = state.settings
-        state._publish_rate_limiter = RateLimiter(
-            max_requests=settings.publish_rate_limit,
-            window_seconds=settings.publish_rate_window,
-        )
-    state._publish_rate_limiter(request)
-
-
 _VALID_VISIBILITIES = {"public", "org"}
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a UUID string, raising 422 with a clear message on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid UUID for {name}: '{value}'") from None
 
 
 # ---------------------------------------------------------------------------
@@ -452,7 +360,7 @@ _STALE_HEARTBEAT_SECONDS = 300
 # also requires ``await zip_file.read()`` which deadlocks under
 # BaseHTTPMiddleware (see CLIVersionMiddleware docstring in app.py).
 @router.post(
-    "/publish", response_model=PublishResponse, status_code=201, dependencies=[Depends(_enforce_publish_rate_limit)]
+    "/publish", response_model=PublishResponse, status_code=201, dependencies=[Depends(limiter_dep("publish"))]
 )
 def publish_skill(
     metadata: str = Form(...),
@@ -556,6 +464,7 @@ def publish_skill(
 
 @public_router.get(
     "/stats",
+    dependencies=[Depends(limiter_dep("list_skills"))],
 )
 def get_registry_stats(
     response: Response,
@@ -569,7 +478,7 @@ def get_registry_stats(
 @public_router.get(
     "/skills",
     response_model=PaginatedSkillsResponse,
-    dependencies=[Depends(_enforce_list_skills_rate_limit)],
+    dependencies=[Depends(limiter_dep("list_skills"))],
 )
 def list_skills(
     page: int = Query(1, ge=1),
@@ -642,6 +551,7 @@ def list_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/summary",
     response_model=SkillSummary,
+    dependencies=[Depends(limiter_dep("list_skills"))],
 )
 def get_skill_summary(
     org_slug: str,
@@ -686,7 +596,7 @@ def get_skill_summary(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/similar",
     response_model=list[SimilarSkillRef],
-    dependencies=[Depends(_enforce_similar_skills_rate_limit)],
+    dependencies=[Depends(limiter_dep("similar_skills"))],
 )
 def get_similar_skills(
     org_slug: str,
@@ -718,6 +628,7 @@ def get_similar_skills(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/latest-version",
     response_model=LatestVersionResponse,
+    dependencies=[Depends(limiter_dep("resolve"))],
 )
 def get_latest_version(
     org_slug: str,
@@ -739,7 +650,7 @@ def get_latest_version(
 @public_router.get(
     "/resolve/{org_slug}/{skill_name}",
     response_model=ResolveResponse,
-    dependencies=[Depends(_enforce_resolve_rate_limit)],
+    dependencies=[Depends(limiter_dep("resolve"))],
 )
 def resolve_skill(
     org_slug: str,
@@ -785,7 +696,7 @@ def resolve_skill(
 
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/download",
-    dependencies=[Depends(_enforce_download_rate_limit)],
+    dependencies=[Depends(limiter_dep("download"))],
 )
 def download_skill(
     org_slug: str,
@@ -820,7 +731,7 @@ def download_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/audit-log",
     response_model=PaginatedAuditLogResponse,
-    dependencies=[Depends(_enforce_audit_log_rate_limit)],
+    dependencies=[Depends(limiter_dep("audit_log"))],
 )
 def get_audit_log(
     org_slug: str,
@@ -867,7 +778,7 @@ def get_audit_log(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/scan-report",
     response_model=ScanReportResponse | None,
-    dependencies=[Depends(_enforce_scan_report_rate_limit)],
+    dependencies=[Depends(limiter_dep("scan_report"))],
 )
 def get_scan_report(
     org_slug: str,
@@ -955,6 +866,7 @@ def get_scan_report(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(limiter_dep("audit_log"))],
 )
 def get_eval_report_by_skill(
     org_slug: str,
@@ -977,6 +889,7 @@ def get_eval_report_by_skill(
 @public_router.get(
     "/skills/{org_slug}/{skill_name}/versions/{semver}/eval-report",
     response_model=EvalReportResponse | None,
+    dependencies=[Depends(limiter_dep("audit_log"))],
 )
 def get_eval_report_by_version_path(
     org_slug: str,
@@ -1127,7 +1040,7 @@ def get_eval_run(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunResponse:
     """Get eval run metadata by run ID."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid_or_422(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
@@ -1147,7 +1060,7 @@ def get_eval_run_logs(
     current_user: User = Depends(get_current_user),
 ) -> EvalRunLogsResponse:
     """Get eval run log events with cursor-based pagination."""
-    parsed_id = _parse_uuid(run_id, "run_id")
+    parsed_id = parse_uuid_or_422(run_id, "run_id")
     run = find_eval_run(conn, parsed_id)
     if run is None or run.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Eval run not found")
@@ -1196,7 +1109,7 @@ def list_eval_runs(
 ) -> list[EvalRunResponse]:
     """List eval runs, optionally filtered by version ID."""
     if version_id is not None:
-        parsed_vid = _parse_uuid(version_id, "version_id")
+        parsed_vid = parse_uuid_or_422(version_id, "version_id")
         runs = find_eval_runs_for_version(conn, parsed_vid)
         runs = [r for r in runs if r.user_id == current_user.id]
     else:

--- a/server/src/decision_hub/api/search_routes.py
+++ b/server/src/decision_hub/api/search_routes.py
@@ -7,13 +7,13 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.engine import Connection, Engine
 
 from decision_hub.api.deps import get_connection, get_current_user_optional, get_engine, get_s3_client, get_settings
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import limiter_dep
 from decision_hub.domain.search import build_index_entry, format_trust_score, resolve_author_display, serialize_index
 from decision_hub.infra.database import insert_search_log, list_user_org_ids, search_skills_hybrid
 from decision_hub.infra.embeddings import EMBEDDING_DIMENSIONS, embed_query
@@ -28,17 +28,7 @@ from decision_hub.settings import Settings
 
 router = APIRouter(prefix="/v1", tags=["search"])
 
-
-def _enforce_search_rate_limit(request: Request) -> None:
-    """Rate-limit the search endpoint. Limiter is initialised lazily from settings."""
-    state = request.app.state
-    if not hasattr(state, "_search_rate_limiter"):
-        settings: Settings = state.settings
-        state._search_rate_limiter = RateLimiter(
-            max_requests=settings.search_rate_limit,
-            window_seconds=settings.search_rate_window,
-        )
-    state._search_rate_limiter(request)
+_enforce_search_rate_limit = limiter_dep("search")
 
 
 # ---------------------------------------------------------------------------

--- a/server/src/decision_hub/api/tracker_routes.py
+++ b/server/src/decision_hub/api/tracker_routes.py
@@ -1,7 +1,6 @@
 """CRUD API routes for skill trackers."""
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger
@@ -9,7 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from decision_hub.api.deps import get_connection, get_current_user, get_settings
+from decision_hub.api.deps import get_connection, get_current_user, get_settings, parse_uuid_or_422
 from decision_hub.domain.tracker import (
     build_canonical_repo_url,
     check_repo_accessible,
@@ -87,14 +86,6 @@ def _tracker_to_response(tracker) -> TrackerResponse:
         last_error=tracker.last_error,
         created_at=tracker.created_at.isoformat() if tracker.created_at else None,
     )
-
-
-def _parse_uuid(value: str, name: str) -> UUID:
-    """Parse a string as UUID, raising HTTP 422 on invalid input."""
-    try:
-        return UUID(value)
-    except ValueError:
-        raise HTTPException(status_code=422, detail=f"Invalid {name}: {value}") from None
 
 
 def _resolve_org_slug(conn: Connection, user: User, org_slug: str | None) -> str:
@@ -210,7 +201,7 @@ def get_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Get details of a specific tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_or_422(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -225,7 +216,7 @@ def update_tracker(
     user: User = Depends(get_current_user),
 ) -> TrackerResponse:
     """Update a tracker's settings."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_or_422(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")
@@ -273,7 +264,7 @@ def delete_tracker(
     user: User = Depends(get_current_user),
 ) -> None:
     """Remove a tracker."""
-    tid = _parse_uuid(tracker_id, "tracker_id")
+    tid = parse_uuid_or_422(tracker_id, "tracker_id")
     tracker = find_skill_tracker(conn, tid)
     if tracker is None or tracker.user_id != user.id:
         raise HTTPException(status_code=404, detail="Tracker not found")

--- a/server/src/decision_hub/domain/orgs.py
+++ b/server/src/decision_hub/domain/orgs.py
@@ -8,25 +8,6 @@ from sqlalchemy.engine import Connection
 
 from dhub_core.validation import _SLUG_PATTERN, validate_org_slug  # noqa: F401 — re-exported
 
-VALID_ROLES: tuple[str, ...] = ("owner", "admin", "member")
-
-
-def validate_role(role: str) -> str:
-    """Validate that a role is one of the allowed values.
-
-    Args:
-        role: The role string to validate.
-
-    Returns:
-        The validated role.
-
-    Raises:
-        ValueError: If the role is not in VALID_ROLES.
-    """
-    if role not in VALID_ROLES:
-        raise ValueError(f"Invalid role '{role}': must be one of {VALID_ROLES}.")
-    return role
-
 
 def sync_user_orgs(
     conn: Connection,

--- a/server/src/decision_hub/infra/anthropic_client.py
+++ b/server/src/decision_hub/infra/anthropic_client.py
@@ -5,9 +5,14 @@ avoiding a heavy SDK dependency.
 """
 
 import json
+import re
 
 import httpx
 from loguru import logger
+
+# Judge responses sometimes come back wrapped in a markdown fence.
+# Compile once at module import -- this fires per eval case.
+_JUDGE_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*\n?(.*?)```", re.DOTALL)
 
 _ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 
@@ -82,11 +87,8 @@ def _parse_judge_response(raw_text: str) -> dict:
 
     Handles JSON wrapped in markdown code blocks (```json ... ```).
     """
-    import re
-
-    # Strip markdown code block wrappers if present
     cleaned = raw_text.strip()
-    match = re.search(r"```(?:json)?\s*\n?(.*?)```", cleaned, re.DOTALL)
+    match = _JUDGE_JSON_FENCE_RE.search(cleaned)
     if match:
         cleaned = match.group(1).strip()
 

--- a/server/src/decision_hub/infra/cache.py
+++ b/server/src/decision_hub/infra/cache.py
@@ -65,16 +65,6 @@ class TTLCache:
                 expires_at=time.monotonic() + ttl,
             )
 
-    def invalidate(self, key: str) -> None:
-        """Remove a specific key from the cache."""
-        with self._lock:
-            self._store.pop(key, None)
-
-    def clear(self) -> None:
-        """Remove all entries."""
-        with self._lock:
-            self._store.clear()
-
     def _evict_one(self) -> None:
         """Evict one entry: prefer expired, then oldest. Caller holds lock."""
         now = time.monotonic()

--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -62,7 +62,20 @@ def create_gemini_client(api_key: str, *, http_client: httpx.Client | None = Non
     }
 
 
-_RETRIABLE_STATUS_CODES = {403, 429, 500, 502, 503}
+_RETRIABLE_STATUS_CODES = {429, 500, 502, 503}
+
+
+def _is_retriable_403(resp: httpx.Response) -> bool:
+    """Return True when a 403 response indicates a transient rate/quota error.
+
+    Gemini uses 403 for both quota exhaustion (transient — retry) and
+    invalid/disabled API keys (permanent — fail fast). Without this check
+    every request with a rotated-but-not-updated key wastes ~7s retrying
+    before failing.
+    """
+    body = resp.text or ""
+    upper = body.upper()
+    return "RESOURCE_EXHAUSTED" in upper or "RATE" in upper or "QUOTA" in upper
 
 
 def gemini_request_with_retry(
@@ -123,7 +136,8 @@ def gemini_request_with_retry(
         if resp.status_code < 400:
             return resp.json()
 
-        if resp.status_code not in _RETRIABLE_STATUS_CODES:
+        retriable = resp.status_code in _RETRIABLE_STATUS_CODES or (resp.status_code == 403 and _is_retriable_403(resp))
+        if not retriable:
             resp.raise_for_status()
 
         last_exc = httpx.HTTPStatusError(

--- a/server/src/decision_hub/infra/gemini.py
+++ b/server/src/decision_hub/infra/gemini.py
@@ -65,6 +65,12 @@ def create_gemini_client(api_key: str, *, http_client: httpx.Client | None = Non
 _RETRIABLE_STATUS_CODES = {429, 500, 502, 503}
 
 
+# Google's canonical error statuses that mean "come back later".
+_RETRIABLE_403_STATUSES = {"RESOURCE_EXHAUSTED", "UNAVAILABLE"}
+# Phrases used in quota/rate messages that lack a machine-readable status.
+_RETRIABLE_403_PHRASES = ("rate limit", "ratelimit", "quota", "too many requests")
+
+
 def _is_retriable_403(resp: httpx.Response) -> bool:
     """Return True when a 403 response indicates a transient rate/quota error.
 
@@ -72,10 +78,28 @@ def _is_retriable_403(resp: httpx.Response) -> bool:
     invalid/disabled API keys (permanent — fail fast). Without this check
     every request with a rotated-but-not-updated key wastes ~7s retrying
     before failing.
+
+    Match on the structured ``error.status`` first and fall back to whole
+    phrases in ``error.message``. Scanning the raw body for bare substrings
+    would misfire — "RATE" is contained in "GENERATE", so a PERMISSION_DENIED
+    message mentioning generation would look retriable.
     """
-    body = resp.text or ""
-    upper = body.upper()
-    return "RESOURCE_EXHAUSTED" in upper or "RATE" in upper or "QUOTA" in upper
+    error: object = {}
+    try:
+        body = resp.json()
+    except ValueError:
+        body = None
+    if isinstance(body, dict):
+        error = body.get("error", {})
+
+    message = ""
+    if isinstance(error, dict):
+        if str(error.get("status", "")).upper() in _RETRIABLE_403_STATUSES:
+            return True
+        message = str(error.get("message", ""))
+
+    haystack = (message or resp.text or "").lower()
+    return any(phrase in haystack for phrase in _RETRIABLE_403_PHRASES)
 
 
 def gemini_request_with_retry(

--- a/server/src/decision_hub/infra/github_client.py
+++ b/server/src/decision_hub/infra/github_client.py
@@ -82,15 +82,24 @@ class GitHubClient:
 
         Raises ``httpx.HTTPStatusError`` on non-2xx responses and
         ``ValueError`` when the response contains GraphQL-level errors.
+
+        Uses the pooled client's connection pool -- calling module-level
+        ``httpx.post`` forced a fresh TCP+TLS handshake per batch and
+        leaked short-lived clients until GC ran.
         """
         self._wait_for_rate_limit()
         payload: dict = {"query": query}
         if variables:
             payload["variables"] = variables
-        headers = {"Accept": "application/json"}
-        if self._token:
-            headers["Authorization"] = f"Bearer {self._token}"
-        resp = httpx.post(GITHUB_GRAPHQL, json=payload, headers=headers, timeout=30)
+        # The base_url on self._client is GITHUB_API (REST). GraphQL lives
+        # on a different absolute URL, so we pass the full URL and let httpx
+        # ignore the base for absolute URLs. Auth + accept headers come from
+        # the client's defaults.
+        resp = self._client.post(
+            GITHUB_GRAPHQL,
+            json=payload,
+            headers={"Accept": "application/json"},
+        )
         self._update_rate_limit(resp)
         resp.raise_for_status()
         body = resp.json()

--- a/server/src/decision_hub/scripts/backfill_embeddings.py
+++ b/server/src/decision_hub/scripts/backfill_embeddings.py
@@ -54,6 +54,11 @@ def backfill(batch_size: int = 100) -> None:
                     )
                 )
                 .where(skills_table.c.embedding.is_(None))
+                # ORDER BY id is required per CLAUDE.md: LIMIT without a
+                # unique tiebreaker is nondeterministic. Without it a
+                # retry after a failing batch could pick a different set
+                # of rows and loop forever.
+                .order_by(skills_table.c.id)
                 .limit(batch_size)
             )
             rows = conn.execute(stmt).all()

--- a/server/src/decision_hub/scripts/crawler/checkpoint.py
+++ b/server/src/decision_hub/scripts/crawler/checkpoint.py
@@ -6,6 +6,7 @@ Flushes every N results to balance durability vs. I/O at scale.
 """
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -24,12 +25,20 @@ class Checkpoint:
     _flush_counter: int = field(default=0, repr=False)
 
     def save(self, path: Path) -> None:
-        """Write checkpoint to disk."""
+        """Write checkpoint to disk atomically.
+
+        Writes to a sibling ``.tmp`` file first, then ``os.replace``s it
+        into place. A SIGKILL/OOM between calls to ``save`` cannot leave
+        a half-written JSON file on disk -- the module docstring calls
+        the crawler "crash-safe" and now actually is.
+        """
         data = {
             "discovered_repos": self.discovered_repos,
             "processed_repos": self.processed_repos,
         }
-        path.write_text(json.dumps(data, indent=2))
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        os.replace(tmp, path)
 
     @classmethod
     def load(cls, path: Path) -> "Checkpoint":

--- a/server/tests/test_api/conftest.py
+++ b/server/tests/test_api/conftest.py
@@ -13,6 +13,7 @@ from decision_hub.api.auth_routes import router as auth_router
 from decision_hub.api.deps import get_current_user
 from decision_hub.api.keys_routes import router as keys_router
 from decision_hub.api.org_routes import org_public_router, org_router
+from decision_hub.api.rate_limit import RateLimiters
 from decision_hub.api.registry_routes import public_router as registry_public_router
 from decision_hub.api.registry_routes import router as registry_router
 from decision_hub.api.taxonomy_routes import public_router as taxonomy_public_router
@@ -52,6 +53,8 @@ def test_settings() -> MagicMock:
     settings.publish_rate_window = 60
     settings.auth_rate_limit = 10
     settings.auth_rate_window = 60
+    settings.scan_report_rate_limit = 30
+    settings.scan_report_rate_window = 60
     # Cache TTLs
     settings.cache_ttl_taxonomy = 300
     settings.cache_ttl_org_profiles = 60
@@ -71,6 +74,9 @@ def test_app(test_settings: MagicMock) -> FastAPI:
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
     app.state.cache = TTLCache(default_ttl=60)
+    # Mirror production create_app(): named limiters are eagerly built
+    # from settings so limiter_dep() can look them up per request.
+    app.state.rate_limiters = RateLimiters(test_settings)
 
     @app.middleware("http")
     async def check_cli_version(request: Request, call_next):

--- a/server/tests/test_api/test_app_auth.py
+++ b/server/tests/test_api/test_app_auth.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from decision_hub.api.deps import get_current_user
 from decision_hub.api.keys_routes import router as keys_router
 from decision_hub.api.org_routes import org_router
+from decision_hub.api.rate_limit import RateLimiters
 from decision_hub.api.registry_routes import router as registry_router
 from decision_hub.api.tracker_routes import router as tracker_router
 
@@ -40,17 +41,16 @@ def _make_app(require_github_org: str = "") -> FastAPI:
         [o.strip() for o in require_github_org.split(",") if o.strip()] if require_github_org else []
     )
     settings.min_cli_version = ""
-    settings.list_skills_rate_limit = 30
-    settings.list_skills_rate_window = 60
-    settings.resolve_rate_limit = 30
-    settings.resolve_rate_window = 60
-    settings.download_rate_limit = 10
-    settings.download_rate_window = 60
+    # RateLimiters iterates every known name — provide sane defaults.
+    for _name in RateLimiters._NAMES:
+        setattr(settings, f"{_name}_rate_limit", 30)
+        setattr(settings, f"{_name}_rate_window", 60)
 
     app = FastAPI()
     app.state.settings = settings
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
+    app.state.rate_limiters = RateLimiters(settings)
 
     # Mirror the unconditional auth wiring from create_app()
     write_deps = [Depends(get_current_user)]

--- a/server/tests/test_api/test_rate_limit.py
+++ b/server/tests/test_api/test_rate_limit.py
@@ -3,9 +3,10 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
-from decision_hub.api.rate_limit import RateLimiter
+from decision_hub.api.rate_limit import RateLimiter, RateLimiters, limiter_dep
 
 
 def _make_request(host: str = "127.0.0.1") -> MagicMock:
@@ -84,3 +85,103 @@ class TestRateLimiter:
         with pytest.raises(HTTPException) as exc_info:
             limiter(request)
         assert exc_info.value.status_code == 429
+
+    def test_purge_uses_monotonic_counter(self) -> None:
+        """Purging fires every N requests via a counter, not sum-of-lens.
+
+        Regression: the old implementation triggered on
+        ``sum(len(v) for v in self._requests.values()) % 100 == 0``,
+        which can easily skip 100 (e.g. counter goes 99 → 101 when the
+        same IP gets pruned before adding). It also ran O(n_ips) work
+        under the lock on every request.
+        """
+        limiter = RateLimiter(max_requests=1000, window_seconds=60)
+
+        with patch("decision_hub.api.rate_limit.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+
+            # Populate a stale bucket that will be purged
+            stale_req = _make_request("10.0.0.99")
+            limiter(stale_req)
+
+            # Advance time so the stale bucket's timestamp is now outside
+            # the window when the next purge runs.
+            mock_time.monotonic.return_value = 1100.0
+
+            # Fire exactly _PURGE_EVERY admissions from a different IP so
+            # the counter reaches the purge threshold.
+            active_req = _make_request("10.0.0.1")
+            for _ in range(RateLimiter._PURGE_EVERY):
+                limiter(active_req)
+
+            # Stale bucket must have been dropped despite never being
+            # the target of the check-and-purge loop.
+            assert "10.0.0.99" not in limiter._requests
+
+    def test_over_limit_admissions_do_not_advance_counter(self) -> None:
+        """Rejected requests must not bump the request counter.
+
+        Otherwise an attacker over the limit could still trigger the
+        (locked) purge sweep on every rejected request.
+        """
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        req = _make_request()
+        limiter(req)  # counter = 1
+        for _ in range(5):
+            with pytest.raises(HTTPException):
+                limiter(req)
+        # Rejections raised before the counter increment, so it stayed at 1.
+        assert limiter._request_count == 1
+
+
+class TestRateLimiters:
+    """The named-container wired up at app startup."""
+
+    def test_builds_all_known_limiters_from_settings(self) -> None:
+        settings = MagicMock()
+        # Every known name reads two settings fields; give them all values.
+        for name in RateLimiters._NAMES:
+            setattr(settings, f"{name}_rate_limit", 5)
+            setattr(settings, f"{name}_rate_window", 60)
+
+        limiters = RateLimiters(settings)
+
+        for name in RateLimiters._NAMES:
+            got = limiters.get(name)
+            assert isinstance(got, RateLimiter)
+            assert got.max_requests == 5
+            assert got.window_seconds == 60
+
+    def test_unknown_name_raises_key_error(self) -> None:
+        settings = MagicMock()
+        for name in RateLimiters._NAMES:
+            setattr(settings, f"{name}_rate_limit", 5)
+            setattr(settings, f"{name}_rate_window", 60)
+        limiters = RateLimiters(settings)
+        with pytest.raises(KeyError):
+            limiters.get("nonexistent")
+
+
+class TestLimiterDep:
+    """FastAPI dependency wiring."""
+
+    def test_limiter_dep_enforces_limit_via_app_state(self) -> None:
+        """Route with limiter_dep('resolve') should 429 the fourth call."""
+        settings = MagicMock()
+        for name in RateLimiters._NAMES:
+            setattr(settings, f"{name}_rate_limit", 3 if name == "resolve" else 100)
+            setattr(settings, f"{name}_rate_window", 60)
+
+        app = FastAPI()
+        app.state.rate_limiters = RateLimiters(settings)
+
+        from fastapi import Depends
+
+        @app.get("/probe", dependencies=[Depends(limiter_dep("resolve"))])
+        def _probe() -> dict:
+            return {"ok": True}
+
+        client = TestClient(app)
+        for _ in range(3):
+            assert client.get("/probe").status_code == 200
+        assert client.get("/probe").status_code == 429

--- a/server/tests/test_api/test_search_routes.py
+++ b/server/tests/test_api/test_search_routes.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from decision_hub.api.rate_limit import RateLimiters
 from decision_hub.api.search_routes import router as search_router
 from decision_hub.infra.gemini import GuardAndParseResult
 
@@ -75,8 +76,10 @@ def search_settings() -> MagicMock:
     settings.google_api_key = "test-google-api-key"
     settings.gemini_model = "gemini-pro"
     settings.s3_bucket = "test-bucket"
-    settings.search_rate_limit = 100
-    settings.search_rate_window = 60
+    # RateLimiters iterates every known name — provide sane defaults for all.
+    for _name in RateLimiters._NAMES:
+        setattr(settings, f"{_name}_rate_limit", 100)
+        setattr(settings, f"{_name}_rate_window", 60)
     settings.search_candidate_limit = 20
     settings.embedding_model = "gemini-embedding-001"
     return settings
@@ -89,6 +92,7 @@ def search_app(search_settings: MagicMock) -> FastAPI:
     app.state.settings = search_settings
     app.state.engine = MagicMock()
     app.state.s3_client = MagicMock()
+    app.state.rate_limiters = RateLimiters(search_settings)
     app.include_router(search_router)
     return app
 
@@ -251,8 +255,12 @@ class TestAskSkills:
 
     def test_ask_rate_limited(self, search_app: FastAPI) -> None:
         """Exceeding the rate limit returns HTTP 429."""
+        # Rate limiters are eagerly built at app startup — mutating settings
+        # after the fact won't take effect. Rebuild the container so the
+        # tightened cap is picked up.
         search_app.state.settings.search_rate_limit = 2
         search_app.state.settings.search_rate_window = 60
+        search_app.state.rate_limiters = RateLimiters(search_app.state.settings)
         client = TestClient(search_app)
 
         with patch(

--- a/server/tests/test_domain/test_orgs.py
+++ b/server/tests/test_domain/test_orgs.py
@@ -7,7 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs, validate_org_slug, validate_role
+from decision_hub.domain.orgs import sync_org_github_metadata, sync_user_orgs, validate_org_slug
 
 # ---------------------------------------------------------------------------
 # validate_org_slug
@@ -47,25 +47,6 @@ class TestValidateOrgSlug:
     def test_invalid_slugs(self, slug: str, reason: str) -> None:
         with pytest.raises(ValueError):
             validate_org_slug(slug)
-
-
-# ---------------------------------------------------------------------------
-# validate_role
-# ---------------------------------------------------------------------------
-
-
-class TestValidateRole:
-    @pytest.mark.parametrize("role", ["owner", "admin", "member"])
-    def test_valid_roles(self, role: str) -> None:
-        assert validate_role(role) == role
-
-    @pytest.mark.parametrize(
-        "role",
-        ["superadmin", "viewer", "", "Owner", "ADMIN"],
-    )
-    def test_invalid_roles(self, role: str) -> None:
-        with pytest.raises(ValueError):
-            validate_role(role)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_infra/test_anthropic_client.py
+++ b/server/tests/test_infra/test_anthropic_client.py
@@ -37,6 +37,17 @@ class TestParseJudgeResponse:
         result = _parse_judge_response(raw)
         assert result["verdict"] == "error"
 
+    def test_strips_markdown_json_fence(self):
+        raw = "```json\n" + json.dumps({"verdict": "pass", "reasoning": "wrapped"}) + "\n```"
+        result = _parse_judge_response(raw)
+        assert result["verdict"] == "pass"
+        assert result["reasoning"] == "wrapped"
+
+    def test_strips_bare_code_fence(self):
+        raw = "```\n" + json.dumps({"verdict": "fail", "reasoning": "still wrapped"}) + "\n```"
+        result = _parse_judge_response(raw)
+        assert result["verdict"] == "fail"
+
 
 class TestJudgeEvalOutput:
     @respx.mock

--- a/server/tests/test_infra/test_cache.py
+++ b/server/tests/test_infra/test_cache.py
@@ -6,7 +6,7 @@ from decision_hub.infra.cache import TTLCache
 
 
 class TestTTLCacheBasics:
-    """Core get/set/invalidate/clear operations."""
+    """Core get/set operations."""
 
     def test_get_returns_none_for_missing_key(self) -> None:
         cache = TTLCache(default_ttl=10)
@@ -16,24 +16,6 @@ class TestTTLCacheBasics:
         cache = TTLCache(default_ttl=10)
         cache.set("key", {"data": 42})
         assert cache.get("key") == {"data": 42}
-
-    def test_invalidate_removes_key(self) -> None:
-        cache = TTLCache(default_ttl=10)
-        cache.set("key", "value")
-        cache.invalidate("key")
-        assert cache.get("key") is None
-
-    def test_invalidate_nonexistent_key_is_noop(self) -> None:
-        cache = TTLCache(default_ttl=10)
-        cache.invalidate("nope")  # should not raise
-
-    def test_clear_removes_all(self) -> None:
-        cache = TTLCache(default_ttl=10)
-        cache.set("a", 1)
-        cache.set("b", 2)
-        cache.clear()
-        assert cache.get("a") is None
-        assert cache.get("b") is None
 
 
 class TestTTLCacheExpiration:

--- a/server/tests/test_infra/test_gemini.py
+++ b/server/tests/test_infra/test_gemini.py
@@ -77,6 +77,45 @@ class TestGeminiPostRetry:
         assert route.call_count == 1
 
     @respx.mock
+    def test_permission_denied_403_mentioning_generation_fails_fast(self, gemini_client: dict) -> None:
+        """Words like "generate" must not be read as a rate-limit signal.
+
+        A bare substring scan for "RATE" also matches "GENERATE"/"SEPARATE",
+        which would send permanent 403s back through the full retry budget.
+        """
+        route = respx.post(_GEMINI_URL).mock(
+            return_value=httpx.Response(
+                403,
+                json={
+                    "error": {
+                        "status": "PERMISSION_DENIED",
+                        "message": "Caller does not have permission to generate content with this model.",
+                    }
+                },
+            )
+        )
+        with (
+            patch("decision_hub.infra.gemini.time.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
+        mock_sleep.assert_not_called()
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_retries_on_403_quota_message_without_status(self, gemini_client: dict) -> None:
+        """Quota 403s that carry no machine-readable status still retry."""
+        route = respx.post(_GEMINI_URL).mock(
+            side_effect=[
+                httpx.Response(403, text="Quota exceeded for this project"),
+                httpx.Response(200, json={"candidates": []}),
+            ]
+        )
+        with patch("decision_hub.infra.gemini.time.sleep"):
+            _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
+        assert route.call_count == 2
+
+    @respx.mock
     def test_retries_on_429_with_backoff(self, gemini_client: dict) -> None:
         route = respx.post(_GEMINI_URL).mock(
             side_effect=[

--- a/server/tests/test_infra/test_gemini.py
+++ b/server/tests/test_infra/test_gemini.py
@@ -32,10 +32,14 @@ class TestGeminiPostRetry:
     """Tests for _gemini_post retry with exponential backoff on transient errors."""
 
     @respx.mock
-    def test_retries_on_403_then_succeeds(self, gemini_client: dict) -> None:
+    def test_retries_on_rate_limit_403_then_succeeds(self, gemini_client: dict) -> None:
+        """A 403 whose body indicates quota/rate exhaustion IS retriable."""
         route = respx.post(_GEMINI_URL).mock(
             side_effect=[
-                httpx.Response(403, text="Forbidden"),
+                httpx.Response(
+                    403,
+                    json={"error": {"status": "RESOURCE_EXHAUSTED", "message": "Quota exceeded"}},
+                ),
                 httpx.Response(200, json={"candidates": []}),
             ]
         )
@@ -47,6 +51,30 @@ class TestGeminiPostRetry:
         assert result == {"candidates": []}
         assert route.call_count == 2
         mock_sleep.assert_called_once_with(1.25)
+
+    @respx.mock
+    def test_permission_denied_403_fails_fast(self, gemini_client: dict) -> None:
+        """A 403 without rate/quota indicators (e.g. invalid API key) must NOT retry.
+
+        Regression: the previous implementation retried every 403 three times,
+        adding ~7s of latency to every request when the key was permanently
+        invalid.
+        """
+        route = respx.post(_GEMINI_URL).mock(
+            return_value=httpx.Response(
+                403,
+                json={"error": {"status": "PERMISSION_DENIED", "message": "API key not valid"}},
+            )
+        )
+        with (
+            patch("decision_hub.infra.gemini.time.sleep") as mock_sleep,
+            pytest.raises(httpx.HTTPStatusError) as exc_info,
+        ):
+            _gemini_post(gemini_client, _DEFAULT_MODEL, {}, max_retries=3)
+        assert exc_info.value.response.status_code == 403
+        # No retries -> no backoff sleeps.
+        mock_sleep.assert_not_called()
+        assert route.call_count == 1
 
     @respx.mock
     def test_retries_on_429_with_backoff(self, gemini_client: dict) -> None:

--- a/server/tests/test_infra/test_github_client.py
+++ b/server/tests/test_infra/test_github_client.py
@@ -1,6 +1,6 @@
 """Tests for decision_hub.infra.github_client."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -67,48 +67,57 @@ class TestGitHubClientContextManager:
 
 
 class TestGitHubClientGraphQL:
-    """Verify GraphQL method."""
+    """Verify GraphQL method routes through the pooled client."""
 
-    @patch("decision_hub.infra.github_client.httpx.post")
-    def test_graphql_success(self, mock_post):
+    def _build_response(self, *, json_body: dict, headers: dict | None = None) -> MagicMock:
         resp = MagicMock()
         resp.status_code = 200
-        resp.headers = {"x-ratelimit-remaining": "100", "x-ratelimit-reset": "1700000000"}
-        resp.json.return_value = {"data": {"viewer": {"login": "test"}}}
+        resp.headers = headers or {}
+        resp.json.return_value = json_body
         resp.raise_for_status = MagicMock()
-        mock_post.return_value = resp
+        return resp
+
+    def test_graphql_success(self):
+        resp = self._build_response(
+            json_body={"data": {"viewer": {"login": "test"}}},
+            headers={"x-ratelimit-remaining": "100", "x-ratelimit-reset": "1700000000"},
+        )
 
         with GitHubClient(token="ghp_test") as gh:
+            gh._client = MagicMock()
+            gh._client.post.return_value = resp
+
             result = gh.graphql("{ viewer { login } }")
 
         assert result == {"viewer": {"login": "test"}}
+        # Regression: must NOT call module-level httpx.post — a fresh
+        # TCP+TLS handshake per batch defeated the connection pool.
+        gh._client.post.assert_called_once()
+        call_args, call_kwargs = gh._client.post.call_args
+        assert call_args[0] == "https://api.github.com/graphql"
+        assert call_kwargs["json"]["query"] == "{ viewer { login } }"
 
-    @patch("decision_hub.infra.github_client.httpx.post")
-    def test_graphql_errors_without_data_raises(self, mock_post):
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.headers = {}
-        resp.json.return_value = {"errors": [{"message": "bad query"}]}
-        resp.raise_for_status = MagicMock()
-        mock_post.return_value = resp
+    def test_graphql_errors_without_data_raises(self):
+        resp = self._build_response(json_body={"errors": [{"message": "bad query"}]})
 
-        with GitHubClient() as gh, pytest.raises(ValueError, match="GraphQL errors"):
-            gh.graphql("{ bad }")
+        with GitHubClient() as gh:
+            gh._client = MagicMock()
+            gh._client.post.return_value = resp
+            with pytest.raises(ValueError, match="GraphQL errors"):
+                gh.graphql("{ bad }")
 
-    @patch("decision_hub.infra.github_client.httpx.post")
-    def test_graphql_partial_errors_returns_data(self, mock_post):
+    def test_graphql_partial_errors_returns_data(self):
         """When both data and errors are present, return data instead of raising."""
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.headers = {}
-        resp.json.return_value = {
-            "data": {"r0": {"ref": {"target": {"oid": "abc123"}}}},
-            "errors": [{"message": "Could not resolve to a Repository"}],
-        }
-        resp.raise_for_status = MagicMock()
-        mock_post.return_value = resp
+        resp = self._build_response(
+            json_body={
+                "data": {"r0": {"ref": {"target": {"oid": "abc123"}}}},
+                "errors": [{"message": "Could not resolve to a Repository"}],
+            }
+        )
 
         with GitHubClient(token="ghp_test") as gh:
+            gh._client = MagicMock()
+            gh._client.post.return_value = resp
             result = gh.graphql("query { ... }")
 
         assert result == {"r0": {"ref": {"target": {"oid": "abc123"}}}}

--- a/server/tests/test_scripts/test_backfill_embeddings.py
+++ b/server/tests/test_scripts/test_backfill_embeddings.py
@@ -1,0 +1,80 @@
+"""Tests for decision_hub.scripts.backfill_embeddings.
+
+Focused on the SQL correctness rule: every LIMIT query must have an
+explicit ORDER BY with a unique tiebreaker (see CLAUDE.md).
+"""
+
+from decision_hub.infra.database import skills_table
+from decision_hub.scripts import backfill_embeddings as backfill_mod
+
+
+def test_backfill_query_orders_by_id_before_limit() -> None:
+    """The batch-fetch SELECT must order by a unique column before LIMIT.
+
+    Regression: without ORDER BY, a batch that fails and gets retried
+    can hit a different set of rows (Postgres is free to reorder), which
+    combined with the circuit-breaker loop caused hot-looping on the
+    same failing rows.
+
+    We inspect the SQLAlchemy select() built inside ``backfill`` by
+    running it against a stubbed engine/connection and capturing the
+    compiled statement. This is easier than mocking the whole run loop.
+    """
+    captured: dict[str, str] = {}
+
+    class _StubResult:
+        def all(self) -> list:
+            return []
+
+    class _StubConn:
+        def __enter__(self) -> "_StubConn":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def execute(self, stmt) -> _StubResult:
+            captured["sql"] = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+            return _StubResult()
+
+        def commit(self) -> None:
+            pass
+
+    class _StubEngine:
+        def connect(self) -> _StubConn:
+            return _StubConn()
+
+    class _StubSettings:
+        google_api_key = "test-key"
+        database_url = "postgresql://ignored"
+        embedding_model = "gemini-embedding-001"
+
+    def _stub_create_engine(_url: str) -> _StubEngine:
+        return _StubEngine()
+
+    def _stub_create_settings(*_a: object, **_kw: object) -> _StubSettings:
+        return _StubSettings()
+
+    def _stub_create_client(_key: str) -> dict:
+        return {}
+
+    orig_create_engine = backfill_mod.create_engine
+    orig_create_client = backfill_mod.create_gemini_client
+    orig_create_settings = backfill_mod.create_settings
+    backfill_mod.create_engine = _stub_create_engine
+    backfill_mod.create_gemini_client = _stub_create_client
+    backfill_mod.create_settings = _stub_create_settings
+    try:
+        backfill_mod.backfill(batch_size=10)
+    finally:
+        backfill_mod.create_engine = orig_create_engine
+        backfill_mod.create_gemini_client = orig_create_client
+        backfill_mod.create_settings = orig_create_settings
+
+    sql = captured["sql"]
+    # LIMIT must appear AFTER an ORDER BY on the unique id column.
+    assert "ORDER BY" in sql.upper()
+    order_pos = sql.upper().find("ORDER BY")
+    limit_pos = sql.upper().find("LIMIT")
+    assert 0 < order_pos < limit_pos, sql
+    assert str(skills_table.c.id) in sql

--- a/server/tests/test_scripts/test_crawler_checkpoint.py
+++ b/server/tests/test_scripts/test_crawler_checkpoint.py
@@ -1,0 +1,72 @@
+"""Tests for decision_hub.scripts.crawler.checkpoint -- atomic checkpoint save."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from decision_hub.scripts.crawler.checkpoint import Checkpoint
+
+
+def test_save_writes_via_tmp_and_replace(tmp_path: Path) -> None:
+    """Checkpoint.save writes to <path>.tmp then os.replaces it into place.
+
+    Regression: previously a SIGKILL/OOM between write_text() and its
+    fsync could leave a truncated JSON file that failed the next load(),
+    losing the entire crawl state even though the docstring called it
+    "crash-safe".
+    """
+    checkpoint_path = tmp_path / "checkpoint.json"
+    tmp_target = tmp_path / "checkpoint.json.tmp"
+
+    cp = Checkpoint(processed_repos={"acme/widget": "sha1"})
+
+    original_replace = __import__("os").replace
+    captured: dict[str, bool] = {}
+
+    def replace_spy(src: str, dst: str) -> None:
+        # By the time we hit os.replace the tmp file must already contain
+        # the full JSON payload — a crash before this line must leave the
+        # real checkpoint intact.
+        captured["tmp_exists"] = Path(src).is_file()
+        captured["tmp_content"] = Path(src).read_text()
+        original_replace(src, dst)
+
+    with patch("decision_hub.scripts.crawler.checkpoint.os.replace", side_effect=replace_spy):
+        cp.save(checkpoint_path)
+
+    assert captured["tmp_exists"] is True
+    assert json.loads(captured["tmp_content"]) == {
+        "discovered_repos": {},
+        "processed_repos": {"acme/widget": "sha1"},
+    }
+    # After a successful save the tmp file has been renamed away.
+    assert not tmp_target.exists()
+    assert checkpoint_path.exists()
+
+
+def test_save_leaves_previous_checkpoint_intact_on_crash(tmp_path: Path) -> None:
+    """If the process is killed mid-save, the original file must survive."""
+    checkpoint_path = tmp_path / "checkpoint.json"
+    # Seed a valid prior checkpoint
+    prior = Checkpoint(processed_repos={"acme/widget": "sha_prior"})
+    prior.save(checkpoint_path)
+    original_content = checkpoint_path.read_text()
+
+    # Simulate a crash during os.replace — the tmp file was written but
+    # never renamed. The original checkpoint must remain untouched.
+    fresh = Checkpoint(processed_repos={"acme/widget": "sha_new"})
+    with (
+        patch(
+            "decision_hub.scripts.crawler.checkpoint.os.replace",
+            side_effect=OSError("simulated SIGKILL"),
+        ),
+        pytest.raises(OSError, match="simulated SIGKILL"),
+    ):
+        fresh.save(checkpoint_path)
+
+    assert checkpoint_path.read_text() == original_content
+    # The load path must still work — no corruption.
+    loaded = Checkpoint.load(checkpoint_path)
+    assert loaded.processed_repos == {"acme/widget": "sha_prior"}


### PR DESCRIPTION
## What changed

Fixes surfaced by a full-codebase review across architecture, bugs, security, performance, testing, and code health. Ten concrete defects plus a handful of dead-code and DRY cleanups — all self-contained, no schema changes, no API-breaking rename.

## Why

Not tied to a single issue. Highlights (each cited with `file:line` in the commit message):

**Rate limiter** — `api/rate_limit.py`
- **Race condition on lazy init.** Eight route handlers used `if not hasattr(state, "_x_limiter"): state._x_limiter = RateLimiter(...)`. FastAPI runs sync deps in a threadpool, so two concurrent first-hits both saw `hasattr == False`, both built a `RateLimiter`, and one silently overwrote the other — dropping the loser's counter and letting a burst through. Replaced with a `RateLimiters` container built eagerly in `create_app()` from settings, and a `limiter_dep("name")` helper that looks limiters up per-request.
- **O(n_ips) work per request under the lock.** `_purge_stale` was gated on `sum(len(v) for v in self._requests.values()) % 100 == 0`, which (a) did O(n_ips) work under the lock every request, and (b) could easily never hit 100 exactly (so the purge fired at unpredictable intervals). Replaced with a monotonic `_request_count` incremented on admitted requests only.
- **Boilerplate.** Removed eight nearly identical `_enforce_*_rate_limit` functions. Each route is now one `Depends(limiter_dep("name"))` line.

**Missing rate limits on public endpoints (CLAUDE.md rule)**
Added limiters to six previously-unbounded GET endpoints: `/v1/stats`, `/v1/skills/{}/{}/summary`, `/v1/skills/{}/{}/latest-version`, `/v1/skills/{}/{}/eval-report`, and the versioned eval-report path. Each did 2–3 DB round-trips per hit with no per-IP cap.

**Correctness bugs**
- **Gemini retried permission-denied 403s.** The retry list treated every 403 as transient, so requests with a rotated-but-not-updated API key wasted ~7 s before failing. 403 is now only retried when the response body contains rate/quota indicators.
- **GitHub `graphql()` bypassed the pooled client.** It called module-level `httpx.post` instead of `self._client.post`, forcing a fresh TCP+TLS handshake per batch.
- **`backfill_embeddings.py` had `LIMIT` without `ORDER BY`.** Violated the CLAUDE.md SQL rule; on retry after a partial commit, PostgreSQL could pick a different row set and hot-loop. Added `ORDER BY skills.id`.
- **Crawler checkpoint non-atomic save.** `path.write_text(...)` in-place could leave a truncated JSON on SIGKILL/OOM despite the "crash-safe" docstring. Now writes to `<path>.tmp` then `os.replace`s into place.

**Small perf / cleanups**
- Anthropic judge regex compiled per call — moved to module scope.
- Dead code removed: `domain/orgs.py::validate_role`, `TTLCache.invalidate/clear` (all had zero application callers, verified by grep).
- DRY: extracted duplicated `_parse_uuid` into `api/deps.py::parse_uuid_or_422`.

## How to test

```bash
make test        # 933 server + 98 shared + client suites pass
make lint        # ruff check + format --check + tsc + eslint
make typecheck   # mypy across 88 source files
```

Concrete regressions to look at:
- `server/tests/test_api/test_rate_limit.py` — `test_purge_uses_monotonic_counter`, `test_over_limit_admissions_do_not_advance_counter`, and the new `TestRateLimiters` / `TestLimiterDep` classes.
- `server/tests/test_infra/test_gemini.py::TestGeminiPostRetry::test_permission_denied_403_fails_fast`.
- `server/tests/test_infra/test_github_client.py::TestGitHubClientGraphQL` — asserts the pooled client is used.
- `server/tests/test_scripts/test_crawler_checkpoint.py` — new file, atomic-write behaviour + prior-checkpoint survival on simulated crash.
- `server/tests/test_scripts/test_backfill_embeddings.py` — new file, asserts `ORDER BY ... LIMIT` in the batch SELECT.

## Checklist
- [x] Tests pass (`make test`)
- [x] No breaking API changes (route paths unchanged, response shapes unchanged, added rate limits use existing settings)
- [x] Database migration included (if schema changed) — N/A, no schema changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsgHnqavEHM47e2EjfoWm1)_