### PR TITLE
chore: poll skill trackers hourly instead of every 10 minutes

### DIFF
--- a/server/modal_app.py
+++ b/server/modal_app.py
@@ -273,9 +273,9 @@ def crawl_trusted_orgs_nightly() -> None:
 _TRACKER_LOOP_BUDGET_SECONDS = 180
 
 
-@app.function(image=crawler_image, timeout=900, schedule=modal.Period(seconds=600))
+@app.function(image=crawler_image, timeout=900, schedule=modal.Period(hours=1))
 def check_trackers():
-    """Poll GitHub repos for skill updates every 10 minutes.
+    """Poll GitHub repos for skill updates every hour.
 
     Loops batch claims until no more trackers are due or the time budget
     is exhausted. Each iteration claims a batch, checks SHAs via GraphQL,


### PR DESCRIPTION
Changes the `check_trackers` Modal schedule from `Period(seconds=600)` to `Period(hours=1)`.

Trackers keep their own per-tracker `poll_interval` / `next_check_at`; the cron only claims what is due. Practical effect: any tracker with an interval shorter than an hour is now effectively checked hourly, and each tick claims a larger backlog (still bounded by `_TRACKER_LOOP_BUDGET_SECONDS = 180` and the 900s container timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)